### PR TITLE
Command line argument: import_forwarder.

### DIFF
--- a/protoc-gen-grpc-gateway/descriptor/registry_test.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry_test.go
@@ -549,3 +549,47 @@ func TestLoadOverridedPackageName(t *testing.T) {
 		t.Errorf("file.GoPkg = %#v; want %#v", got, want)
 	}
 }
+
+func TestSetForwardResponsePkg(t *testing.T) {
+	reg := NewRegistry()
+
+	// set absolute path
+	if err := reg.SetForwardResponsePkg("/root"); err == nil {
+		t.Error("reg.SetForwardResponsePkg(/absolute/path) - ok; absolute path cannot be used as a forward response package")
+	}
+
+	var value = "github.com/grpc-ecosystem/grpc-gateway/runtime"
+	// set standard package name
+	if err := reg.SetForwardResponsePkg(value); err != nil {
+		t.Error("reg.SetForwardResponsePkg - failed to set standard forward response package")
+	}
+	if reg.ForwardResponsePkg().Name != "runtime" {
+		t.Errorf("invalid  value reg.ForwardResponsePkg().Name = %q, expected %q", reg.ForwardResponsePkg().Name, "runtime")
+	}
+	if reg.ForwardResponsePkg().Path != value {
+		t.Errorf("invalid  value reg.ForwardResponsePkg().Path = %q, expected %q", reg.ForwardResponsePkg().Path, value)
+	}
+	if reg.ForwardResponsePkg().Alias != "" {
+		t.Errorf("invalid  value reg.ForwardResponsePkg().Alias = %q, expected %q", reg.ForwardResponsePkg().Alias, "")
+	}
+
+	// set external package name
+	value = "github.com/third-party-lib/runtime"
+	if err := reg.SetForwardResponsePkg(value); err != nil {
+		t.Error("reg.SetForwardResponsePkg - failed to set external forward response package")
+	}
+	if reg.ForwardResponsePkg().Name != "runtime" {
+		t.Errorf("invalid  value reg.ForwardResponsePkg().Name = %q, expected %q", reg.ForwardResponsePkg().Name, "runtime")
+	}
+	if reg.ForwardResponsePkg().Path != value {
+		t.Errorf("invalid  value reg.ForwardResponsePkg().Path = %q, expected %q", reg.ForwardResponsePkg().Path, value)
+	}
+	if reg.ForwardResponsePkg().Alias != "runtime_0" {
+		t.Errorf("invalid  value reg.ForwardResponsePkg().Alias = %q, expected %q", reg.ForwardResponsePkg().Alias, "runtime_0")
+	}
+
+	// set empty package
+	if err := reg.SetForwardResponsePkg(""); err != nil {
+		t.Error("reg.SetForwardResponsePkg- failed to set empty forward response package")
+	}
+}

--- a/protoc-gen-grpc-gateway/gengateway/generator_test.go
+++ b/protoc-gen-grpc-gateway/gengateway/generator_test.go
@@ -123,7 +123,7 @@ func TestGenerateOutputPath(t *testing.T) {
 		},
 	}
 
-	g := &generator{}
+	g := &generator{forwardResponsePkg: "runtime"}
 	for _, c := range cases {
 		file := c.file
 		gots, err := g.Generate([]*descriptor.File{crossLinkFixture(file)})
@@ -149,5 +149,32 @@ func TestGenerateOutputPath(t *testing.T) {
 			t.Errorf("Generate(%#v) failed; got path: %s expected path: %s", file, gotPath, expectedPath)
 			return
 		}
+	}
+}
+
+func TestForwadResponsePgk(t *testing.T) {
+	reg := descriptor.NewRegistry()
+
+	// custom name - forward response package is set
+	if err := reg.SetForwardResponsePkg("github.com/grpc-ecosystem/grpc-gateway/fw"); err != nil {
+		t.Errorf("failed to set ForwardResponsePkg: %s", err)
+	}
+
+	gen := New(reg, true)
+	g := gen.(*generator)
+	if g.forwardResponsePkg != "fw" {
+		t.Errorf("invalid forwardResponsePkg = %q, expected = %q", g.forwardResponsePkg, "fw")
+	}
+
+	reg = descriptor.NewRegistry()
+	if err := reg.SetForwardResponsePkg(""); err != nil {
+		t.Errorf("failed to set empty forwardResponsePkg: %s", err)
+	}
+
+	// default name - forward response package is not set
+	gen = New(reg, true)
+	g = gen.(*generator)
+	if g.forwardResponsePkg != "runtime" {
+		t.Errorf("invalid forwardResponsePkg = %q, expected = %q", g.forwardResponsePkg, "runtime")
 	}
 }

--- a/protoc-gen-grpc-gateway/gengateway/template_test.go
+++ b/protoc-gen-grpc-gateway/gengateway/template_test.go
@@ -222,7 +222,7 @@ func TestApplyTemplateRequestWithoutClientStreaming(t *testing.T) {
 				},
 			},
 		}
-		got, err := applyTemplate(param{File: crossLinkFixture(&file)})
+		got, err := applyTemplate(param{File: crossLinkFixture(&file), ForwardResponsePkg: "runtime"})
 		if err != nil {
 			t.Errorf("applyTemplate(%#v) failed with %v; want success", file, err)
 			return
@@ -244,6 +244,9 @@ func TestApplyTemplateRequestWithoutClientStreaming(t *testing.T) {
 		}
 		if want := `pattern_ExampleService_Echo_0 = runtime.MustPattern(runtime.NewPattern(1, []int{0, 0}, []string(nil), ""))`; !strings.Contains(got, want) {
 			t.Errorf("applyTemplate(%#v) = %s; want to contain %s", file, got, want)
+		}
+		if want := `forward_ExampleService_Echo_0 = runtime.ForwardResponse`; !strings.Contains(got, want) {
+			t.Errorf("applytTemplate(%#v) = %s; want to contain %s", file, got, want)
 		}
 	}
 }
@@ -383,7 +386,7 @@ func TestApplyTemplateRequestWithClientStreaming(t *testing.T) {
 				},
 			},
 		}
-		got, err := applyTemplate(param{File: crossLinkFixture(&file)})
+		got, err := applyTemplate(param{File: crossLinkFixture(&file), ForwardResponsePkg: "nonstandard"})
 		if err != nil {
 			t.Errorf("applyTemplate(%#v) failed with %v; want success", file, err)
 			return
@@ -399,6 +402,9 @@ func TestApplyTemplateRequestWithClientStreaming(t *testing.T) {
 		}
 		if want := `pattern_ExampleService_Echo_0 = runtime.MustPattern(runtime.NewPattern(1, []int{0, 0}, []string(nil), ""))`; !strings.Contains(got, want) {
 			t.Errorf("applyTemplate(%#v) = %s; want to contain %s", file, got, want)
+		}
+		if want := `forward_ExampleService_Echo_0 = nonstandard.ForwardResponse`; !strings.Contains(got, want) {
+			t.Errorf("applytTemplate(%#v) = %s; want to contain %s", file, got, want)
 		}
 	}
 }


### PR DESCRIPTION
When you want to provide consistency for all your applications that expose public REST API endpoints you need to put common `ForwardResponseMessage` and `ForwardResponseStream` in some place so that all your applications can import them and use as forwarders.

That is too boring and sometimes error-prone to overwrite default forwarders as described [here](https://github.com/grpc-ecosystem/grpc-gateway/wiki/How-to-customize-your-gateway#replace-a-response-forwarder-per-method).

This PR:
   - introduces new command line argument `import_forwarder` for `protoc-gen-grpc-gateway`
- `import_forwarder` indicates a package that contains implementations for ForwardResponseMessage and ForwardResponseStream
- during generation a package path provided by `import_forwarder` is used as an replacement of default `github.com/grpc-ecosystem/grpc-gateway/runtime` only for ForwardResponseMessage and ForwardResponseStream functions.
- if `import_forwarder` is not set `github.com/grpc-ecosystem/grpc-gateway/runtime` is used as usual.
