### PR TITLE
fix noenc error by fixing Details error field

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -65,9 +65,9 @@ var (
 )
 
 type errorBody struct {
-	Error   string    `protobuf:"bytes,1,name=error" json:"error"`
-	Code    int32     `protobuf:"varint,2,name=code" json:"code"`
-	Details []any.Any `protobuf:"bytes,3,name=details" json:"details"`
+	Error   string     `protobuf:"bytes,1,name=error" json:"error"`
+	Code    int32      `protobuf:"varint,2,name=code" json:"code"`
+	Details []*any.Any `protobuf:"bytes,3,rep,name=details" json:"details,omitempty"`
 }
 
 // Make this also conform to proto.Message for builtin JSONPb Marshaler
@@ -103,7 +103,7 @@ func DefaultHTTPError(ctx context.Context, mux *ServeMux, marshaler Marshaler, w
 			if err != nil {
 				grpclog.Printf("Failed to marshal any: %v", err)
 			} else {
-				body.Details = append(body.Details, *a)
+				body.Details = append(body.Details, a)
 			}
 		}
 	}


### PR DESCRIPTION
As advised by @itizir in the discussion of #551.

However, I've gone with the minimal change to make the error go away, I
haven't introduced a proper, generated protobuf definition.

Also, I've noticed our error body message there looks suspiciously like
[Status](https://github.com/google/go-genproto/blob/2b5a72b8730b0b/googleapis/rpc/status/status.pb.go#L83-L93), except for the field name "Error" vs "Message".

Fixes #551.