### PR TITLE
protoc-gen-swagger: output https first in schemas key

### DIFF
--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -443,7 +443,7 @@ func applyTemplate(p param) (string, error) {
 	s := swaggerObject{
 		// Swagger 2.0 is the version of this document
 		Swagger:     "2.0",
-		Schemes:     []string{"http", "https"},
+		Schemes:     []string{"https", "http"},
 		Consumes:    []string{"application/json"},
 		Produces:    []string{"application/json"},
 		Paths:       make(swaggerPathsObject),

--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -101,7 +101,7 @@ func TestApplyTemplateSimple(t *testing.T) {
 	if want, is, name := "", got.BasePath, "BasePath"; !reflect.DeepEqual(is, want) {
 		t.Errorf("applyTemplate(%#v).%s = %s want to be %s", file, name, is, want)
 	}
-	if want, is, name := []string{"http", "https"}, got.Schemes, "Schemes"; !reflect.DeepEqual(is, want) {
+	if want, is, name := []string{"https", "http"}, got.Schemes, "Schemes"; !reflect.DeepEqual(is, want) {
 		t.Errorf("applyTemplate(%#v).%s = %s want to be %s", file, name, is, want)
 	}
 	if want, is, name := []string{"application/json"}, got.Consumes, "Consumes"; !reflect.DeepEqual(is, want) {
@@ -261,7 +261,7 @@ func TestApplyTemplateRequestWithoutClientStreaming(t *testing.T) {
 	if want, got := "", obj.BasePath; !reflect.DeepEqual(got, want) {
 		t.Errorf("applyTemplate(%#v).BasePath = %s want to be %s", file, got, want)
 	}
-	if want, got := []string{"http", "https"}, obj.Schemes; !reflect.DeepEqual(got, want) {
+	if want, got := []string{"https", "http"}, obj.Schemes; !reflect.DeepEqual(got, want) {
 		t.Errorf("applyTemplate(%#v).Schemes = %s want to be %s", file, got, want)
 	}
 	if want, got := []string{"application/json"}, obj.Consumes; !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
Workaround for #161

This assumes that (most) everyone is running grpc-gateway under https. If that's not a valid assumption, maybe adding a `schemas` option to `protoc-gen-swagger` is needed.

Also, a better default might be to omit the `schemas` key, which should cause swagger-ui to use whichever schema it's being accessed through.

https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schema
