### PR TITLE
add support for adding context annotators, expose runtime.AddContextAnnotator

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -103,7 +103,7 @@ func AnnotateContext(ctx context.Context, req *http.Request) (context.Context, e
 		var err error
 		ctx, err = annotator(ctx, req)
 		if err != nil {
-			return nil, err
+			return context.Background(), err
 		}
 	}
 	if len(pairs) == 0 {


### PR DESCRIPTION
For services that need to read from `http.Request` (for example take something from cookie) and modify GRPC context (`ctx`).
A very useful (or maybe essential) use case is reading JWT token from cookie and puttng it in GRPC context (with or without validation)