### PR TITLE
Use go_package option if found.

### DIFF
--- a/protoc-gen-grpc-gateway/gengateway/generator.go
+++ b/protoc-gen-grpc-gateway/gengateway/generator.go
@@ -77,7 +77,7 @@ func (g *generator) Generate(targets []*descriptor.File) ([]*plugin.CodeGenerato
 			glog.Errorf("%v: %s", err, code)
 			return nil, err
 		}
-		name := file.GetName()
+		name := file.GoPkg.Path
 		ext := filepath.Ext(name)
 		base := strings.TrimSuffix(name, ext)
 		output := fmt.Sprintf("%s.pb.gw.go", base)


### PR DESCRIPTION
Currently, `protoc-gen-grpc-gateway` does not respect the `go_package` option for output path. 

Check if a `go_package` option was specified and use that as the base output path.