### PR TITLE
Use golang/protobuf instead of gogo/protobuf

### DIFF
--- a/runtime/convert.go
+++ b/runtime/convert.go
@@ -3,7 +3,7 @@ package runtime
 import (
 	"strconv"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/timestamp"
 )


### PR DESCRIPTION
It seems gogo protobuf is mistakenly(?) used.