### PR TITLE
runtime - export prefix constants

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -15,8 +15,8 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-const metadataHeaderPrefix = "Grpc-Metadata-"
-const metadataTrailerPrefix = "Grpc-Trailer-"
+const MetadataHeaderPrefix = "Grpc-Metadata-"
+const MetadataTrailerPrefix = "Grpc-Trailer-"
 const metadataGrpcTimeout = "Grpc-Timeout"
 
 const xForwardedFor = "X-Forwarded-For"
@@ -52,8 +52,8 @@ func AnnotateContext(ctx context.Context, req *http.Request) (context.Context, e
 				pairs = append(pairs, "authorization", val)
 				continue
 			}
-			if strings.HasPrefix(key, metadataHeaderPrefix) {
-				pairs = append(pairs, key[len(metadataHeaderPrefix):], val)
+			if strings.HasPrefix(key, MetadataHeaderPrefix) {
+				pairs = append(pairs, key[len(MetadataHeaderPrefix):], val)
 			}
 		}
 	}

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -15,7 +15,11 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+// MetadataHeaderPrefix is prepended to HTTP headers in order to convert them to 
+// gRPC metadata for incoming requests processed by grpc-gateway
 const MetadataHeaderPrefix = "Grpc-Metadata-"
+// MetadataTrailerPrefix is prepended to gRPC metadata as it is converted to
+// HTTP headers in a response handled by grpc-gateway
 const MetadataTrailerPrefix = "Grpc-Trailer-"
 const metadataGrpcTimeout = "Grpc-Timeout"
 

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -67,7 +67,7 @@ func ForwardResponseStream(ctx context.Context, marshaler Marshaler, w http.Resp
 
 func handleForwardResponseServerMetadata(w http.ResponseWriter, md ServerMetadata) {
 	for k, vs := range md.HeaderMD {
-		hKey := fmt.Sprintf("%s%s", metadataHeaderPrefix, k)
+		hKey := fmt.Sprintf("%s%s", MetadataHeaderPrefix, k)
 		for i := range vs {
 			w.Header().Add(hKey, vs[i])
 		}
@@ -76,14 +76,14 @@ func handleForwardResponseServerMetadata(w http.ResponseWriter, md ServerMetadat
 
 func handleForwardResponseTrailerHeader(w http.ResponseWriter, md ServerMetadata) {
 	for k := range md.TrailerMD {
-		tKey := textproto.CanonicalMIMEHeaderKey(fmt.Sprintf("%s%s", metadataTrailerPrefix, k))
+		tKey := textproto.CanonicalMIMEHeaderKey(fmt.Sprintf("%s%s", MetadataTrailerPrefix, k))
 		w.Header().Add("Trailer", tKey)
 	}
 }
 
 func handleForwardResponseTrailer(w http.ResponseWriter, md ServerMetadata) {
 	for k, vs := range md.TrailerMD {
-		tKey := fmt.Sprintf("%s%s", metadataTrailerPrefix, k)
+		tKey := fmt.Sprintf("%s%s", MetadataTrailerPrefix, k)
 		for i := range vs {
 			w.Header().Add(tKey, vs[i])
 		}


### PR DESCRIPTION
Some clients that map HTTP to GRPC requests (e.g. for tracing purposes or  for having a load balancer denote an external ip) need to know how this library maps HTTP to gRPC. Rather than hardcoding the prefix in their code, I think that users should be able to import this variable so that future gprc-gateway changes do not (transparently) break this functionality.

(and I'm writing a client right now that would benefit from this)