### PR TITLE
If there are no http rules or options, don't register methods

### DIFF
--- a/protoc-gen-grpc-gateway/descriptor/services.go
+++ b/protoc-gen-grpc-gateway/descriptor/services.go
@@ -32,6 +32,7 @@ func (r *Registry) loadServices(file *File) error {
 			}
 			if opts == nil {
 				glog.V(1).Infof("Found non-target method: %s.%s", svc.GetName(), md.GetName())
+				continue
 			}
 			meth, err := r.newMethod(svc, md, opts)
 			if err != nil {


### PR DESCRIPTION
Fix: https://github.com/grpc-ecosystem/grpc-gateway/issues/276

@tmc @yugui 