### PR TITLE
Use the gRPC status Message when possible in stream errors

### DIFF
--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -42,7 +42,7 @@ func ForwardResponseStream(ctx context.Context, mux *ServeMux, marshaler Marshal
 	if d, ok := marshaler.(Delimited); ok {
 		delimiter = d.Delimiter()
 	} else {
-	    delimiter = []byte("\n")
+		delimiter = []byte("\n")
 	}
 
 	var wroteHeader bool
@@ -168,16 +168,13 @@ func handleForwardResponseStreamError(wroteHeader bool, marshaler Marshaler, w h
 
 func streamChunk(result proto.Message, err error) map[string]proto.Message {
 	if err != nil {
-		grpcCode := codes.Unknown
-		if s, ok := status.FromError(err); ok {
-			grpcCode = s.Code()
-		}
-		httpCode := HTTPStatusFromCode(grpcCode)
+		s, _ := status.FromError(err)
+		httpCode := HTTPStatusFromCode(s.Code())
 		return map[string]proto.Message{
 			"error": &internal.StreamError{
-				GrpcCode:   int32(grpcCode),
+				GrpcCode:   int32(s.Code()),
 				HttpCode:   int32(httpCode),
-				Message:    err.Error(),
+				Message:    s.Message(),
 				HttpStatus: http.StatusText(httpCode),
 			},
 		}

--- a/runtime/handler_test.go
+++ b/runtime/handler_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/golang/protobuf/proto"
 	pb "github.com/grpc-ecosystem/grpc-gateway/examples/examplepb"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime/internal"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestForwardResponseStream(t *testing.T) {
@@ -84,9 +86,31 @@ func TestForwardResponseStream(t *testing.T) {
 			w.Body.Close()
 
 			var want []byte
-			for _, msg := range tt.msgs {
+			for i, msg := range tt.msgs {
 				if msg.err != nil {
-					t.Skip("checking erorr encodings")
+					if i == 0 {
+						// Skip non-stream errors
+						t.Skip("checking error encodings")
+					}
+					st, _ := status.FromError(msg.err)
+					httpCode := runtime.HTTPStatusFromCode(st.Code())
+					b, err := marshaler.Marshal(map[string]proto.Message{
+						"error": &internal.StreamError{
+							GrpcCode:   int32(st.Code()),
+							HttpCode:   int32(httpCode),
+							Message:    st.Message(),
+							HttpStatus: http.StatusText(httpCode),
+						},
+					})
+					if err != nil {
+						t.Errorf("marshaler.Marshal() failed %v", err)
+					}
+					errBytes := body[len(want):]
+					if string(errBytes) != string(b) {
+						t.Errorf("ForwardResponseStream() = \"%s\" want \"%s\"", errBytes, b)
+					}
+
+					return
 				}
 				b, err := marshaler.Marshal(map[string]proto.Message{"result": msg.pb})
 				if err != nil {
@@ -103,17 +127,16 @@ func TestForwardResponseStream(t *testing.T) {
 	}
 }
 
-
 // A custom marshaler implementation, that doesn't implement the delimited interface
 type CustomMarshaler struct {
-    m *runtime.JSONPb
+	m *runtime.JSONPb
 }
-func (c *CustomMarshaler) Marshal(v interface{}) ([]byte, error) { return c.m.Marshal(v) }
-func (c *CustomMarshaler) Unmarshal(data []byte, v interface{}) error { return c.m.Unmarshal(data, v) }
-func (c *CustomMarshaler) NewDecoder(r io.Reader) runtime.Decoder { return c.m.NewDecoder(r) }
-func (c *CustomMarshaler) NewEncoder(w io.Writer) runtime.Encoder { return c.m.NewEncoder(w) }
-func (c *CustomMarshaler) ContentType() string { return c.m.ContentType() }
 
+func (c *CustomMarshaler) Marshal(v interface{}) ([]byte, error)      { return c.m.Marshal(v) }
+func (c *CustomMarshaler) Unmarshal(data []byte, v interface{}) error { return c.m.Unmarshal(data, v) }
+func (c *CustomMarshaler) NewDecoder(r io.Reader) runtime.Decoder     { return c.m.NewDecoder(r) }
+func (c *CustomMarshaler) NewEncoder(w io.Writer) runtime.Encoder     { return c.m.NewEncoder(w) }
+func (c *CustomMarshaler) ContentType() string                        { return c.m.ContentType() }
 
 func TestForwardResponseStreamCustomMarshaler(t *testing.T) {
 	type msg struct {


### PR DESCRIPTION
The default behaviour when returning errors in a stream is to use the error code from the gRPC status, but still use the error string instead of the gRPC status message. This PR changes it to use the gRPC status message.