### PR TITLE
Update build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grpc-gateway
 
-[![Build Status](https://travis-ci.org/gengo/grpc-gateway.svg?branch=master)](https://travis-ci.org/gengo/grpc-gateway)
+[![Build Status](https://travis-ci.org/grpc-ecosystem/grpc-gateway.svg?branch=master)](https://travis-ci.org/gengo/grpc-gateway)
 
 grpc-gateway is a plugin of [protoc](http://github.com/google/protobuf).
 It reads [gRPC](http://github.com/grpc/grpc-common) service definition,


### PR DESCRIPTION
Tiny thing but the badge is still pointing to https://travis-ci.org/gengo/grpc-gateway