### PR TITLE
Fix ruby gen command

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ Make sure that your `$GOPATH/bin` is in your `$PATH`.
        --grpc-ruby_out=. \
        path/to/your/service.proto
      ```
-   2. Implement your service
+   2. Add the googleapis-common-protos gem (or your language equivalent) as a dependency to your project.
+   3. Implement your service
+   
 5. Generate reverse-proxy
    
    ```sh

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Make sure that your `$GOPATH/bin` is in your `$PATH`.
      protoc -I/usr/local/include -I. \
        -I$GOPATH/src \
        -I$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
-       --plugin=protoc-gen-grpc-ruby=grpc_ruby_plugin \
+       --plugin=protoc-gen-grpc=grpc_ruby_plugin \
        --grpc-ruby_out=. \
        path/to/your/service.proto
      ```


### PR DESCRIPTION
protoc-gen-grpc-ruby doesn't work in my machine and google points to this readme as the only occurance...