### PR TITLE
Bump swagger-client to 2.1.28 for examples/browser

### DIFF
--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -17,7 +17,7 @@
     "gulp-shell": "^0.5.2",
     "jasmine": "^2.4.1",
     "phantomjs": "^2.1.7",
-    "swagger-client": "2.1.26",
+    "swagger-client": "^2.1.28",
     "webpack-stream": "^3.2.0"
   }
 }


### PR DESCRIPTION
swagger-client responded quickly to report: https://github.com/swagger-api/swagger-js/pull/924 update to new version