### PR TITLE
runtime: use r.Context()

### DIFF
--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -146,8 +146,7 @@ func (s *ServeMux) Handle(meth string, pat Pattern, h HandlerFunc) {
 
 // ServeHTTP dispatches the request to the first handler whose pattern matches to r.Method and r.Path.
 func (s *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// TODO: use r.Context for go 1.7+
-	ctx := context.Background()
+	ctx := r.Context()
 
 	path := r.URL.Path
 	if !strings.HasPrefix(path, "/") {


### PR DESCRIPTION
Looks like we're only using 1.7+ (judging [from travis](https://github.com/grpc-ecosystem/grpc-gateway/blob/c323909dd41de182a54b4d1610f26034da5e097e/.travis.yml#L3-L7)) -- so, let's squash that TODO, shall we? 😉 