### PR TITLE
Use canonical header form in default header matcher.

### DIFF
--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -1,13 +1,12 @@
 package runtime
 
 import (
-	"fmt"
 	"net/http"
+	"net/textproto"
 	"strings"
 
-	"golang.org/x/net/context"
-
 	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -48,8 +47,9 @@ type HeaderMatcherFunc func(string) (string, bool)
 // keys (as specified by the IANA) to gRPC context with grpcgateway- prefix. HTTP headers that start with
 // 'Grpc-Metadata-' are mapped to gRPC metadata after removing prefix 'Grpc-Metadata-'.
 func DefaultHeaderMatcher(key string) (string, bool) {
+	key = textproto.CanonicalMIMEHeaderKey(key)
 	if isPermanentHTTPHeader(key) {
-		return strings.ToLower(fmt.Sprintf("%s%s", MetadataPrefix, key)), true
+		return MetadataPrefix + key, true
 	} else if strings.HasPrefix(key, MetadataHeaderPrefix) {
 		return key[len(MetadataHeaderPrefix):], true
 	}


### PR DESCRIPTION
 - I also removed strings.ToLower(), since metadata method itself performs this transformation for http/2.
 - This will also strip `Grpc-Metadata-` prefix regardless of the original casing used in http header.