### PR TITLE
Memoise calls to fullyQualifiedNameToSwaggerName to speed it up for large registries

### DIFF
--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -758,7 +758,8 @@ func TestResolveFullyQualifiedNameToSwaggerName(t *testing.T) {
 	}
 
 	for _, data := range tests {
-		output := resolveFullyQualifiedNameToSwaggerName(data.input, data.listOfFQMNs)
+		names := resolveFullyQualifiedNameToSwaggerNames(data.listOfFQMNs)
+		output := names[data.input]
 		if output != data.output {
 			t.Errorf("Expected fullyQualifiedNameToSwaggerName(%v) to be %s but got %s",
 				data.input, data.output, output)


### PR DESCRIPTION
We're observing some very slow compile times (on the order of ~1 minute) for reasonably large protos, containing hundreds of messages or so.

This implements a very simple cache of calls to determine Swagger names inside `fullyQualifiedNameToSwaggerName` which appears to be taking most of the time; after this change compilation time is well under 1 second.