### PR TITLE
Fix gen-swagger to support more well known types

### DIFF
--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -25,6 +25,29 @@ var wktSchemas = map[string]schemaCore{
 	".google.protobuf.Duration": schemaCore{
 		Type: "string",
 	},
+	".google.protobuf.StringValue": schemaCore{
+		Type: "string",
+	},
+	".google.protobuf.Int32Value": schemaCore{
+		Type:   "integer",
+		Format: "int32",
+	},
+	".google.protobuf.Int64Value": schemaCore{
+		Type:   "integer",
+		Format: "int64",
+	},
+	".google.protobuf.FloatValue": schemaCore{
+		Type:   "number",
+		Format: "float",
+	},
+	".google.protobuf.DoubleValue": schemaCore{
+		Type:   "number",
+		Format: "double",
+	},
+	".google.protobuf.BoolValue": schemaCore{
+		Type:   "boolean",
+		Format: "boolean",
+	},
 }
 
 func listEnumNames(enum *descriptor.Enum) (names []string) {

--- a/protoc-gen-swagger/genswagger/types.go
+++ b/protoc-gen-swagger/genswagger/types.go
@@ -122,6 +122,13 @@ type schemaCore struct {
 
 type swaggerItemsObject schemaCore
 
+func (o *swaggerItemsObject) getType() string {
+	if o == nil {
+		return ""
+	}
+	return o.Type
+}
+
 // http://swagger.io/specification/#responsesObject
 type swaggerResponsesObject map[string]swaggerResponseObject
 


### PR DESCRIPTION
Some well know types are not handled correctly. Given we have the following proto message.

```
// proto
message User {
  google.protobuf.StringValue name = 1;
}
```

`name` is output as an object.

```
// swagger.json
"name": {
  "$ref": "#/definitions/protobufStringValue"
}
```

It should be output as a primitive.

```
// swagger.json
"name": {
  "type": "string"
}
```

This PR adds support for the following well know types.

- StringValue
- Int32Value
- Int64Value
- FloatValue
- DoubleValue
- BoolValue