### PR TITLE
README - Add CoreOS example

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ More examples are available under `examples` directory.
 * `server/main.go`: service implementation
 * `main.go`: entrypoint of the generated reverse proxy
 
+To use the same port for custom HTTP handlers (e.g. serving `swagger.json`), gRPC-gateway, and a gRPC server, see [this code example by CoreOS](https://github.com/philips/grpc-gateway-example/blob/master/cmd/serve.go) (and its accompanying [blog post](https://coreos.com/blog/gRPC-protobufs-swagger.html))
+
 ## Features
 ### Supported
 * Generating JSON API handlers


### PR DESCRIPTION
Show users how to combine these different projects in a unified way, e.g. how to serve the generated `swagger.json` on the API

Closes #230