### PR TITLE
Update stale path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Make sure that your `$GOPATH/bin` is in your `$PATH`.
    ```sh
    protoc -I/usr/local/include -I. \
      -I$GOPATH/src \
-     -I$GOPATH/src/github.com/googleapis/googleapis/ \
+     -I$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
      --go_out=,plugins=grpc:. \
      path/to/your_service.proto
    ```


### PR DESCRIPTION
This was missed in the genproto compatibility change.