### PR TITLE
fix in protoc-gen-grpc-gateway/gengateway/template.go, 

### DIFF
--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -361,6 +361,7 @@ func Register{{$svc.GetName}}Handler(ctx context.Context, mux *runtime.ServeMux,
 		rctx, err := runtime.AnnotateContext(ctx, mux, req)
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
 		}
 		resp, md, err := request_{{$svc.GetName}}_{{$m.GetName}}_{{$b.Index}}(rctx, inboundMarshaler, client, req, pathParams)
 		ctx = runtime.NewServerMetadataContext(ctx, md)


### PR DESCRIPTION
Return if runtime.AnnotateContext gave error, don't pass to grpc client and don't send request to grpc server

PS: Don't forget to 'go install' inside protoc-gen-grpc-gateway/