### PR TITLE
Correct runtime.errorBody protobuf field tag

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -64,7 +64,7 @@ var (
 
 type errorBody struct {
 	Error string `protobuf:"bytes,1,name=error" json:"error"`
-	Code  int    `protobuf:"bytes,2,name=code" json:"code"`
+	Code  int32  `protobuf:"varint,2,name=code" json:"code"`
 }
 
 //Make this also conform to proto.Message for builtin JSONPb Marshaler
@@ -85,7 +85,7 @@ func DefaultHTTPError(ctx context.Context, marshaler Marshaler, w http.ResponseW
 	w.Header().Set("Content-Type", marshaler.ContentType())
 	body := &errorBody{
 		Error: grpc.ErrorDesc(err),
-		Code:  int(grpc.Code(err)),
+		Code:  int32(grpc.Code(err)),
 	}
 
 	buf, merr := marshaler.Marshal(body)


### PR DESCRIPTION
The tag field on errorBody.Code should be `varint` not `bytes` as well as `int32` vs `int` -- the protobuf library prints `proto: no coders for int` to stderr when marshaling these errors. 