### PR TITLE
Add `go_package` option

### DIFF
--- a/third_party/googleapis/google/api/annotations.proto
+++ b/third_party/googleapis/google/api/annotations.proto
@@ -22,6 +22,7 @@ import "google/protobuf/descriptor.proto";
 option java_multiple_files = true;
 option java_outer_classname = "AnnotationsProto";
 option java_package = "com.google.api";
+option go_package = "github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api";
 
 extend google.protobuf.MethodOptions {
   // See `HttpRule`.


### PR DESCRIPTION
So when `annotations.proto` is imported in another proto, the generated code of that proto import the right package.