### PR TITLE
Add Handler method to pass in client

### DIFF
--- a/examples/examplepb/a_bit_of_everything.pb.gw.go
+++ b/examples/examplepb/a_bit_of_everything.pb.gw.go
@@ -478,7 +478,15 @@ func RegisterABitOfEverythingServiceHandlerFromEndpoint(ctx context.Context, mux
 // RegisterABitOfEverythingServiceHandler registers the http handlers for service ABitOfEverythingService to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
 func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
-	client := NewABitOfEverythingServiceClient(conn)
+	return RegisterABitOfEverythingServiceHandlerClient(ctx, mux, NewABitOfEverythingServiceClient(conn))
+}
+
+// RegisterABitOfEverythingServiceHandler registers the http handlers for service ABitOfEverythingService to "mux".
+// The handlers forward requests to the grpc endpoint over the given implementation of "ABitOfEverythingServiceClient".
+// Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "ABitOfEverythingServiceClient"
+// doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
+// "ABitOfEverythingServiceClient" to call the correct interceptors.
+func RegisterABitOfEverythingServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux, client ABitOfEverythingServiceClient) error {
 
 	mux.Handle("POST", pattern_ABitOfEverythingService_Create_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)

--- a/examples/examplepb/echo_service.pb.gw.go
+++ b/examples/examplepb/echo_service.pb.gw.go
@@ -142,7 +142,15 @@ func RegisterEchoServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.Se
 // RegisterEchoServiceHandler registers the http handlers for service EchoService to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
 func RegisterEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
-	client := NewEchoServiceClient(conn)
+	return RegisterEchoServiceHandlerClient(ctx, mux, NewEchoServiceClient(conn))
+}
+
+// RegisterEchoServiceHandler registers the http handlers for service EchoService to "mux".
+// The handlers forward requests to the grpc endpoint over the given implementation of "EchoServiceClient".
+// Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "EchoServiceClient"
+// doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
+// "EchoServiceClient" to call the correct interceptors.
+func RegisterEchoServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux, client EchoServiceClient) error {
 
 	mux.Handle("POST", pattern_EchoService_Echo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)

--- a/examples/examplepb/flow_combination.pb.gw.go
+++ b/examples/examplepb/flow_combination.pb.gw.go
@@ -1013,7 +1013,15 @@ func RegisterFlowCombinationHandlerFromEndpoint(ctx context.Context, mux *runtim
 // RegisterFlowCombinationHandler registers the http handlers for service FlowCombination to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
 func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
-	client := NewFlowCombinationClient(conn)
+	return RegisterFlowCombinationHandlerClient(ctx, mux, NewFlowCombinationClient(conn))
+}
+
+// RegisterFlowCombinationHandler registers the http handlers for service FlowCombination to "mux".
+// The handlers forward requests to the grpc endpoint over the given implementation of "FlowCombinationClient".
+// Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "FlowCombinationClient"
+// doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
+// "FlowCombinationClient" to call the correct interceptors.
+func RegisterFlowCombinationHandlerClient(ctx context.Context, mux *runtime.ServeMux, client FlowCombinationClient) error {
 
 	mux.Handle("POST", pattern_FlowCombination_RpcEmptyRpc_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)

--- a/examples/examplepb/stream.pb.gw.go
+++ b/examples/examplepb/stream.pb.gw.go
@@ -168,7 +168,15 @@ func RegisterStreamServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.
 // RegisterStreamServiceHandler registers the http handlers for service StreamService to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
 func RegisterStreamServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
-	client := NewStreamServiceClient(conn)
+	return RegisterStreamServiceHandlerClient(ctx, mux, NewStreamServiceClient(conn))
+}
+
+// RegisterStreamServiceHandler registers the http handlers for service StreamService to "mux".
+// The handlers forward requests to the grpc endpoint over the given implementation of "StreamServiceClient".
+// Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "StreamServiceClient"
+// doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
+// "StreamServiceClient" to call the correct interceptors.
+func RegisterStreamServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux, client StreamServiceClient) error {
 
 	mux.Handle("POST", pattern_StreamService_BulkCreate_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)

--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -338,7 +338,15 @@ func Register{{$svc.GetName}}HandlerFromEndpoint(ctx context.Context, mux *runti
 // Register{{$svc.GetName}}Handler registers the http handlers for service {{$svc.GetName}} to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
 func Register{{$svc.GetName}}Handler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
-	client := New{{$svc.GetName}}Client(conn)
+	return Register{{$svc.GetName}}HandlerClient(ctx, mux, New{{$svc.GetName}}Client(conn))
+}
+
+// Register{{$svc.GetName}}Handler registers the http handlers for service {{$svc.GetName}} to "mux".
+// The handlers forward requests to the grpc endpoint over the given implementation of "{{$svc.GetName}}Client".
+// Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "{{$svc.GetName}}Client"
+// doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
+// "{{$svc.GetName}}Client" to call the correct interceptors.
+func Register{{$svc.GetName}}HandlerClient(ctx context.Context, mux *runtime.ServeMux, client {{$svc.GetName}}Client) error {
 	{{range $m := $svc.Methods}}
 	{{range $b := $m.Bindings}}
 	mux.Handle({{$b.HTTPMethod | printf "%q"}}, pattern_{{$svc.GetName}}_{{$m.GetName}}_{{$b.Index}}, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {


### PR DESCRIPTION
Right now if you want to embed the JSON proxy into your service you end
up having to have a client talking to loopback which is messy. With this
API addition you can simply pass in something which implements the
client interface -- meaning you could wrap it yourself and return
directly (without all the loopback and serialization overhead).