### PR TITLE
Convert the first letter of method name to upper

### DIFF
--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -76,6 +76,8 @@ func applyTemplate(p param) (string, error) {
 		var methodWithBindingsSeen bool
 		for _, meth := range svc.Methods {
 			glog.V(2).Infof("Processing %s.%s", svc.GetName(), meth.GetName())
+			methName := strings.Title(*meth.Name)
+			meth.Name = &methName
 			for _, b := range meth.Bindings {
 				methodWithBindingsSeen = true
 				if err := handlerTemplate.Execute(w, binding{Binding: b}); err != nil {


### PR DESCRIPTION
It'll generate wrong method name if the method name starts with a lower-case letter in the proto file of gRPC.

The code generation rule of protoc-go will convert the first letter to upper-case but grpc-gateway do not.

So I just slightly changed the method name before applying the template.