### PR TITLE
Use importPath to set package name rather than package path.

### DIFF
--- a/protoc-gen-grpc-gateway/descriptor/registry.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry.go
@@ -301,12 +301,6 @@ func (r *Registry) defaultGoPackageName(f *descriptor.FileDescriptorProto) strin
 // protoc-gen-grpc-gateway rejects CodeGenerationRequests which contains more than one packages
 // as protoc-gen-go does.
 func (r *Registry) packageIdentityName(f *descriptor.FileDescriptorProto) string {
-	if p := r.importPath; len(p) != 0 {
-		if i := strings.LastIndex(p, "/"); i >= 0 {
-			p = p[i+1:]
-		}
-		return p
-	}
 	if f.Options != nil && f.Options.GoPackage != nil {
 		gopkg := f.Options.GetGoPackage()
 		idx := strings.LastIndex(gopkg, "/")
@@ -323,6 +317,12 @@ func (r *Registry) packageIdentityName(f *descriptor.FileDescriptorProto) string
 
 		}
 		return sanitizePackageName(gopkg[sc+1:])
+	}
+	if p := r.importPath; len(p) != 0 {
+		if i := strings.LastIndex(p, "/"); i >= 0 {
+			p = p[i+1:]
+		}
+		return p
 	}
 
 	if f.Package == nil {

--- a/protoc-gen-grpc-gateway/descriptor/registry.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry.go
@@ -61,7 +61,7 @@ func (r *Registry) Load(req *plugin.CodeGeneratorRequest) error {
 		if target == nil {
 			return fmt.Errorf("no such file: %s", name)
 		}
-		name := packageIdentityName(target.FileDescriptorProto)
+		name := r.packageIdentityName(target.FileDescriptorProto)
 		if targetPkg == "" {
 			targetPkg = name
 		} else {
@@ -83,7 +83,7 @@ func (r *Registry) Load(req *plugin.CodeGeneratorRequest) error {
 func (r *Registry) loadFile(file *descriptor.FileDescriptorProto) {
 	pkg := GoPackage{
 		Path: r.goPackagePath(file),
-		Name: defaultGoPackageName(file),
+		Name: r.defaultGoPackageName(file),
 	}
 	if err := r.ReserveGoPackageAlias(pkg.Name, pkg.Path); err != nil {
 		for i := 0; ; i++ {
@@ -247,9 +247,6 @@ func (r *Registry) goPackagePath(f *descriptor.FileDescriptorProto) string {
 	}
 
 	gopkg := f.Options.GetGoPackage()
-	if len(gopkg) == 0 {
-		gopkg = r.importPath
-	}
 	idx := strings.LastIndex(gopkg, "/")
 	if idx >= 0 {
 		if sc := strings.LastIndex(gopkg, ";"); sc > 0 {
@@ -295,15 +292,21 @@ func sanitizePackageName(pkgName string) string {
 
 // defaultGoPackageName returns the default go package name to be used for go files generated from "f".
 // You might need to use an unique alias for the package when you import it.  Use ReserveGoPackageAlias to get a unique alias.
-func defaultGoPackageName(f *descriptor.FileDescriptorProto) string {
-	name := packageIdentityName(f)
+func (r *Registry) defaultGoPackageName(f *descriptor.FileDescriptorProto) string {
+	name := r.packageIdentityName(f)
 	return sanitizePackageName(name)
 }
 
 // packageIdentityName returns the identity of packages.
 // protoc-gen-grpc-gateway rejects CodeGenerationRequests which contains more than one packages
 // as protoc-gen-go does.
-func packageIdentityName(f *descriptor.FileDescriptorProto) string {
+func (r *Registry) packageIdentityName(f *descriptor.FileDescriptorProto) string {
+	if p := r.importPath; len(p) != 0 {
+		if i := strings.LastIndex(p, "/"); i >= 0 {
+			p = p[i+1:]
+		}
+		return p
+	}
 	if f.Options != nil && f.Options.GoPackage != nil {
 		gopkg := f.Options.GetGoPackage()
 		idx := strings.LastIndex(gopkg, "/")

--- a/protoc-gen-grpc-gateway/descriptor/registry_test.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry_test.go
@@ -549,3 +549,40 @@ func TestLoadOverridedPackageName(t *testing.T) {
 		t.Errorf("file.GoPkg = %#v; want %#v", got, want)
 	}
 }
+
+func TestLoadSetInputPath(t *testing.T) {
+	reg := NewRegistry()
+	reg.SetImportPath("foo/examplepb")
+	loadFile(t, reg, `
+		name: 'example.proto'
+		package: 'example'
+	`)
+	file := reg.files["example.proto"]
+	if file == nil {
+		t.Errorf("reg.files[%q] = nil; want non-nil", "example.proto")
+		return
+	}
+	wantPkg := GoPackage{Path: ".", Name: "examplepb"}
+	if got, want := file.GoPkg, wantPkg; got != want {
+		t.Errorf("file.GoPkg = %#v; want %#v", got, want)
+	}
+}
+
+func TestLoadGoPackageInputPath(t *testing.T) {
+	reg := NewRegistry()
+	reg.SetImportPath("examplepb")
+	loadFile(t, reg, `
+		name: 'example.proto'
+		package: 'example'
+		options < go_package: 'example.com/xyz;pb' >
+	`)
+	file := reg.files["example.proto"]
+	if file == nil {
+		t.Errorf("reg.files[%q] = nil; want non-nil", "example.proto")
+		return
+	}
+	wantPkg := GoPackage{Path: "example.com/xyz", Name: "pb"}
+	if got, want := file.GoPkg, wantPkg; got != want {
+		t.Errorf("file.GoPkg = %#v; want %#v", got, want)
+	}
+}


### PR DESCRIPTION
In #536 @shynie correctly observes that the `import_path` flag was not implemented correctly in #507. Although it is called `import_path`, in `golang/protobuf` the flag is used to set the package identity name.

> import_path=foo/bar - used as the package if no input files declare go_package. If it contains slashes, everything up to the rightmost slash is ignored.

Currently it is used to set the package path:

https://github.com/grpc-ecosystem/grpc-gateway/blob/6658b3a4fd7017117532b54b5c6bf2fd2207ffc2/protoc-gen-grpc-gateway/descriptor/registry.go#L251

This PR moves the use of the `importPath` field to the `packageIdentityName` function.

Note that eventually the "Want to support" section of the README should be updated:

https://github.com/grpc-ecosystem/grpc-gateway/blob/6658b3a4fd7017117532b54b5c6bf2fd2207ffc2/README.md#want-to-support