### PR TITLE
Error output should have lowercase attribute names

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -63,8 +63,8 @@ var (
 )
 
 type errorBody struct {
-	Error string `json:"error"`
-	Code  int    `json:"code"`
+	Error string `protobuf:"bytes,1,name=error" json:"error"`
+	Code  int    `protobuf:"bytes,2,name=code" json:"code"`
 }
 
 //Make this also conform to proto.Message for builtin JSONPb Marshaler


### PR DESCRIPTION
The current error output is titlecase (`{"Error": "...", "Code": "..."}`) when it should be lowercase (`{"error": "...", "code": "..."}`). This appears to be due to `errorBody` implementing `proto.Message` interface but lacking protobuf tags needed to marshal correctly. When I patch [errorBody][1] with the following I end up with correct behavior:

```go
type errorBody struct {
	Error string `protobuf:"bytes,1,name=error" json:"error"`
	Code  int    `protobuf:"bytes,2,name=code" json:"code"`
}
```
[1]:https://github.com/grpc-ecosystem/grpc-gateway/blob/master/runtime/errors.go#L65
