### PR TITLE
error details: add @type key by switching to any.Any

### DIFF
--- a/examples/integration_test.go
+++ b/examples/integration_test.go
@@ -761,6 +761,13 @@ func TestErrorWithDetails(t *testing.T) {
 	if got, want := ok, true; got != want {
 		t.Fatalf("msg.Details[0] got type: %T, want %T", msg.Details[0], map[string]interface{}{})
 	}
+	typ, ok := details["@type"].(string)
+	if got, want := ok, true; got != want {
+		t.Fatalf("msg.Details[0][\"@type\"] got type: %T, want %T", typ, "")
+	}
+	if got, want := details["@type"], "type.googleapis.com/google.rpc.DebugInfo"; got != want {
+		t.Errorf("msg.Details[\"@type\"] = %q; want %q", got, want)
+	}
 	if got, want := details["detail"], "error debug details"; got != want {
 		t.Errorf("msg.Details[\"detail\"] = %q; want %q", got, want)
 	}


### PR DESCRIPTION
This is arguably more correct than what was introduced in #515. So, any
error details no have a "@type" field indicating their underlying
proto.Message's type, following the Cloud API docs<sup>[1]</sup>.

[1]: https://cloud.google.com/apis/design/errors#http_mapping

Note that this does **not** help with #551. The error is still present.