### PR TITLE
adds opts.Tags to operationObject.Tags

### DIFF
--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -635,8 +635,13 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
 							operationObject.ExternalDocs.URL = opts.ExternalDocs.Url
 						}
 					}
+
 					// TODO(ivucica): this would be better supported by looking whether the method is deprecated in the proto file
 					operationObject.Deprecated = opts.Deprecated
+
+					if opts.Tags != nil {
+						operationObject.Tags = opts.Tags
+					}
 
 					// TODO(ivucica): add remaining fields of operation object
 				}


### PR DESCRIPTION
this is a continuation of work in #145, which left as a TODO to check
remaining options fields for the operationObject during swagger generation.
This PR causes protoc-gen-swagger to check if opts.Tags exists and
overwrite the default value if it does exist.