### PR TITLE
metadata: fix properly and change to Outgoing

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -94,7 +94,7 @@ func AnnotateContext(ctx context.Context, req *http.Request) (context.Context, e
 	if len(pairs) == 0 {
 		return ctx, nil
 	}
-	return metadata.NewIncomingContext(ctx, metadata.Pairs(pairs...)), nil
+	return metadata.NewOutgoingContext(ctx, metadata.Pairs(pairs...)), nil
 }
 
 // ServerMetadata consists of metadata sent from gRPC server.

--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -28,7 +28,7 @@ func TestAnnotateContext_WorksWithEmpty(t *testing.T) {
 		t.Errorf("runtime.AnnotateContext(ctx, %#v) failed with %v; want success", request, err)
 		return
 	}
-	md, ok := metadata.FromIncomingContext(annotated)
+	md, ok := metadata.FromOutgoingContext(annotated)
 	if !ok || len(md) != emptyForwardMetaCount {
 		t.Errorf("Expected %d metadata items in context; got %v", emptyForwardMetaCount, md)
 	}
@@ -50,7 +50,7 @@ func TestAnnotateContext_ForwardsGrpcMetadata(t *testing.T) {
 		t.Errorf("runtime.AnnotateContext(ctx, %#v) failed with %v; want success", request, err)
 		return
 	}
-	md, ok := metadata.FromIncomingContext(annotated)
+	md, ok := metadata.FromOutgoingContext(annotated)
 	if got, want := len(md), emptyForwardMetaCount+4; !ok || got != want {
 		t.Errorf("metadata items in context = %d want %d: %v", got, want, md)
 	}
@@ -82,7 +82,7 @@ func TestAnnotateContext_XForwardedFor(t *testing.T) {
 		t.Errorf("runtime.AnnotateContext(ctx, %#v) failed with %v; want success", request, err)
 		return
 	}
-	md, ok := metadata.FromIncomingContext(annotated)
+	md, ok := metadata.FromOutgoingContext(annotated)
 	if !ok || len(md) != emptyForwardMetaCount+1 {
 		t.Errorf("Expected %d metadata items in context; got %v", emptyForwardMetaCount+1, md)
 	}


### PR DESCRIPTION
I was hasty in my modification before. As we're pre-call here this should use outgoing not incoming.