### PR TITLE
Set int64 fields as integers in Swagger doc

### DIFF
--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -258,7 +258,7 @@ func primitiveSchema(t pbdescriptor.FieldDescriptorProto_Type) (ftype, format st
 	case pbdescriptor.FieldDescriptorProto_TYPE_FLOAT:
 		return "number", "float", true
 	case pbdescriptor.FieldDescriptorProto_TYPE_INT64:
-		return "number", "int64", true
+		return "integer", "int64", true
 	case pbdescriptor.FieldDescriptorProto_TYPE_UINT64:
 		// 64bit integer types are marshaled as string in the default JSONPb marshaler.
 		// TODO(yugui) Add an option to declare 64bit integers as int64.

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -258,7 +258,7 @@ func primitiveSchema(t pbdescriptor.FieldDescriptorProto_Type) (ftype, format st
 	case pbdescriptor.FieldDescriptorProto_TYPE_FLOAT:
 		return "number", "float", true
 	case pbdescriptor.FieldDescriptorProto_TYPE_INT64:
-		return "string", "int64", true
+		return "number", "int64", true
 	case pbdescriptor.FieldDescriptorProto_TYPE_UINT64:
 		// 64bit integer types are marshaled as string in the default JSONPb marshaler.
 		// TODO(yugui) Add an option to declare 64bit integers as int64.


### PR DESCRIPTION
Since jsonpb happily accepts int64s as both strings and integers from JSON - I think it's more intuitive to report them as integers in Swagger docs.