### PR TITLE
runtime: support FieldMask as query param

### DIFF
--- a/runtime/query_test.go
+++ b/runtime/query_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"
+	"google.golang.org/genproto/protobuf/field_mask"
 )
 
 func TestPopulateParameters(t *testing.T) {
@@ -24,6 +25,9 @@ func TestPopulateParameters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't setup timestamp in Protobuf format: %v", err)
 	}
+
+	fieldmaskStr := "float_value,double_value"
+	fieldmaskPb := &field_mask.FieldMask{[]string{"float_value", "double_value"}}
 
 	for _, spec := range []struct {
 		values  url.Values
@@ -46,6 +50,7 @@ func TestPopulateParameters(t *testing.T) {
 				"enum_value":            {"1"},
 				"repeated_enum":         {"1", "2", "0"},
 				"timestamp_value":       {timeStr},
+				"fieldmask_value":       {fieldmaskStr},
 				"wrapper_float_value":   {"1.5"},
 				"wrapper_double_value":  {"2.5"},
 				"wrapper_int64_value":   {"-1"},
@@ -71,6 +76,7 @@ func TestPopulateParameters(t *testing.T) {
 				EnumValue:          EnumValue_Y,
 				RepeatedEnum:       []EnumValue{EnumValue_Y, EnumValue_Z, EnumValue_X},
 				TimestampValue:     timePb,
+				FieldMaskValue:     fieldmaskPb,
 				WrapperFloatValue:  &wrappers.FloatValue{1.5},
 				WrapperDoubleValue: &wrappers.DoubleValue{2.5},
 				WrapperInt64Value:  &wrappers.Int64Value{-1},
@@ -97,6 +103,7 @@ func TestPopulateParameters(t *testing.T) {
 				"enumValue":          {"1"},
 				"repeatedEnum":       {"1", "2", "0"},
 				"timestampValue":     {timeStr},
+				"fieldmaskValue":     {fieldmaskStr},
 				"wrapperFloatValue":  {"1.5"},
 				"wrapperDoubleValue": {"2.5"},
 				"wrapperInt64Value":  {"-1"},
@@ -122,6 +129,7 @@ func TestPopulateParameters(t *testing.T) {
 				EnumValue:          EnumValue_Y,
 				RepeatedEnum:       []EnumValue{EnumValue_Y, EnumValue_Z, EnumValue_X},
 				TimestampValue:     timePb,
+				FieldMaskValue:     fieldmaskPb,
 				WrapperFloatValue:  &wrappers.FloatValue{1.5},
 				WrapperDoubleValue: &wrappers.DoubleValue{2.5},
 				WrapperInt64Value:  &wrappers.Int64Value{-1},
@@ -484,6 +492,7 @@ type proto3Message struct {
 	EnumValue          EnumValue                `protobuf:"varint,11,opt,name=enum_value,json=enumValue,enum=runtime_test_api.EnumValue" json:"enum_value,omitempty"`
 	RepeatedEnum       []EnumValue              `protobuf:"varint,12,rep,packed,name=repeated_enum,json=repeatedEnum,enum=runtime_test_api.EnumValue" json:"repeated_enum,omitempty"`
 	TimestampValue     *timestamp.Timestamp     `protobuf:"bytes,16,opt,name=timestamp_value,json=timestampValue" json:"timestamp_value,omitempty"`
+	FieldMaskValue     *field_mask.FieldMask    `protobuf:"bytes,27,opt,name=fieldmask_value,json=fieldmaskValue" json:"fieldmask_value,omitempty"`
 	OneofValue         proto3Message_OneofValue `protobuf_oneof:"oneof_value"`
 	WrapperDoubleValue *wrappers.DoubleValue    `protobuf:"bytes,17,opt,name=wrapper_double_value,json=wrapperDoubleValue" json:"wrapper_double_value,omitempty"`
 	WrapperFloatValue  *wrappers.FloatValue     `protobuf:"bytes,18,opt,name=wrapper_float_value,json=wrapperFloatValue" json:"wrapper_float_value,omitempty"`


### PR DESCRIPTION
In order to support [`FieldMask`](https://developers.google.com/protocol-buffers/docs/reference/csharp/class/google/protobuf/well-known-types/field-mask) in query params, [as Google proposes](https://cloud.google.com/apis/design/standard_methods#update), this should be treated as another known type.

/cc @achew22 @tmc 

As a reference:
https://cloud.google.com/iam/reference/rest/v1/organizations.roles/patch
https://github.com/googleapis/googleapis/blob/f704d14a7224a140bca5cc26835fae471eaf7281/google/iam/admin/v1/iam.proto#L157
https://github.com/googleapis/googleapis/blob/f704d14a7224a140bca5cc26835fae471eaf7281/google/iam/admin/v1/iam.proto#L614-L626