### PR TITLE
Look up enum value maps by their proto name

### DIFF
--- a/runtime/query_test.go
+++ b/runtime/query_test.go
@@ -241,8 +241,8 @@ type proto3Message struct {
 	BoolValue      bool                 `protobuf:"varint,8,opt,name=bool_value" json:"bool_value,omitempty"`
 	StringValue    string               `protobuf:"bytes,9,opt,name=string_value" json:"string_value,omitempty"`
 	RepeatedValue  []string             `protobuf:"bytes,10,rep,name=repeated_value" json:"repeated_value,omitempty"`
-	EnumValue      EnumValue            `protobuf:"varint,11,opt,name=enum_value,json=enumValue,enum=api.EnumValue" json:"enum_value,omitempty"`
-	RepeatedEnum   []EnumValue          `protobuf:"varint,12,rep,packed,name=repeated_enum,json=repeated_enum,enum=api.EnumValue" json:"repeated_enum,omitempty"`
+	EnumValue      EnumValue            `protobuf:"varint,11,opt,name=enum_value,json=enumValue,enum=runtime_test_api.EnumValue" json:"enum_value,omitempty"`
+	RepeatedEnum   []EnumValue          `protobuf:"varint,12,rep,packed,name=repeated_enum,json=repeated_enum,enum=runtime_test_api.EnumValue" json:"repeated_enum,omitempty"`
 	TimestampValue *timestamp.Timestamp `protobuf:"bytes,11,opt,name=timestamp_value" json:"timestamp_value,omitempty"`
 }
 
@@ -268,8 +268,8 @@ type proto2Message struct {
 	BoolValue        *bool          `protobuf:"varint,8,opt,name=bool_value" json:"bool_value,omitempty"`
 	StringValue      *string        `protobuf:"bytes,9,opt,name=string_value" json:"string_value,omitempty"`
 	RepeatedValue    []string       `protobuf:"bytes,10,rep,name=repeated_value" json:"repeated_value,omitempty"`
-	EnumValue        EnumValue      `protobuf:"varint,11,opt,name=enum_value,json=enumValue,enum=api.EnumValue" json:"enum_value,omitempty"`
-	RepeatedEnum     []EnumValue    `protobuf:"varint,12,rep,packed,name=repeated_enum,json=repeated_enum,enum=api.EnumValue" json:"repeated_enum,omitempty"`
+	EnumValue        EnumValue      `protobuf:"varint,11,opt,name=enum_value,json=enumValue,enum=runtime_test_api.EnumValue" json:"enum_value,omitempty"`
+	RepeatedEnum     []EnumValue    `protobuf:"varint,12,rep,packed,name=repeated_enum,json=repeated_enum,enum=runtime_test_api.EnumValue" json:"repeated_enum,omitempty"`
 	XXX_unrecognized []byte         `json:"-"`
 }
 
@@ -367,5 +367,5 @@ var EnumValue_value = map[string]int32{
 }
 
 func init() {
-	proto.RegisterEnum("runtime_test.EnumValue", EnumValue_name, EnumValue_value)
+	proto.RegisterEnum("runtime_test_api.EnumValue", EnumValue_name, EnumValue_value)
 }

--- a/runtime/query_test.go
+++ b/runtime/query_test.go
@@ -136,7 +136,7 @@ func TestPopulateParameters(t *testing.T) {
 		msg.Reset()
 		err := runtime.PopulateQueryParameters(msg, spec.values, spec.filter)
 		if err != nil {
-			t.Errorf("runtime.PoplateQueryParameters(msg, %v, %v) failed with %v; want success", spec.values, spec.filter, err)
+			t.Errorf("runtime.PopulateQueryParameters(msg, %v, %v) failed with %v; want success", spec.values, spec.filter, err)
 			continue
 		}
 		if got, want := msg, spec.want; !proto.Equal(got, want) {


### PR DESCRIPTION
This fixes parsing of the string form of protobuf enum values in query
parameters and fixes the enum value map lookup done by query.go,
originally introduced in #314.

Previously, the runtime looked up the the enum value map via the Go
type name of the enum, derived from its reflect.Type. The Go type name
may not always map 1:1 to the protobuf name, though. For example, if
the proto file declares a package such as `google.protobuf`, it won't
match since the enum's name is fully qualified when registered for the
proto package. To make sure tests reflected the disparity, the query
test was amended to use a different package name from the Go package
when registering the enum.

To support this, it's necessary to pass the *proto.Properties for
fields forward when populating them, in order to allow the
populateField functions to determine if the field is an enum and look
up its value map by the props.Enum field.

As a result of this, the tests now pass, using the protobuf enum name
as registered (i.e., fully qualified package name) instead of the Go
package name derived by calling (reflect.Type).String. This should have
no real impact on existing use, but it may be justified to re-add
a fallback case for that reflect.Type name for hand-written protobuf
types. Even then, however, it seems unlikely that it should be expected
for enums-by-name to work when registering the enum map under a name
other than the one it's referred to in protobuf.