### PR TITLE
Render the swagger request body properly

### DIFF
--- a/examples/clients/abe/ABitOfEverythingServiceApi.go
+++ b/examples/clients/abe/ABitOfEverythingServiceApi.go
@@ -414,8 +414,8 @@ func (a ABitOfEverythingServiceApi) Echo_1 () (SubStringMessage, error) {
  * @param body 
  * @return SubStringMessage
  */
-//func (a ABitOfEverythingServiceApi) Echo_2 (body SubStringMessage) (SubStringMessage, error) {
-func (a ABitOfEverythingServiceApi) Echo_2 (body SubStringMessage) (SubStringMessage, error) {
+//func (a ABitOfEverythingServiceApi) Echo_2 (body string) (SubStringMessage, error) {
+func (a ABitOfEverythingServiceApi) Echo_2 (body string) (SubStringMessage, error) {
 
     _sling := sling.New().Post(a.basePath)
 

--- a/examples/examplepb/a_bit_of_everything.swagger.json
+++ b/examples/examplepb/a_bit_of_everything.swagger.json
@@ -332,7 +332,8 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/subStringMessage"
+              "type": "string",
+              "format": "string"
             }
           }
         ],

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -377,6 +377,19 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
 				}
 				// Now check if there is a body parameter
 				if b.Body != nil {
+					var schema swaggerSchemaObject
+
+					if len(b.Body.FieldPath) == 0 {
+						schema = swaggerSchemaObject{
+							schemaCore: schemaCore{
+								Ref: fmt.Sprintf("#/definitions/%s", fullyQualifiedNameToSwaggerName(meth.RequestType.FQMN(), reg)),
+							},
+						}
+					} else {
+						lastField := b.Body.FieldPath[len(b.Body.FieldPath) - 1]
+						schema = schemaOfField(lastField.Target, reg)
+					}
+
 					desc := ""
 					if meth.GetClientStreaming() {
 						desc = "(streaming inputs)"
@@ -386,11 +399,7 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
 						Description: desc,
 						In:          "body",
 						Required:    true,
-						Schema: &swaggerSchemaObject{
-							schemaCore: schemaCore{
-								Ref: fmt.Sprintf("#/definitions/%s", fullyQualifiedNameToSwaggerName(meth.RequestType.FQMN(), reg)),
-							},
-						},
+						Schema: &schema,
 					})
 				}
 


### PR DESCRIPTION
The rendering of the http body was always the methods request type.

This is _only_ correct if the body is "*" which is not always true.