### PR TITLE
Update go_out parameter to remove comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Make sure that your `$GOPATH/bin` is in your `$PATH`.
    protoc -I/usr/local/include -I. \
      -I$GOPATH/src \
      -I$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
-     --go_out=,plugins=grpc:. \
+     --go_out=plugins=grpc:. \
      path/to/your_service.proto
    ```
    


### PR DESCRIPTION
This was missed when removing the now-unneeded "M=" mapping.