### PR TITLE
Reference import grpc Status to suppress unused errors.

### DIFF
--- a/examples/examplepb/a_bit_of_everything.pb.gw.go
+++ b/examples/examplepb/a_bit_of_everything.pb.gw.go
@@ -28,6 +28,7 @@ import (
 
 var _ codes.Code
 var _ io.Reader
+var _ status.Status
 var _ = runtime.String
 var _ = utilities.NewDoubleArray
 

--- a/examples/examplepb/echo_service.pb.gw.go
+++ b/examples/examplepb/echo_service.pb.gw.go
@@ -25,6 +25,7 @@ import (
 
 var _ codes.Code
 var _ io.Reader
+var _ status.Status
 var _ = runtime.String
 var _ = utilities.NewDoubleArray
 

--- a/examples/examplepb/flow_combination.pb.gw.go
+++ b/examples/examplepb/flow_combination.pb.gw.go
@@ -25,6 +25,7 @@ import (
 
 var _ codes.Code
 var _ io.Reader
+var _ status.Status
 var _ = runtime.String
 var _ = utilities.NewDoubleArray
 

--- a/examples/examplepb/stream.pb.gw.go
+++ b/examples/examplepb/stream.pb.gw.go
@@ -27,6 +27,7 @@ import (
 
 var _ codes.Code
 var _ io.Reader
+var _ status.Status
 var _ = runtime.String
 var _ = utilities.NewDoubleArray
 

--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -129,6 +129,7 @@ import (
 
 var _ codes.Code
 var _ io.Reader
+var _ status.Status
 var _ = runtime.String
 var _ = utilities.NewDoubleArray
 `))


### PR DESCRIPTION
Here is an example proto file that resulted in unused errors:

```
syntax = "proto3";

package appscode.ci.v1beta1;

option go_package = "v1beta1";

import "google/api/annotations.proto";
import "appscode/api/annotations.proto";

service Metadata {
  rpc ServerInfo(dtypes.VoidRequest) returns (ServerInfoResponse) {
    option (google.api.http) = {
      get : "/ci/v1beta1/metadata/server-info/json"
    };
  }
}

message ServerInfoResponse {
  string provider = 1;
  string server_url = 2;
  string ca_cert = 3;
}
```