### PR TITLE
Emit default values in marshalled JSON

### DIFF
--- a/runtime/marshaler_registry.go
+++ b/runtime/marshaler_registry.go
@@ -13,7 +13,11 @@ var (
 	acceptHeader      = http.CanonicalHeaderKey("Accept")
 	contentTypeHeader = http.CanonicalHeaderKey("Content-Type")
 
-	defaultMarshaler = &JSONPb{OrigName: true}
+	// defaultMarhaler controls how protobufs are marshalled to JSON. Note that
+	// it uses the JSONpb package, not standard JSON / annotations. To override its
+	// behavior, use the WithMarshalerOption:
+	// 	gwmux := runtime.NewServeMux(runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{OrigName: true, EmitDefaults: false}))
+	defaultMarshaler = &JSONPb{OrigName: true, EmitDefaults: true}
 )
 
 // MarshalerForRequest returns the inbound/outbound marshalers for this request.


### PR DESCRIPTION
In order to make APIs more restful, require the marshaler to emit
default values. By default, it omits empty types. This causes
unexpected REST behavior by omitting all false values or zero-valued
integers.

Closes #233
