### PR TITLE
Add charset=utf-8 to json marhalers

### DIFF
--- a/runtime/errors_test.go
+++ b/runtime/errors_test.go
@@ -37,7 +37,7 @@ func TestDefaultHTTPError(t *testing.T) {
 		req, _ := http.NewRequest("", "", nil) // Pass in an empty request to match the signature
 		runtime.DefaultHTTPError(ctx, &runtime.JSONBuiltin{}, w, req, spec.err)
 
-		if got, want := w.Header().Get("Content-Type"), "application/json"; got != want {
+		if got, want := w.Header().Get("Content-Type"), "application/json; charset=utf-8"; got != want {
 			t.Errorf(`w.Header().Get("Content-Type") = %q; want %q; on spec.err=%v`, got, want, spec.err)
 		}
 		if got, want := w.Code, spec.status; got != want {

--- a/runtime/marshal_json.go
+++ b/runtime/marshal_json.go
@@ -11,9 +11,9 @@ import (
 // it does not support advanced features of protobuf, e.g. map, oneof, ....
 type JSONBuiltin struct{}
 
-// ContentType always Returns "application/json".
+// ContentType always Returns "application/json; charset=utf-8".
 func (*JSONBuiltin) ContentType() string {
-	return "application/json"
+	return "application/json; charset=utf-8"
 }
 
 // Marshal marshals "v" into JSON

--- a/runtime/marshal_jsonpb.go
+++ b/runtime/marshal_jsonpb.go
@@ -16,9 +16,9 @@ import (
 // It supports fully functionality of protobuf unlike JSONBuiltin.
 type JSONPb jsonpb.Marshaler
 
-// ContentType always returns "application/json".
+// ContentType always returns "application/json; charset=utf-8".
 func (*JSONPb) ContentType() string {
-	return "application/json"
+	return "application/json; charset=utf-8"
 }
 
 // Marshal marshals "v" into JSON


### PR DESCRIPTION
It's just minor change, but it should remove some worries for new users who uses  Chrome. Because when Chrome got content with "Content-Type: application/json" it doesnt set utf-8 charset as default.