### PR TITLE
Move to stdlib context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ GATEWAY_PLUGIN_SRC= utilities/doc.go \
 GATEWAY_PLUGIN_FLAGS?=
 
 GOOGLEAPIS_DIR=third_party/googleapis
+GOOGLEAPIS_GENPROTOS=google.golang.org/genproto/googleapis/api/annotations
 OUTPUT_DIR=_output
 
 RUNTIME_PROTO=runtime/internal/stream_chunk.proto
@@ -116,7 +117,10 @@ $(ABE_EXAMPLE_SRCS): $(ABE_EXAMPLE_SPEC)
 	    -l go -o examples/clients --additional-properties packageName=abe
 	@rm -f $(EXAMPLE_CLIENT_DIR)/README.md $(EXAMPLE_CLIENT_DIR)/git_push.sh $(EXAMPLE_CLIENT_DIR)/.gitignore
 
-examples: $(EXAMPLE_SVCSRCS) $(EXAMPLE_GWSRCS) $(EXAMPLE_DEPSRCS) $(EXAMPLE_SWAGGERSRCS) $(EXAMPLE_CLIENT_SRCS)
+deps:
+	go get $(GOOGLEAPIS_GENPROTOS)
+
+examples: deps $(EXAMPLE_SVCSRCS) $(EXAMPLE_GWSRCS) $(EXAMPLE_DEPSRCS) $(EXAMPLE_SWAGGERSRCS) $(EXAMPLE_CLIENT_SRCS)
 test: examples
 	go test -race $(PKG)/...
 

--- a/examples/examplepb/a_bit_of_everything.pb.go
+++ b/examples/examplepb/a_bit_of_everything.pb.go
@@ -15,7 +15,7 @@ import sub2 "github.com/grpc-ecosystem/grpc-gateway/examples/sub2"
 import google_protobuf3 "github.com/golang/protobuf/ptypes/timestamp"
 
 import (
-	context "golang.org/x/net/context"
+	context "context"
 	grpc "google.golang.org/grpc"
 )
 

--- a/examples/examplepb/echo_service.pb.go
+++ b/examples/examplepb/echo_service.pb.go
@@ -33,7 +33,7 @@ import math "math"
 import _ "google.golang.org/genproto/googleapis/api/annotations"
 
 import (
-	context "golang.org/x/net/context"
+	context "context"
 	grpc "google.golang.org/grpc"
 )
 

--- a/examples/examplepb/flow_combination.pb.go
+++ b/examples/examplepb/flow_combination.pb.go
@@ -10,7 +10,7 @@ import math "math"
 import _ "google.golang.org/genproto/googleapis/api/annotations"
 
 import (
-	context "golang.org/x/net/context"
+	context "context"
 	grpc "google.golang.org/grpc"
 )
 

--- a/examples/examplepb/stream.pb.go
+++ b/examples/examplepb/stream.pb.go
@@ -12,7 +12,7 @@ import google_protobuf1 "github.com/golang/protobuf/ptypes/empty"
 import grpc_gateway_examples_sub "github.com/grpc-ecosystem/grpc-gateway/examples/sub"
 
 import (
-	context "golang.org/x/net/context"
+	context "context"
 	grpc "google.golang.org/grpc"
 )
 


### PR DESCRIPTION
CI will fail on this until https://github.com/grpc/grpc-go/pull/1160 lands.

Fixes #326 