### PR TITLE
Use status package for error and introduce WithProtoErrorHandler option

### DIFF
--- a/examples/examplepb/a_bit_of_everything.pb.gw.go
+++ b/examples/examplepb/a_bit_of_everything.pb.gw.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/status"
 )
 
 var _ codes.Code
@@ -47,7 +48,7 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["float_value"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "float_value")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "float_value")
 	}
 
 	protoReq.FloatValue, err = runtime.Float32(val)
@@ -58,7 +59,7 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["double_value"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "double_value")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "double_value")
 	}
 
 	protoReq.DoubleValue, err = runtime.Float64(val)
@@ -69,7 +70,7 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["int64_value"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "int64_value")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "int64_value")
 	}
 
 	protoReq.Int64Value, err = runtime.Int64(val)
@@ -80,7 +81,7 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["uint64_value"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "uint64_value")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "uint64_value")
 	}
 
 	protoReq.Uint64Value, err = runtime.Uint64(val)
@@ -91,7 +92,7 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["int32_value"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "int32_value")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "int32_value")
 	}
 
 	protoReq.Int32Value, err = runtime.Int32(val)
@@ -102,7 +103,7 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["fixed64_value"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "fixed64_value")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "fixed64_value")
 	}
 
 	protoReq.Fixed64Value, err = runtime.Uint64(val)
@@ -113,7 +114,7 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["fixed32_value"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "fixed32_value")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "fixed32_value")
 	}
 
 	protoReq.Fixed32Value, err = runtime.Uint32(val)
@@ -124,7 +125,7 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["bool_value"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "bool_value")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "bool_value")
 	}
 
 	protoReq.BoolValue, err = runtime.Bool(val)
@@ -135,7 +136,7 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["string_value"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "string_value")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "string_value")
 	}
 
 	protoReq.StringValue, err = runtime.String(val)
@@ -146,7 +147,7 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["uint32_value"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "uint32_value")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "uint32_value")
 	}
 
 	protoReq.Uint32Value, err = runtime.Uint32(val)
@@ -157,7 +158,7 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["sfixed32_value"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "sfixed32_value")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "sfixed32_value")
 	}
 
 	protoReq.Sfixed32Value, err = runtime.Int32(val)
@@ -168,7 +169,7 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["sfixed64_value"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "sfixed64_value")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "sfixed64_value")
 	}
 
 	protoReq.Sfixed64Value, err = runtime.Int64(val)
@@ -179,7 +180,7 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["sint32_value"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "sint32_value")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "sint32_value")
 	}
 
 	protoReq.Sint32Value, err = runtime.Int32(val)
@@ -190,7 +191,7 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["sint64_value"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "sint64_value")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "sint64_value")
 	}
 
 	protoReq.Sint64Value, err = runtime.Int64(val)
@@ -201,7 +202,7 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["nonConventionalNameValue"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "nonConventionalNameValue")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "nonConventionalNameValue")
 	}
 
 	protoReq.NonConventionalNameValue, err = runtime.String(val)
@@ -211,7 +212,7 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, marshaler run
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_ABitOfEverythingService_Create_0); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.Create(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -224,7 +225,7 @@ func request_ABitOfEverythingService_CreateBody_0(ctx context.Context, marshaler
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.CreateBody(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -245,7 +246,7 @@ func request_ABitOfEverythingService_Lookup_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["uuid"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
 	}
 
 	protoReq.Uuid, err = runtime.String(val)
@@ -264,7 +265,7 @@ func request_ABitOfEverythingService_Update_0(ctx context.Context, marshaler run
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -276,7 +277,7 @@ func request_ABitOfEverythingService_Update_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["uuid"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
 	}
 
 	protoReq.Uuid, err = runtime.String(val)
@@ -303,7 +304,7 @@ func request_ABitOfEverythingService_Delete_0(ctx context.Context, marshaler run
 
 	val, ok = pathParams["uuid"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
 	}
 
 	protoReq.Uuid, err = runtime.String(val)
@@ -334,7 +335,7 @@ func request_ABitOfEverythingService_GetQuery_0(ctx context.Context, marshaler r
 
 	val, ok = pathParams["uuid"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
 	}
 
 	protoReq.Uuid, err = runtime.String(val)
@@ -344,7 +345,7 @@ func request_ABitOfEverythingService_GetQuery_0(ctx context.Context, marshaler r
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_ABitOfEverythingService_GetQuery_0); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.GetQuery(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -365,7 +366,7 @@ func request_ABitOfEverythingService_Echo_0(ctx context.Context, marshaler runti
 
 	val, ok = pathParams["value"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "value")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "value")
 	}
 
 	protoReq.Value, err = runtime.StringP(val)
@@ -384,7 +385,7 @@ func request_ABitOfEverythingService_Echo_1(ctx context.Context, marshaler runti
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Value); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.Echo(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -401,7 +402,7 @@ func request_ABitOfEverythingService_Echo_2(ctx context.Context, marshaler runti
 	var metadata runtime.ServerMetadata
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_ABitOfEverythingService_Echo_2); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.Echo(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -414,7 +415,7 @@ func request_ABitOfEverythingService_DeepPathEcho_0(ctx context.Context, marshal
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -426,7 +427,7 @@ func request_ABitOfEverythingService_DeepPathEcho_0(ctx context.Context, marshal
 
 	val, ok = pathParams["single_nested.name"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "single_nested.name")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "single_nested.name")
 	}
 
 	err = runtime.PopulateFieldFromPath(&protoReq, "single_nested.name", val)

--- a/examples/examplepb/echo_service.pb.gw.go
+++ b/examples/examplepb/echo_service.pb.gw.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/status"
 )
 
 var _ codes.Code
@@ -40,7 +41,7 @@ func request_EchoService_Echo_0(ctx context.Context, marshaler runtime.Marshaler
 
 	val, ok = pathParams["id"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
 	}
 
 	protoReq.Id, err = runtime.String(val)
@@ -59,7 +60,7 @@ func request_EchoService_EchoBody_0(ctx context.Context, marshaler runtime.Marsh
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.EchoBody(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))

--- a/examples/examplepb/flow_combination.pb.gw.go
+++ b/examples/examplepb/flow_combination.pb.gw.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/status"
 )
 
 var _ codes.Code
@@ -69,7 +70,7 @@ func request_FlowCombination_StreamEmptyRpc_0(ctx context.Context, marshaler run
 		}
 		if err != nil {
 			grpclog.Printf("Failed to decode request: %v", err)
-			return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+			return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
 			grpclog.Printf("Failed to send request: %v", err)
@@ -151,7 +152,7 @@ func request_FlowCombination_RpcBodyRpc_0(ctx context.Context, marshaler runtime
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.RpcBodyRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -172,7 +173,7 @@ func request_FlowCombination_RpcBodyRpc_1(ctx context.Context, marshaler runtime
 
 	val, ok = pathParams["a"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
 	}
 
 	protoReq.A, err = runtime.String(val)
@@ -183,7 +184,7 @@ func request_FlowCombination_RpcBodyRpc_1(ctx context.Context, marshaler runtime
 
 	val, ok = pathParams["b"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
 	}
 
 	protoReq.B, err = runtime.String(val)
@@ -194,7 +195,7 @@ func request_FlowCombination_RpcBodyRpc_1(ctx context.Context, marshaler runtime
 
 	val, ok = pathParams["c"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "c")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "c")
 	}
 
 	protoReq.C, err = runtime.String(val)
@@ -217,7 +218,7 @@ func request_FlowCombination_RpcBodyRpc_2(ctx context.Context, marshaler runtime
 	var metadata runtime.ServerMetadata
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcBodyRpc_2); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.RpcBodyRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -230,7 +231,7 @@ func request_FlowCombination_RpcBodyRpc_3(ctx context.Context, marshaler runtime
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -242,7 +243,7 @@ func request_FlowCombination_RpcBodyRpc_3(ctx context.Context, marshaler runtime
 
 	val, ok = pathParams["a"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
 	}
 
 	protoReq.A, err = runtime.String(val)
@@ -253,7 +254,7 @@ func request_FlowCombination_RpcBodyRpc_3(ctx context.Context, marshaler runtime
 
 	val, ok = pathParams["b"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
 	}
 
 	protoReq.B, err = runtime.String(val)
@@ -276,11 +277,11 @@ func request_FlowCombination_RpcBodyRpc_4(ctx context.Context, marshaler runtime
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcBodyRpc_4); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.RpcBodyRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -297,7 +298,7 @@ func request_FlowCombination_RpcBodyRpc_5(ctx context.Context, marshaler runtime
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -309,7 +310,7 @@ func request_FlowCombination_RpcBodyRpc_5(ctx context.Context, marshaler runtime
 
 	val, ok = pathParams["a"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
 	}
 
 	protoReq.A, err = runtime.String(val)
@@ -319,7 +320,7 @@ func request_FlowCombination_RpcBodyRpc_5(ctx context.Context, marshaler runtime
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcBodyRpc_5); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.RpcBodyRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -344,7 +345,7 @@ func request_FlowCombination_RpcBodyRpc_6(ctx context.Context, marshaler runtime
 
 	val, ok = pathParams["a"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
 	}
 
 	protoReq.A, err = runtime.String(val)
@@ -354,7 +355,7 @@ func request_FlowCombination_RpcBodyRpc_6(ctx context.Context, marshaler runtime
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcBodyRpc_6); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.RpcBodyRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -379,7 +380,7 @@ func request_FlowCombination_RpcPathSingleNestedRpc_0(ctx context.Context, marsh
 
 	val, ok = pathParams["a.str"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
 	}
 
 	err = runtime.PopulateFieldFromPath(&protoReq, "a.str", val)
@@ -389,7 +390,7 @@ func request_FlowCombination_RpcPathSingleNestedRpc_0(ctx context.Context, marsh
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcPathSingleNestedRpc_0); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.RpcPathSingleNestedRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -406,7 +407,7 @@ func request_FlowCombination_RpcPathNestedRpc_0(ctx context.Context, marshaler r
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -418,7 +419,7 @@ func request_FlowCombination_RpcPathNestedRpc_0(ctx context.Context, marshaler r
 
 	val, ok = pathParams["a.str"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
 	}
 
 	err = runtime.PopulateFieldFromPath(&protoReq, "a.str", val)
@@ -429,7 +430,7 @@ func request_FlowCombination_RpcPathNestedRpc_0(ctx context.Context, marshaler r
 
 	val, ok = pathParams["b"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
 	}
 
 	protoReq.B, err = runtime.String(val)
@@ -439,7 +440,7 @@ func request_FlowCombination_RpcPathNestedRpc_0(ctx context.Context, marshaler r
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcPathNestedRpc_0); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.RpcPathNestedRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -464,7 +465,7 @@ func request_FlowCombination_RpcPathNestedRpc_1(ctx context.Context, marshaler r
 
 	val, ok = pathParams["a.str"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
 	}
 
 	err = runtime.PopulateFieldFromPath(&protoReq, "a.str", val)
@@ -474,7 +475,7 @@ func request_FlowCombination_RpcPathNestedRpc_1(ctx context.Context, marshaler r
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcPathNestedRpc_1); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.RpcPathNestedRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -491,7 +492,7 @@ func request_FlowCombination_RpcPathNestedRpc_2(ctx context.Context, marshaler r
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -503,7 +504,7 @@ func request_FlowCombination_RpcPathNestedRpc_2(ctx context.Context, marshaler r
 
 	val, ok = pathParams["a.str"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
 	}
 
 	err = runtime.PopulateFieldFromPath(&protoReq, "a.str", val)
@@ -513,7 +514,7 @@ func request_FlowCombination_RpcPathNestedRpc_2(ctx context.Context, marshaler r
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcPathNestedRpc_2); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.RpcPathNestedRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -526,7 +527,7 @@ func request_FlowCombination_RpcBodyStream_0(ctx context.Context, marshaler runt
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	stream, err := client.RpcBodyStream(ctx, &protoReq)
@@ -555,7 +556,7 @@ func request_FlowCombination_RpcBodyStream_1(ctx context.Context, marshaler runt
 
 	val, ok = pathParams["a"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
 	}
 
 	protoReq.A, err = runtime.String(val)
@@ -566,7 +567,7 @@ func request_FlowCombination_RpcBodyStream_1(ctx context.Context, marshaler runt
 
 	val, ok = pathParams["b"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
 	}
 
 	protoReq.B, err = runtime.String(val)
@@ -577,7 +578,7 @@ func request_FlowCombination_RpcBodyStream_1(ctx context.Context, marshaler runt
 
 	val, ok = pathParams["c"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "c")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "c")
 	}
 
 	protoReq.C, err = runtime.String(val)
@@ -608,7 +609,7 @@ func request_FlowCombination_RpcBodyStream_2(ctx context.Context, marshaler runt
 	var metadata runtime.ServerMetadata
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcBodyStream_2); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	stream, err := client.RpcBodyStream(ctx, &protoReq)
@@ -629,7 +630,7 @@ func request_FlowCombination_RpcBodyStream_3(ctx context.Context, marshaler runt
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -641,7 +642,7 @@ func request_FlowCombination_RpcBodyStream_3(ctx context.Context, marshaler runt
 
 	val, ok = pathParams["a"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
 	}
 
 	protoReq.A, err = runtime.String(val)
@@ -652,7 +653,7 @@ func request_FlowCombination_RpcBodyStream_3(ctx context.Context, marshaler runt
 
 	val, ok = pathParams["b"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
 	}
 
 	protoReq.B, err = runtime.String(val)
@@ -683,11 +684,11 @@ func request_FlowCombination_RpcBodyStream_4(ctx context.Context, marshaler runt
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcBodyStream_4); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	stream, err := client.RpcBodyStream(ctx, &protoReq)
@@ -712,7 +713,7 @@ func request_FlowCombination_RpcBodyStream_5(ctx context.Context, marshaler runt
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -724,7 +725,7 @@ func request_FlowCombination_RpcBodyStream_5(ctx context.Context, marshaler runt
 
 	val, ok = pathParams["a"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
 	}
 
 	protoReq.A, err = runtime.String(val)
@@ -734,7 +735,7 @@ func request_FlowCombination_RpcBodyStream_5(ctx context.Context, marshaler runt
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcBodyStream_5); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	stream, err := client.RpcBodyStream(ctx, &protoReq)
@@ -767,7 +768,7 @@ func request_FlowCombination_RpcBodyStream_6(ctx context.Context, marshaler runt
 
 	val, ok = pathParams["a"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
 	}
 
 	protoReq.A, err = runtime.String(val)
@@ -777,7 +778,7 @@ func request_FlowCombination_RpcBodyStream_6(ctx context.Context, marshaler runt
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcBodyStream_6); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	stream, err := client.RpcBodyStream(ctx, &protoReq)
@@ -810,7 +811,7 @@ func request_FlowCombination_RpcPathSingleNestedStream_0(ctx context.Context, ma
 
 	val, ok = pathParams["a.str"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
 	}
 
 	err = runtime.PopulateFieldFromPath(&protoReq, "a.str", val)
@@ -820,7 +821,7 @@ func request_FlowCombination_RpcPathSingleNestedStream_0(ctx context.Context, ma
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcPathSingleNestedStream_0); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	stream, err := client.RpcPathSingleNestedStream(ctx, &protoReq)
@@ -845,7 +846,7 @@ func request_FlowCombination_RpcPathNestedStream_0(ctx context.Context, marshale
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -857,7 +858,7 @@ func request_FlowCombination_RpcPathNestedStream_0(ctx context.Context, marshale
 
 	val, ok = pathParams["a.str"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
 	}
 
 	err = runtime.PopulateFieldFromPath(&protoReq, "a.str", val)
@@ -868,7 +869,7 @@ func request_FlowCombination_RpcPathNestedStream_0(ctx context.Context, marshale
 
 	val, ok = pathParams["b"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
 	}
 
 	protoReq.B, err = runtime.String(val)
@@ -878,7 +879,7 @@ func request_FlowCombination_RpcPathNestedStream_0(ctx context.Context, marshale
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcPathNestedStream_0); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	stream, err := client.RpcPathNestedStream(ctx, &protoReq)
@@ -911,7 +912,7 @@ func request_FlowCombination_RpcPathNestedStream_1(ctx context.Context, marshale
 
 	val, ok = pathParams["a.str"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
 	}
 
 	err = runtime.PopulateFieldFromPath(&protoReq, "a.str", val)
@@ -921,7 +922,7 @@ func request_FlowCombination_RpcPathNestedStream_1(ctx context.Context, marshale
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcPathNestedStream_1); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	stream, err := client.RpcPathNestedStream(ctx, &protoReq)
@@ -946,7 +947,7 @@ func request_FlowCombination_RpcPathNestedStream_2(ctx context.Context, marshale
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -958,7 +959,7 @@ func request_FlowCombination_RpcPathNestedStream_2(ctx context.Context, marshale
 
 	val, ok = pathParams["a.str"]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
 	}
 
 	err = runtime.PopulateFieldFromPath(&protoReq, "a.str", val)
@@ -968,7 +969,7 @@ func request_FlowCombination_RpcPathNestedStream_2(ctx context.Context, marshale
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcPathNestedStream_2); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	stream, err := client.RpcPathNestedStream(ctx, &protoReq)

--- a/examples/examplepb/stream.pb.gw.go
+++ b/examples/examplepb/stream.pb.gw.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/status"
 )
 
 var _ codes.Code
@@ -45,7 +46,7 @@ func request_StreamService_BulkCreate_0(ctx context.Context, marshaler runtime.M
 		}
 		if err != nil {
 			grpclog.Printf("Failed to decode request: %v", err)
-			return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+			return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
 			grpclog.Printf("Failed to send request: %v", err)

--- a/examples/integration_test.go
+++ b/examples/integration_test.go
@@ -722,3 +722,43 @@ func TestTimeout(t *testing.T) {
 		t.Errorf("resp.StatusCode = %d; want %d", got, want)
 	}
 }
+
+func TestUnknownPath(t *testing.T) {
+	url := "http://localhost:8080"
+	resp, err := http.Post(url, "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Errorf("http.Post(%q) failed with %v; want success", url, err)
+		return
+	}
+	defer resp.Body.Close()
+	buf, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("iotuil.ReadAll(resp.Body) failed with %v; want success", err)
+		return
+	}
+
+	if got, want := resp.StatusCode, http.StatusNotFound; got != want {
+		t.Errorf("resp.StatusCode = %d; want %d", got, want)
+		t.Logf("%s", buf)
+	}
+}
+
+func TestMethodNotAllowed(t *testing.T) {
+	url := "http://localhost:8080/v1/example/echo/myid"
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Errorf("http.Post(%q) failed with %v; want success", url, err)
+		return
+	}
+	defer resp.Body.Close()
+	buf, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("iotuil.ReadAll(resp.Body) failed with %v; want success", err)
+		return
+	}
+
+	if got, want := resp.StatusCode, http.StatusMethodNotAllowed; got != want {
+		t.Errorf("resp.StatusCode = %d; want %d", got, want)
+		t.Logf("%s", buf)
+	}
+}

--- a/examples/integration_test.go
+++ b/examples/integration_test.go
@@ -36,7 +36,7 @@ func TestEcho(t *testing.T) {
 	}
 
 	testEcho(t, 8080, "application/json")
-	testEchoBody(t)
+	testEchoBody(t, 8080)
 }
 
 func TestForwardResponseOption(t *testing.T) {
@@ -92,7 +92,7 @@ func testEcho(t *testing.T, port int, contentType string) {
 	}
 }
 
-func testEchoBody(t *testing.T) {
+func testEchoBody(t *testing.T, port int) {
 	sent := gw.SimpleMessage{Id: "example"}
 	var m jsonpb.Marshaler
 	payload, err := m.MarshalToString(&sent)
@@ -100,7 +100,7 @@ func testEchoBody(t *testing.T) {
 		t.Fatalf("m.MarshalToString(%#v) failed with %v; want success", payload, err)
 	}
 
-	url := "http://localhost:8080/v1/example/echo_body"
+	url := fmt.Sprintf("http://localhost:%d/v1/example/echo_body", port)
 	resp, err := http.Post(url, "", strings.NewReader(payload))
 	if err != nil {
 		t.Errorf("http.Post(%q) failed with %v; want success", url, err)
@@ -148,18 +148,18 @@ func TestABE(t *testing.T) {
 		return
 	}
 
-	testABECreate(t)
-	testABECreateBody(t)
-	testABEBulkCreate(t)
-	testABELookup(t)
-	testABELookupNotFound(t)
-	testABEList(t)
-	testABEBulkEcho(t)
-	testABEBulkEchoZeroLength(t)
-	testAdditionalBindings(t)
+	testABECreate(t, 8080)
+	testABECreateBody(t, 8080)
+	testABEBulkCreate(t, 8080)
+	testABELookup(t, 8080)
+	testABELookupNotFound(t, 8080)
+	testABEList(t, 8080)
+	testABEBulkEcho(t, 8080)
+	testABEBulkEchoZeroLength(t, 8080)
+	testAdditionalBindings(t, 8080)
 }
 
-func testABECreate(t *testing.T) {
+func testABECreate(t *testing.T, port int) {
 	want := gw.ABitOfEverything{
 		FloatValue:               1.5,
 		DoubleValue:              2.5,
@@ -177,7 +177,7 @@ func testABECreate(t *testing.T) {
 		Sint64Value:              4611686018427387903,
 		NonConventionalNameValue: "camelCase",
 	}
-	url := fmt.Sprintf("http://localhost:8080/v1/example/a_bit_of_everything/%f/%f/%d/separator/%d/%d/%d/%d/%v/%s/%d/%d/%d/%d/%d/%s", want.FloatValue, want.DoubleValue, want.Int64Value, want.Uint64Value, want.Int32Value, want.Fixed64Value, want.Fixed32Value, want.BoolValue, want.StringValue, want.Uint32Value, want.Sfixed32Value, want.Sfixed64Value, want.Sint32Value, want.Sint64Value, want.NonConventionalNameValue)
+	url := fmt.Sprintf("http://localhost:%d/v1/example/a_bit_of_everything/%f/%f/%d/separator/%d/%d/%d/%d/%v/%s/%d/%d/%d/%d/%d/%s", port, want.FloatValue, want.DoubleValue, want.Int64Value, want.Uint64Value, want.Int32Value, want.Fixed64Value, want.Fixed32Value, want.BoolValue, want.StringValue, want.Uint32Value, want.Sfixed32Value, want.Sfixed64Value, want.Sint32Value, want.Sint64Value, want.NonConventionalNameValue)
 
 	resp, err := http.Post(url, "application/json", strings.NewReader("{}"))
 	if err != nil {
@@ -210,7 +210,7 @@ func testABECreate(t *testing.T) {
 	}
 }
 
-func testABECreateBody(t *testing.T) {
+func testABECreateBody(t *testing.T, port int) {
 	want := gw.ABitOfEverything{
 		FloatValue:               1.5,
 		DoubleValue:              2.5,
@@ -255,7 +255,7 @@ func testABECreateBody(t *testing.T) {
 			"b": {Name: "y", Amount: 2},
 		},
 	}
-	url := "http://localhost:8080/v1/example/a_bit_of_everything"
+	url := fmt.Sprintf("http://localhost:%d/v1/example/a_bit_of_everything", port)
 	var m jsonpb.Marshaler
 	payload, err := m.MarshalToString(&want)
 	if err != nil {
@@ -293,7 +293,7 @@ func testABECreateBody(t *testing.T) {
 	}
 }
 
-func testABEBulkCreate(t *testing.T) {
+func testABEBulkCreate(t *testing.T, port int) {
 	count := 0
 	r, w := io.Pipe()
 	go func(w io.WriteCloser) {
@@ -344,7 +344,7 @@ func testABEBulkCreate(t *testing.T) {
 			count++
 		}
 	}(w)
-	url := "http://localhost:8080/v1/example/a_bit_of_everything/bulk"
+	url := fmt.Sprintf("http://localhost:%d/v1/example/a_bit_of_everything/bulk", port)
 	resp, err := http.Post(url, "application/json", r)
 	if err != nil {
 		t.Errorf("http.Post(%q) failed with %v; want success", url, err)
@@ -380,8 +380,8 @@ func testABEBulkCreate(t *testing.T) {
 	}
 }
 
-func testABELookup(t *testing.T) {
-	url := "http://localhost:8080/v1/example/a_bit_of_everything"
+func testABELookup(t *testing.T, port int) {
+	url := fmt.Sprintf("http://localhost:%d/v1/example/a_bit_of_everything", port)
 	cresp, err := http.Post(url, "application/json", strings.NewReader(`
 		{"bool_value": true, "string_value": "strprefix/example"}
 	`))
@@ -435,8 +435,8 @@ func testABELookup(t *testing.T) {
 	}
 }
 
-func testABELookupNotFound(t *testing.T) {
-	url := "http://localhost:8080/v1/example/a_bit_of_everything"
+func testABELookupNotFound(t *testing.T, port int) {
+	url := fmt.Sprintf("http://localhost:%d/v1/example/a_bit_of_everything", port)
 	uuid := "not_exist"
 	url = fmt.Sprintf("%s/%s", url, uuid)
 	resp, err := http.Get(url)
@@ -469,6 +469,11 @@ func testABELookupNotFound(t *testing.T) {
 		return
 	}
 
+	if got, want := msg.Error, "not found"; got != want {
+		t.Errorf("msg.Error = %s; want %s", got, want)
+		return
+	}
+
 	if got, want := resp.Header.Get("Grpc-Metadata-Uuid"), uuid; got != want {
 		t.Errorf("Grpc-Metadata-Uuid was %s, wanted %s", got, want)
 	}
@@ -480,8 +485,8 @@ func testABELookupNotFound(t *testing.T) {
 	}
 }
 
-func testABEList(t *testing.T) {
-	url := "http://localhost:8080/v1/example/a_bit_of_everything"
+func testABEList(t *testing.T, port int) {
+	url := fmt.Sprintf("http://localhost:%d/v1/example/a_bit_of_everything", port)
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Errorf("http.Get(%q) failed with %v; want success", url, err)
@@ -531,7 +536,7 @@ func testABEList(t *testing.T) {
 	}
 }
 
-func testABEBulkEcho(t *testing.T) {
+func testABEBulkEcho(t *testing.T, port int) {
 	reqr, reqw := io.Pipe()
 	var wg sync.WaitGroup
 	var want []*sub.StringMessage
@@ -555,7 +560,7 @@ func testABEBulkEcho(t *testing.T) {
 		}
 	}()
 
-	url := "http://localhost:8080/v1/example/a_bit_of_everything/echo"
+	url := fmt.Sprintf("http://localhost:%d/v1/example/a_bit_of_everything/echo", port)
 	req, err := http.NewRequest("POST", url, reqr)
 	if err != nil {
 		t.Errorf("http.NewRequest(%q, %q, reqr) failed with %v; want success", "POST", url, err)
@@ -609,8 +614,8 @@ func testABEBulkEcho(t *testing.T) {
 	}
 }
 
-func testABEBulkEchoZeroLength(t *testing.T) {
-	url := "http://localhost:8080/v1/example/a_bit_of_everything/echo"
+func testABEBulkEchoZeroLength(t *testing.T, port int) {
+	url := fmt.Sprintf("http://localhost:%d/v1/example/a_bit_of_everything/echo", port)
 	req, err := http.NewRequest("POST", url, bytes.NewReader(nil))
 	if err != nil {
 		t.Errorf("http.NewRequest(%q, %q, bytes.NewReader(nil)) failed with %v; want success", "POST", url, err)
@@ -641,10 +646,10 @@ func testABEBulkEchoZeroLength(t *testing.T) {
 	}
 }
 
-func testAdditionalBindings(t *testing.T) {
+func testAdditionalBindings(t *testing.T, port int) {
 	for i, f := range []func() *http.Response{
 		func() *http.Response {
-			url := "http://localhost:8080/v1/example/a_bit_of_everything/echo/hello"
+			url := fmt.Sprintf("http://localhost:%d/v1/example/a_bit_of_everything/echo/hello", port)
 			resp, err := http.Get(url)
 			if err != nil {
 				t.Errorf("http.Get(%q) failed with %v; want success", url, err)
@@ -653,7 +658,7 @@ func testAdditionalBindings(t *testing.T) {
 			return resp
 		},
 		func() *http.Response {
-			url := "http://localhost:8080/v2/example/echo"
+			url := fmt.Sprintf("http://localhost:%d/v2/example/echo", port)
 			resp, err := http.Post(url, "application/json", strings.NewReader(`"hello"`))
 			if err != nil {
 				t.Errorf("http.Post(%q, %q, %q) failed with %v; want success", url, "application/json", `"hello"`, err)
@@ -662,7 +667,7 @@ func testAdditionalBindings(t *testing.T) {
 			return resp
 		},
 		func() *http.Response {
-			url := "http://localhost:8080/v2/example/echo?value=hello"
+			url := fmt.Sprintf("http://localhost:%d/v2/example/echo?value=hello", port)
 			resp, err := http.Get(url)
 			if err != nil {
 				t.Errorf("http.Get(%q) failed with %v; want success", url, err)

--- a/examples/proto_error_test.go
+++ b/examples/proto_error_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+)
+
+func TestWithProtoErrorHandler(t *testing.T) {
+	go func() {
+		if err := Run(
+			":8082",
+			runtime.WithProtoErrorHandler(runtime.DefaultHTTPProtoErrorHandler),
+		); err != nil {
+			t.Errorf("gw.Run() failed with %v; want success", err)
+			return
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	testEcho(t, 8082, "application/json")
+	testEchoBody(t, 8082)
+}
+
+func TestABEWithProtoErrorHandler(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+		return
+	}
+
+	testABECreate(t, 8082)
+	testABECreateBody(t, 8082)
+	testABEBulkCreate(t, 8082)
+	testABELookup(t, 8082)
+	testABELookupNotFoundWithProtoError(t)
+	testABEList(t, 8082)
+	testABEBulkEcho(t, 8082)
+	testABEBulkEchoZeroLength(t, 8082)
+	testAdditionalBindings(t, 8082)
+}
+
+func testABELookupNotFoundWithProtoError(t *testing.T) {
+	url := "http://localhost:8082/v1/example/a_bit_of_everything"
+	uuid := "not_exist"
+	url = fmt.Sprintf("%s/%s", url, uuid)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Errorf("http.Get(%q) failed with %v; want success", url, err)
+		return
+	}
+	defer resp.Body.Close()
+
+	buf, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		return
+	}
+
+	if got, want := resp.StatusCode, http.StatusNotFound; got != want {
+		t.Errorf("resp.StatusCode = %d; want %d", got, want)
+		t.Logf("%s", buf)
+		return
+	}
+
+	var msg spb.Status
+	if err := jsonpb.UnmarshalString(string(buf), &msg); err != nil {
+		t.Errorf("jsonpb.UnmarshalString(%s, &msg) failed with %v; want success", buf, err)
+		return
+	}
+
+	if got, want := msg.Code, int32(codes.NotFound); got != want {
+		t.Errorf("msg.Code = %d; want %d", got, want)
+		return
+	}
+
+	if got, want := msg.Message, "not found"; got != want {
+		t.Errorf("msg.Message = %s; want %s", got, want)
+		return
+	}
+
+	if got, want := resp.Header.Get("Grpc-Metadata-Uuid"), uuid; got != want {
+		t.Errorf("Grpc-Metadata-Uuid was %s, wanted %s", got, want)
+	}
+	if got, want := resp.Trailer.Get("Grpc-Trailer-Foo"), "foo2"; got != want {
+		t.Errorf("Grpc-Trailer-Foo was %q, wanted %q", got, want)
+	}
+	if got, want := resp.Trailer.Get("Grpc-Trailer-Bar"), "bar2"; got != want {
+		t.Errorf("Grpc-Trailer-Bar was %q, wanted %q", got, want)
+	}
+}
+
+func TestUnknownPathWithProtoError(t *testing.T) {
+	url := "http://localhost:8082"
+	resp, err := http.Post(url, "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Errorf("http.Post(%q) failed with %v; want success", url, err)
+		return
+	}
+	defer resp.Body.Close()
+	buf, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("iotuil.ReadAll(resp.Body) failed with %v; want success", err)
+		return
+	}
+
+	if got, want := resp.StatusCode, http.StatusNotImplemented; got != want {
+		t.Errorf("resp.StatusCode = %d; want %d", got, want)
+		t.Logf("%s", buf)
+	}
+
+	var msg spb.Status
+	if err := jsonpb.UnmarshalString(string(buf), &msg); err != nil {
+		t.Errorf("jsonpb.UnmarshalString(%s, &msg) failed with %v; want success", buf, err)
+		return
+	}
+
+	if got, want := msg.Code, int32(codes.Unimplemented); got != want {
+		t.Errorf("msg.Code = %d; want %d", got, want)
+		return
+	}
+
+	if msg.Message == "" {
+		t.Errorf("msg.Message should not be empty")
+		return
+	}
+}
+
+func TestMethodNotAllowedWithProtoError(t *testing.T) {
+	url := "http://localhost:8082/v1/example/echo/myid"
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Errorf("http.Post(%q) failed with %v; want success", url, err)
+		return
+	}
+	defer resp.Body.Close()
+	buf, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("iotuil.ReadAll(resp.Body) failed with %v; want success", err)
+		return
+	}
+
+	if got, want := resp.StatusCode, http.StatusNotImplemented; got != want {
+		t.Errorf("resp.StatusCode = %d; want %d", got, want)
+		t.Logf("%s", buf)
+	}
+
+	var msg spb.Status
+	if err := jsonpb.UnmarshalString(string(buf), &msg); err != nil {
+		t.Errorf("jsonpb.UnmarshalString(%s, &msg) failed with %v; want success", buf, err)
+		return
+	}
+
+	if got, want := msg.Code, int32(codes.Unimplemented); got != want {
+		t.Errorf("msg.Code = %d; want %d", got, want)
+		return
+	}
+
+	if msg.Message == "" {
+		t.Errorf("msg.Message should not be empty")
+		return
+	}
+}

--- a/examples/server/a_bit_of_everything.go
+++ b/examples/server/a_bit_of_everything.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // Implements of ABitOfEverythingServiceServer
@@ -112,7 +113,7 @@ func (s *_ABitOfEverythingServer) Lookup(ctx context.Context, msg *sub2.IdMessag
 		"foo": "foo2",
 		"bar": "bar2",
 	}))
-	return nil, grpc.Errorf(codes.NotFound, "not found")
+	return nil, status.Errorf(codes.NotFound, "not found")
 }
 
 func (s *_ABitOfEverythingServer) List(_ *empty.Empty, stream examples.StreamService_ListServer) error {
@@ -139,7 +140,7 @@ func (s *_ABitOfEverythingServer) List(_ *empty.Empty, stream examples.StreamSer
 				"foo": "foo2",
 				"bar": "bar2",
 			}))
-			return grpc.Errorf(codes.InvalidArgument, "error metadata: %v", v)
+			return status.Errorf(codes.InvalidArgument, "error metadata: %v", v)
 		}
 	}
 	return nil
@@ -153,7 +154,7 @@ func (s *_ABitOfEverythingServer) Update(ctx context.Context, msg *examples.ABit
 	if _, ok := s.v[msg.Uuid]; ok {
 		s.v[msg.Uuid] = msg
 	} else {
-		return nil, grpc.Errorf(codes.NotFound, "not found")
+		return nil, status.Errorf(codes.NotFound, "not found")
 	}
 	return new(empty.Empty), nil
 }
@@ -166,7 +167,7 @@ func (s *_ABitOfEverythingServer) Delete(ctx context.Context, msg *sub2.IdMessag
 	if _, ok := s.v[msg.Uuid]; ok {
 		delete(s.v, msg.Uuid)
 	} else {
-		return nil, grpc.Errorf(codes.NotFound, "not found")
+		return nil, status.Errorf(codes.NotFound, "not found")
 	}
 	return new(empty.Empty), nil
 }
@@ -179,7 +180,7 @@ func (s *_ABitOfEverythingServer) GetQuery(ctx context.Context, msg *examples.AB
 	if _, ok := s.v[msg.Uuid]; ok {
 		s.v[msg.Uuid] = msg
 	} else {
-		return nil, grpc.Errorf(codes.NotFound, "not found")
+		return nil, status.Errorf(codes.NotFound, "not found")
 	}
 	return new(empty.Empty), nil
 }

--- a/protoc-gen-grpc-gateway/gengateway/generator.go
+++ b/protoc-gen-grpc-gateway/gengateway/generator.go
@@ -39,6 +39,7 @@ func New(reg *descriptor.Registry, useRequestContext bool) gen.Generator {
 		"google.golang.org/grpc",
 		"google.golang.org/grpc/codes",
 		"google.golang.org/grpc/grpclog",
+		"google.golang.org/grpc/status",
 	} {
 		pkg := descriptor.GoPackage{
 			Path: pkgpath,

--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -167,7 +167,7 @@ func request_{{.Method.Service.GetName}}_{{.Method.GetName}}_{{.Index}}(ctx cont
 		}
 		if err != nil {
 			grpclog.Printf("Failed to decode request: %v", err)
-			return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+			return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
 			grpclog.Printf("Failed to send request: %v", err)
@@ -206,7 +206,7 @@ var (
 	var metadata runtime.ServerMetadata
 {{if .Body}}
 	if err := marshaler.NewDecoder(req.Body).Decode(&{{.Body.RHS "protoReq"}}); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 {{end}}
 {{if .PathParams}}
@@ -219,7 +219,7 @@ var (
 	{{range $param := .PathParams}}
 	val, ok = pathParams[{{$param | printf "%q"}}]
 	if !ok {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", {{$param | printf "%q"}})
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", {{$param | printf "%q"}})
 	}
 {{if $param.IsNestedProto3 }}
 	err = runtime.PopulateFieldFromPath(&protoReq, {{$param | printf "%q"}}, val)
@@ -233,7 +233,7 @@ var (
 {{end}}
 {{if .HasQueryParam}}
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_{{.Method.Service.GetName}}_{{.Method.GetName}}_{{.Index}}); err != nil {
-		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 {{end}}
 {{if .Method.GetServerStreaming}}

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -9,10 +9,10 @@ import (
 	"time"
 
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // MetadataHeaderPrefix is the http prefix that represents custom metadata
@@ -51,7 +51,7 @@ func AnnotateContext(ctx context.Context, mux *ServeMux, req *http.Request) (con
 		var err error
 		timeout, err = timeoutDecode(tm)
 		if err != nil {
-			return nil, grpc.Errorf(codes.InvalidArgument, "invalid grpc-timeout: %s", tm)
+			return nil, status.Errorf(codes.InvalidArgument, "invalid grpc-timeout: %s", tm)
 		}
 	}
 

--- a/runtime/errors_test.go
+++ b/runtime/errors_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestDefaultHTTPError(t *testing.T) {
@@ -28,7 +28,7 @@ func TestDefaultHTTPError(t *testing.T) {
 			msg:    "example error",
 		},
 		{
-			err:    grpc.Errorf(codes.NotFound, "no such resource"),
+			err:    status.Error(codes.NotFound, "no such resource"),
 			status: http.StatusNotFound,
 			msg:    "no such resource",
 		},
@@ -49,6 +49,7 @@ func TestDefaultHTTPError(t *testing.T) {
 			t.Errorf("json.Unmarshal(%q, &body) failed with %v; want success", w.Body.Bytes(), err)
 			continue
 		}
+
 		if got, want := body["error"].(string), spec.msg; !strings.Contains(got, want) {
 			t.Errorf(`body["error"] = %q; want %q; on spec.err=%v`, got, want, spec.err)
 		}

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -9,8 +9,9 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime/internal"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/status"
 )
 
 // ForwardResponseStream forwards the stream from gRPC server to REST client.
@@ -152,7 +153,10 @@ func handleForwardResponseStreamError(marshaler Marshaler, w http.ResponseWriter
 
 func streamChunk(result proto.Message, err error) map[string]proto.Message {
 	if err != nil {
-		grpcCode := grpc.Code(err)
+		grpcCode := codes.Unknown
+		if s, ok := status.FromError(err); ok {
+			grpcCode = s.Code()
+		}
 		httpCode := HTTPStatusFromCode(grpcCode)
 		return map[string]proto.Message{
 			"error": &internal.StreamError{

--- a/runtime/proto_errors.go
+++ b/runtime/proto_errors.go
@@ -1,0 +1,61 @@
+package runtime
+
+import (
+	"io"
+	"net/http"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/status"
+)
+
+// ProtoErrorHandlerFunc handles the error as a gRPC error generated via status package and replies to the request.
+type ProtoErrorHandlerFunc func(context.Context, *ServeMux, Marshaler, http.ResponseWriter, *http.Request, error)
+
+var _ ProtoErrorHandlerFunc = DefaultHTTPProtoErrorHandler
+
+// DefaultHTTPProtoErrorHandler is an implementation of HTTPError.
+// If "err" is an error from gRPC system, the function replies with the status code mapped by HTTPStatusFromCode.
+// If otherwise, it replies with http.StatusInternalServerError.
+//
+// The response body returned by this function is a Status message marshaled by a Marshaler.
+//
+// Do not set this function to HTTPError variable directly, use WithProtoErrorHandler option instead.
+func DefaultHTTPProtoErrorHandler(ctx context.Context, mux *ServeMux, marshaler Marshaler, w http.ResponseWriter, _ *http.Request, err error) {
+	// return Internal when Marshal failed
+	const fallback = `{"code": 13, "message": "failed to marshal error message"}`
+
+	w.Header().Del("Trailer")
+	w.Header().Set("Content-Type", marshaler.ContentType())
+
+	s, ok := status.FromError(err)
+	if !ok {
+		s = status.New(codes.Unknown, err.Error())
+	}
+
+	buf, merr := marshaler.Marshal(s.Proto())
+	if merr != nil {
+		grpclog.Printf("Failed to marshal error message %q: %v", s.Proto(), merr)
+		w.WriteHeader(http.StatusInternalServerError)
+		if _, err := io.WriteString(w, fallback); err != nil {
+			grpclog.Printf("Failed to write response: %v", err)
+		}
+		return
+	}
+
+	md, ok := ServerMetadataFromContext(ctx)
+	if !ok {
+		grpclog.Printf("Failed to extract ServerMetadata from context")
+	}
+
+	handleForwardResponseServerMetadata(w, mux, md)
+	handleForwardResponseTrailerHeader(w, md)
+	st := HTTPStatusFromCode(s.Code())
+	w.WriteHeader(st)
+	if _, err := w.Write(buf); err != nil {
+		grpclog.Printf("Failed to write response: %v", err)
+	}
+
+	handleForwardResponseTrailer(w, md)
+}


### PR DESCRIPTION
grpc-go introduced status package to handle errors with concrete types instead of interface and obsoleted some functions like grpc.Errorf.

First, this PR changed code to use status package. This will require grpc-go v1.3+
And, add `WithProtoErrorHandler` option and `ProtoErrorHandlerFunc` for handle errors as `Status` message in grpc-gateway instead of original error type a.k.a `errorBody`.
This also unifies errors returned by gRPC server and errors happened inside grpc-gateway, which helps error handling in client.

I think discussion required for response status of errors inside grpc-gateway and how to handle errors for streaming.
If needed, I will separate this PR into two PRs.
