### PR TITLE
fixes package name override doesn't work

### DIFF
--- a/protoc-gen-grpc-gateway/descriptor/registry.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry.go
@@ -239,6 +239,9 @@ func (r *Registry) goPackagePath(f *descriptor.FileDescriptorProto) string {
 	gopkg := f.Options.GetGoPackage()
 	idx := strings.LastIndex(gopkg, "/")
 	if idx >= 0 {
+		if sc := strings.LastIndex(gopkg, ";"); sc > 0 {
+			gopkg = gopkg[:sc+1-1]
+		}
 		return gopkg
 	}
 
@@ -284,10 +287,17 @@ func packageIdentityName(f *descriptor.FileDescriptorProto) string {
 		gopkg := f.Options.GetGoPackage()
 		idx := strings.LastIndex(gopkg, "/")
 		if idx < 0 {
-			return gopkg
+			gopkg = gopkg[idx+1:]
 		}
 
-		return gopkg[idx+1:]
+		gopkg = gopkg[idx+1:]
+		// package name is overrided with the string after the
+		// ';' character
+		sc := strings.IndexByte(gopkg, ';')
+		if sc < 0 {
+			return gopkg
+		}
+		return gopkg[sc+1:]
 	}
 
 	if f.Package == nil {

--- a/protoc-gen-grpc-gateway/descriptor/registry.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry.go
@@ -272,11 +272,19 @@ func (r *Registry) SetAllowDeleteBody(allow bool) {
 	r.allowDeleteBody = allow
 }
 
+// sanitizePackageName replaces unallowed character in package name
+// with allowed character.
+func sanitizePackageName(pkgName string) string {
+	pkgName = strings.Replace(pkgName, ".", "_", -1)
+	pkgName = strings.Replace(pkgName, "-", "_", -1)
+	return pkgName
+}
+
 // defaultGoPackageName returns the default go package name to be used for go files generated from "f".
 // You might need to use an unique alias for the package when you import it.  Use ReserveGoPackageAlias to get a unique alias.
 func defaultGoPackageName(f *descriptor.FileDescriptorProto) string {
 	name := packageIdentityName(f)
-	return strings.Replace(name, ".", "_", -1)
+	return sanitizePackageName(name)
 }
 
 // packageIdentityName returns the identity of packages.
@@ -295,9 +303,10 @@ func packageIdentityName(f *descriptor.FileDescriptorProto) string {
 		// ';' character
 		sc := strings.IndexByte(gopkg, ';')
 		if sc < 0 {
-			return gopkg
+			return sanitizePackageName(gopkg)
+
 		}
-		return gopkg[sc+1:]
+		return sanitizePackageName(gopkg[sc+1:])
 	}
 
 	if f.Package == nil {

--- a/protoc-gen-grpc-gateway/descriptor/registry_test.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry_test.go
@@ -531,3 +531,21 @@ func TestLoadWithInconsistentTargetPackage(t *testing.T) {
 		}
 	}
 }
+
+func TestLoadOverridedPackageName(t *testing.T) {
+	reg := NewRegistry()
+	loadFile(t, reg, `
+		name: 'example.proto'
+		package: 'example'
+		options < go_package: 'example.com/xyz;pb' >
+	`)
+	file := reg.files["example.proto"]
+	if file == nil {
+		t.Errorf("reg.files[%q] = nil; want non-nil", "example.proto")
+		return
+	}
+	wantPkg := GoPackage{Path: "example.com/xyz", Name: "pb"}
+	if got, want := file.GoPkg, wantPkg; got != want {
+		t.Errorf("file.GoPkg = %#v; want %#v", got, want)
+	}
+}


### PR DESCRIPTION
Fixed failed tests in https://github.com/grpc-ecosystem/grpc-gateway/issues/207.

- `option go_package = "github.com/9bug/bug;pb";`
- `option go_package = "github.com/9bug/bug-1";`