### PR TITLE
Add description, summary and tags fields in operationObject (swagger)

### DIFF
--- a/examples/examplepb/a_bit_of_everything.proto
+++ b/examples/examplepb/a_bit_of_everything.proto
@@ -187,6 +187,7 @@ service ABitOfEverythingService {
 		};
 		option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
             description: "Description Echo";
+            summary: "Summary: Echo rpc";
 			external_docs: {
 				url: "https://github.com/grpc-ecosystem/grpc-gateway";
 				description: "Find out more Echo";

--- a/examples/examplepb/a_bit_of_everything.proto
+++ b/examples/examplepb/a_bit_of_everything.proto
@@ -188,6 +188,8 @@ service ABitOfEverythingService {
 		option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
             description: "Description Echo";
             summary: "Summary: Echo rpc";
+            tags: "echo service";
+            tags: "echo rpc";
 			external_docs: {
 				url: "https://github.com/grpc-ecosystem/grpc-gateway";
 				description: "Find out more Echo";

--- a/examples/examplepb/a_bit_of_everything.proto
+++ b/examples/examplepb/a_bit_of_everything.proto
@@ -186,10 +186,10 @@ service ABitOfEverythingService {
 			}
 		};
 		option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
-            description: "Description Echo";
-            summary: "Summary: Echo rpc";
-            tags: "echo service";
-            tags: "echo rpc";
+			description: "Description Echo";
+			summary: "Summary: Echo rpc";
+			tags: "echo service";
+			tags: "echo rpc";
 			external_docs: {
 				url: "https://github.com/grpc-ecosystem/grpc-gateway";
 				description: "Find out more Echo";

--- a/examples/examplepb/a_bit_of_everything.proto
+++ b/examples/examplepb/a_bit_of_everything.proto
@@ -186,6 +186,7 @@ service ABitOfEverythingService {
 			}
 		};
 		option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+            description: "Description Echo";
 			external_docs: {
 				url: "https://github.com/grpc-ecosystem/grpc-gateway";
 				description: "Find out more Echo";

--- a/examples/examplepb/a_bit_of_everything.swagger.json
+++ b/examples/examplepb/a_bit_of_everything.swagger.json
@@ -51,8 +51,8 @@
     },
     "/v1/example/a_bit_of_everything/echo/{value}": {
       "get": {
-        "summary": "Echo allows posting a StringMessage value.",
-        "description": "It also exposes multiple bindings.\n\nThis makes it useful when validating that the OpenAPI v2 API\ndescription exposes documentation correctly on all paths\ndefined as additional_bindings in the proto.",
+        "summary": "Summary: Echo rpc",
+        "description": "Description Echo",
         "operationId": "Echo",
         "responses": {
           "200": {
@@ -71,7 +71,8 @@
           }
         ],
         "tags": [
-          "ABitOfEverythingService"
+          "echo service",
+          "echo rpc"
         ],
         "externalDocs": {
           "description": "Find out more Echo",
@@ -523,8 +524,8 @@
     },
     "/v2/example/echo": {
       "get": {
-        "summary": "Echo allows posting a StringMessage value.",
-        "description": "It also exposes multiple bindings.\n\nThis makes it useful when validating that the OpenAPI v2 API\ndescription exposes documentation correctly on all paths\ndefined as additional_bindings in the proto.",
+        "summary": "Summary: Echo rpc",
+        "description": "Description Echo",
         "operationId": "Echo3",
         "responses": {
           "200": {
@@ -543,7 +544,8 @@
           }
         ],
         "tags": [
-          "ABitOfEverythingService"
+          "echo service",
+          "echo rpc"
         ],
         "externalDocs": {
           "description": "Find out more Echo",
@@ -551,8 +553,8 @@
         }
       },
       "post": {
-        "summary": "Echo allows posting a StringMessage value.",
-        "description": "It also exposes multiple bindings.\n\nThis makes it useful when validating that the OpenAPI v2 API\ndescription exposes documentation correctly on all paths\ndefined as additional_bindings in the proto.",
+        "summary": "Summary: Echo rpc",
+        "description": "Description Echo",
         "operationId": "Echo2",
         "responses": {
           "200": {
@@ -573,7 +575,8 @@
           }
         ],
         "tags": [
-          "ABitOfEverythingService"
+          "echo service",
+          "echo rpc"
         ],
         "externalDocs": {
           "description": "Find out more Echo",

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -644,6 +644,10 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
                     if opts.Description != "" {
                         operationObject.Description = opts.Description
                     }
+                    if len(opts.Tags) > 0 {
+                        operationObject.Tags = make([]string, len(opts.Tags))
+                        copy(operationObject.Tags, opts.Tags)
+                    }
 
 					// TODO(ivucica): add remaining fields of operation object
 				}

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -638,6 +638,10 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
 					// TODO(ivucica): this would be better supported by looking whether the method is deprecated in the proto file
 					operationObject.Deprecated = opts.Deprecated
 
+                    if opts.Summary != "" {
+                        operationObject.Summary = opts.Summary
+                    }
+
 					// TODO(ivucica): add remaining fields of operation object
 				}
 

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -641,6 +641,9 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
                     if opts.Summary != "" {
                         operationObject.Summary = opts.Summary
                     }
+                    if opts.Description != "" {
+                        operationObject.Description = opts.Description
+                    }
 
 					// TODO(ivucica): add remaining fields of operation object
 				}

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -638,16 +638,16 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
 					// TODO(ivucica): this would be better supported by looking whether the method is deprecated in the proto file
 					operationObject.Deprecated = opts.Deprecated
 
-                    if opts.Summary != "" {
-                        operationObject.Summary = opts.Summary
-                    }
-                    if opts.Description != "" {
-                        operationObject.Description = opts.Description
-                    }
-                    if len(opts.Tags) > 0 {
-                        operationObject.Tags = make([]string, len(opts.Tags))
-                        copy(operationObject.Tags, opts.Tags)
-                    }
+					if opts.Summary != "" {
+						operationObject.Summary = opts.Summary
+					}
+					if opts.Description != "" {
+						operationObject.Description = opts.Description
+					}
+					if len(opts.Tags) > 0 {
+						operationObject.Tags = make([]string, len(opts.Tags))
+						copy(operationObject.Tags, opts.Tags)
+					}
 
 					// TODO(ivucica): add remaining fields of operation object
 				}


### PR DESCRIPTION
Hello all,

Small PR to add `description`, `summary` and `tags` fields in [operationObject](https://swagger.io/specification/#operationObject) (swagger -- #145). `Tags` field was already fixed by @thurt in https://github.com/grpc-ecosystem/grpc-gateway/pull/524 but not merge (yet).

Devnull-