### PR TITLE
Fixed build error with golang 1.8.1 related to metadata.Context.

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -96,7 +96,7 @@ func AnnotateContext(ctx context.Context, mux *ServeMux, req *http.Request) (con
 	if mux.metadataAnnotator != nil {
 		md = metadata.Join(md, mux.metadataAnnotator(ctx, req))
 	}
-	return metadata.NewOutgoingContext(ctx, md), nil
+	return metadata.NewContext(ctx, md), nil
 }
 
 // ServerMetadata consists of metadata sent from gRPC server.

--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -28,7 +28,7 @@ func TestAnnotateContext_WorksWithEmpty(t *testing.T) {
 		t.Errorf("runtime.AnnotateContext(ctx, %#v) failed with %v; want success", request, err)
 		return
 	}
-	md, ok := metadata.FromOutgoingContext(annotated)
+	md, ok := metadata.FromContext(annotated)
 	if !ok || len(md) != emptyForwardMetaCount {
 		t.Errorf("Expected %d metadata items in context; got %v", emptyForwardMetaCount, md)
 	}
@@ -50,7 +50,7 @@ func TestAnnotateContext_ForwardsGrpcMetadata(t *testing.T) {
 		t.Errorf("runtime.AnnotateContext(ctx, %#v) failed with %v; want success", request, err)
 		return
 	}
-	md, ok := metadata.FromOutgoingContext(annotated)
+	md, ok := metadata.FromContext(annotated)
 	if got, want := len(md), emptyForwardMetaCount+4; !ok || got != want {
 		t.Errorf("metadata items in context = %d want %d: %v", got, want, md)
 	}
@@ -82,7 +82,7 @@ func TestAnnotateContext_XForwardedFor(t *testing.T) {
 		t.Errorf("runtime.AnnotateContext(ctx, %#v) failed with %v; want success", request, err)
 		return
 	}
-	md, ok := metadata.FromOutgoingContext(annotated)
+	md, ok := metadata.FromContext(annotated)
 	if !ok || len(md) != emptyForwardMetaCount+1 {
 		t.Errorf("Expected %d metadata items in context; got %v", emptyForwardMetaCount+1, md)
 	}


### PR DESCRIPTION
Latest version appears to have a breaking API change.

```
$ go build ./...
# github.com/grpc-ecosystem/grpc-gateway/runtime
runtime/context.go:99: undefined: metadata.NewOutgoingContext
```

```
$ go test ./...
# github.com/grpc-ecosystem/grpc-gateway/runtime_test
runtime/context_test.go:31: undefined: metadata.FromOutgoingContext
runtime/context_test.go:53: undefined: metadata.FromOutgoingContext
runtime/context_test.go:85: undefined: metadata.FromOutgoingContext
```