### PR TITLE
Support of Go 1.7 http.Request's Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ Make sure that your `$GOPATH/bin` is in your `$PATH`.
 `protoc-gen-grpc-gateway` supports custom mapping from Protobuf `import` to Golang import path.
 They are compatible to [the parameters with same names in `protoc-gen-go`](https://github.com/golang/protobuf#parameters).
 
+In addition we also support the `request_context` parameter in order to use the `http.Request`'s Context (only for Go 1.7 and above).
+This parameter can be useful to pass request scoped context between the gateway and the gRPC service.
+**WARNING**: using `request_context` has breaking API: `context.Context` is removed from all `Register${SvcName}Handler` functions.
+
 `protoc-gen-grpc-gateway` also supports some more command line flags to control logging. You can give these flags together with parameters above. Run `protoc-gen-grpc-gateway --help` for more details about the flags.
 
 ## More Examples

--- a/protoc-gen-grpc-gateway/gengateway/generator.go
+++ b/protoc-gen-grpc-gateway/gengateway/generator.go
@@ -20,12 +20,13 @@ var (
 )
 
 type generator struct {
-	reg         *descriptor.Registry
-	baseImports []descriptor.GoPackage
+	reg               *descriptor.Registry
+	baseImports       []descriptor.GoPackage
+	useRequestContext bool
 }
 
 // New returns a new generator which generates grpc gateway files.
-func New(reg *descriptor.Registry) gen.Generator {
+func New(reg *descriptor.Registry, useRequestContext bool) gen.Generator {
 	var imports []descriptor.GoPackage
 	for _, pkgpath := range []string{
 		"io",
@@ -54,7 +55,7 @@ func New(reg *descriptor.Registry) gen.Generator {
 		}
 		imports = append(imports, pkg)
 	}
-	return &generator{reg: reg, baseImports: imports}
+	return &generator{reg: reg, baseImports: imports, useRequestContext: useRequestContext}
 }
 
 func (g *generator) Generate(targets []*descriptor.File) ([]*plugin.CodeGeneratorResponse_File, error) {
@@ -107,5 +108,5 @@ func (g *generator) generate(file *descriptor.File) (string, error) {
 			imports = append(imports, pkg)
 		}
 	}
-	return applyTemplate(param{File: file, Imports: imports})
+	return applyTemplate(param{File: file, Imports: imports, UseRequestContext: g.useRequestContext})
 }

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -23,7 +23,8 @@ import (
 )
 
 var (
-	importPrefix = flag.String("import_prefix", "", "prefix to be added to go package paths for imported proto files")
+	importPrefix      = flag.String("import_prefix", "", "prefix to be added to go package paths for imported proto files")
+	useRequestContext = flag.Bool("request_context", false, "determine whether to use http.Request's context or not")
 )
 
 func parseReq(r io.Reader) (*plugin.CodeGeneratorRequest, error) {
@@ -73,7 +74,7 @@ func main() {
 		}
 	}
 
-	g := gengateway.New(reg)
+	g := gengateway.New(reg, *useRequestContext)
 
 	reg.SetPrefix(*importPrefix)
 	if err := reg.Load(req); err != nil {


### PR DESCRIPTION
This PR enable to use the Go 1.7 http.Request Context.

This feature is disable by default but can be enabled through the `request_context` parameter.

The usefulness of this is that we can now add middlewares and add metadata before calling gRPC services. I'm also using that as part of a distributed system (e.g. Zipkin) and need to pass metadata between HTTP and gRPC which can only be done through the same per-request `context.Context`.

If you enable the option there will be breaking changes.