### PR TITLE
readme: added links to additional documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 grpc-gateway is a plugin of [protoc](http://github.com/google/protobuf).
 It reads [gRPC](http://github.com/grpc/grpc-common) service definition,
 and generates a reverse-proxy server which translates a RESTful JSON API into gRPC.
+This server is generated according to [custom options](https://cloud.google.com/service-management/reference/rpc/google.api#http) in your gRPC definition.
 
 It helps you to provide your APIs in both gRPC and RESTful style at the same time.
 
@@ -60,7 +61,7 @@ Make sure that your `$GOPATH/bin` is in your `$PATH`.
      rpc Echo(StringMessage) returns (StringMessage) {}
    }
    ```
-2. Add a custom option to the .proto file
+2. Add a [custom option](https://cloud.google.com/service-management/reference/rpc/google.api#http) to the .proto file
    
    your_service.proto:
    ```diff


### PR DESCRIPTION
This commit adds links to the google cloud platform's documentation on the custom options used by grpc-gateway to generate your http proxy. This documentation has information about how path, query, and body parameters are handled, as well as specific assumptions about the arguments present for different http methods.

I added the link in a couple of places in the readme that seemed like places where you might want additional documentation. Let me know if they should be linked to differently or something like that. 

Fixes #212