### PR TITLE
option to tweak generated Register* function names

### DIFF
--- a/examples/proto/examplepb/a_bit_of_everything.pb.gw.go
+++ b/examples/proto/examplepb/a_bit_of_everything.pb.gw.go
@@ -561,8 +561,8 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 	return RegisterABitOfEverythingServiceHandlerClient(ctx, mux, NewABitOfEverythingServiceClient(conn))
 }
 
-// RegisterABitOfEverythingServiceHandler registers the http handlers for service ABitOfEverythingService to "mux".
-// The handlers forward requests to the grpc endpoint over the given implementation of "ABitOfEverythingServiceClient".
+// RegisterABitOfEverythingServiceHandlerClient registers the http handlers for service ABitOfEverythingService
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "ABitOfEverythingServiceClient".
 // Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "ABitOfEverythingServiceClient"
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "ABitOfEverythingServiceClient" to call the correct interceptors.
@@ -1068,8 +1068,8 @@ func RegisterCamelCaseServiceNameHandler(ctx context.Context, mux *runtime.Serve
 	return RegisterCamelCaseServiceNameHandlerClient(ctx, mux, NewCamelCaseServiceNameClient(conn))
 }
 
-// RegisterCamelCaseServiceNameHandler registers the http handlers for service CamelCaseServiceName to "mux".
-// The handlers forward requests to the grpc endpoint over the given implementation of "CamelCaseServiceNameClient".
+// RegisterCamelCaseServiceNameHandlerClient registers the http handlers for service CamelCaseServiceName
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "CamelCaseServiceNameClient".
 // Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "CamelCaseServiceNameClient"
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "CamelCaseServiceNameClient" to call the correct interceptors.

--- a/examples/proto/examplepb/echo_service.pb.gw.go
+++ b/examples/proto/examplepb/echo_service.pb.gw.go
@@ -329,8 +329,8 @@ func RegisterEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn
 	return RegisterEchoServiceHandlerClient(ctx, mux, NewEchoServiceClient(conn))
 }
 
-// RegisterEchoServiceHandler registers the http handlers for service EchoService to "mux".
-// The handlers forward requests to the grpc endpoint over the given implementation of "EchoServiceClient".
+// RegisterEchoServiceHandlerClient registers the http handlers for service EchoService
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "EchoServiceClient".
 // Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "EchoServiceClient"
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "EchoServiceClient" to call the correct interceptors.

--- a/examples/proto/examplepb/flow_combination.pb.gw.go
+++ b/examples/proto/examplepb/flow_combination.pb.gw.go
@@ -1016,8 +1016,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 	return RegisterFlowCombinationHandlerClient(ctx, mux, NewFlowCombinationClient(conn))
 }
 
-// RegisterFlowCombinationHandler registers the http handlers for service FlowCombination to "mux".
-// The handlers forward requests to the grpc endpoint over the given implementation of "FlowCombinationClient".
+// RegisterFlowCombinationHandlerClient registers the http handlers for service FlowCombination
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "FlowCombinationClient".
 // Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "FlowCombinationClient"
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "FlowCombinationClient" to call the correct interceptors.

--- a/examples/proto/examplepb/stream.pb.gw.go
+++ b/examples/proto/examplepb/stream.pb.gw.go
@@ -171,8 +171,8 @@ func RegisterStreamServiceHandler(ctx context.Context, mux *runtime.ServeMux, co
 	return RegisterStreamServiceHandlerClient(ctx, mux, NewStreamServiceClient(conn))
 }
 
-// RegisterStreamServiceHandler registers the http handlers for service StreamService to "mux".
-// The handlers forward requests to the grpc endpoint over the given implementation of "StreamServiceClient".
+// RegisterStreamServiceHandlerClient registers the http handlers for service StreamService
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "StreamServiceClient".
 // Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "StreamServiceClient"
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "StreamServiceClient" to call the correct interceptors.

--- a/examples/proto/examplepb/unannotated_echo_service.pb.gw.go
+++ b/examples/proto/examplepb/unannotated_echo_service.pb.gw.go
@@ -170,8 +170,8 @@ func RegisterUnannotatedEchoServiceHandler(ctx context.Context, mux *runtime.Ser
 	return RegisterUnannotatedEchoServiceHandlerClient(ctx, mux, NewUnannotatedEchoServiceClient(conn))
 }
 
-// RegisterUnannotatedEchoServiceHandler registers the http handlers for service UnannotatedEchoService to "mux".
-// The handlers forward requests to the grpc endpoint over the given implementation of "UnannotatedEchoServiceClient".
+// RegisterUnannotatedEchoServiceHandlerClient registers the http handlers for service UnannotatedEchoService
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "UnannotatedEchoServiceClient".
 // Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "UnannotatedEchoServiceClient"
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "UnannotatedEchoServiceClient" to call the correct interceptors.

--- a/examples/proto/examplepb/wrappers.pb.gw.go
+++ b/examples/proto/examplepb/wrappers.pb.gw.go
@@ -72,8 +72,8 @@ func RegisterWrappersServiceHandler(ctx context.Context, mux *runtime.ServeMux, 
 	return RegisterWrappersServiceHandlerClient(ctx, mux, NewWrappersServiceClient(conn))
 }
 
-// RegisterWrappersServiceHandler registers the http handlers for service WrappersService to "mux".
-// The handlers forward requests to the grpc endpoint over the given implementation of "WrappersServiceClient".
+// RegisterWrappersServiceHandlerClient registers the http handlers for service WrappersService
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "WrappersServiceClient".
 // Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "WrappersServiceClient"
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "WrappersServiceClient" to call the correct interceptors.

--- a/protoc-gen-grpc-gateway/gengateway/generator.go
+++ b/protoc-gen-grpc-gateway/gengateway/generator.go
@@ -20,13 +20,14 @@ var (
 )
 
 type generator struct {
-	reg               *descriptor.Registry
-	baseImports       []descriptor.GoPackage
-	useRequestContext bool
+	reg                *descriptor.Registry
+	baseImports        []descriptor.GoPackage
+	useRequestContext  bool
+	registerFuncSuffix string
 }
 
 // New returns a new generator which generates grpc gateway files.
-func New(reg *descriptor.Registry, useRequestContext bool) gen.Generator {
+func New(reg *descriptor.Registry, useRequestContext bool, registerFuncSuffix string) gen.Generator {
 	var imports []descriptor.GoPackage
 	for _, pkgpath := range []string{
 		"io",
@@ -56,7 +57,12 @@ func New(reg *descriptor.Registry, useRequestContext bool) gen.Generator {
 		}
 		imports = append(imports, pkg)
 	}
-	return &generator{reg: reg, baseImports: imports, useRequestContext: useRequestContext}
+	return &generator{
+		reg:                reg,
+		baseImports:        imports,
+		useRequestContext:  useRequestContext,
+		registerFuncSuffix: registerFuncSuffix,
+	}
 }
 
 func (g *generator) Generate(targets []*descriptor.File) ([]*plugin.CodeGeneratorResponse_File, error) {
@@ -110,5 +116,11 @@ func (g *generator) generate(file *descriptor.File) (string, error) {
 			imports = append(imports, pkg)
 		}
 	}
-	return applyTemplate(param{File: file, Imports: imports, UseRequestContext: g.useRequestContext})
+	params := param{
+		File:               file,
+		Imports:            imports,
+		UseRequestContext:  g.useRequestContext,
+		RegisterFuncSuffix: g.registerFuncSuffix,
+	}
+	return applyTemplate(params)
 }

--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -13,8 +13,9 @@ import (
 
 type param struct {
 	*descriptor.File
-	Imports           []descriptor.GoPackage
-	UseRequestContext bool
+	Imports            []descriptor.GoPackage
+	UseRequestContext  bool
+	RegisterFuncSuffix string
 }
 
 type binding struct {
@@ -68,8 +69,9 @@ func (f queryParamFilter) String() string {
 }
 
 type trailerParams struct {
-	Services          []*descriptor.Service
-	UseRequestContext bool
+	Services           []*descriptor.Service
+	UseRequestContext  bool
+	RegisterFuncSuffix string
 }
 
 func applyTemplate(p param) (string, error) {
@@ -102,8 +104,9 @@ func applyTemplate(p param) (string, error) {
 	}
 
 	tp := trailerParams{
-		Services:          targetServices,
-		UseRequestContext: p.UseRequestContext,
+		Services:           targetServices,
+		UseRequestContext:  p.UseRequestContext,
+		RegisterFuncSuffix: p.RegisterFuncSuffix,
 	}
 	if err := trailerTemplate.Execute(w, tp); err != nil {
 		return "", err
@@ -312,9 +315,9 @@ var (
 	trailerTemplate = template.Must(template.New("trailer").Parse(`
 {{$UseRequestContext := .UseRequestContext}}
 {{range $svc := .Services}}
-// Register{{$svc.GetName}}HandlerFromEndpoint is same as Register{{$svc.GetName}}Handler but
+// Register{{$svc.GetName}}{{$.RegisterFuncSuffix}}FromEndpoint is same as Register{{$svc.GetName}}{{$.RegisterFuncSuffix}} but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
-func Register{{$svc.GetName}}HandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
+func Register{{$svc.GetName}}{{$.RegisterFuncSuffix}}FromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
 	conn, err := grpc.Dial(endpoint, opts...)
 	if err != nil {
 		return err
@@ -334,21 +337,21 @@ func Register{{$svc.GetName}}HandlerFromEndpoint(ctx context.Context, mux *runti
 		}()
 	}()
 
-	return Register{{$svc.GetName}}Handler(ctx, mux, conn)
+	return Register{{$svc.GetName}}{{$.RegisterFuncSuffix}}(ctx, mux, conn)
 }
 
-// Register{{$svc.GetName}}Handler registers the http handlers for service {{$svc.GetName}} to "mux".
+// Register{{$svc.GetName}}{{$.RegisterFuncSuffix}} registers the http handlers for service {{$svc.GetName}} to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func Register{{$svc.GetName}}Handler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
-	return Register{{$svc.GetName}}HandlerClient(ctx, mux, New{{$svc.GetName}}Client(conn))
+func Register{{$svc.GetName}}{{$.RegisterFuncSuffix}}(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
+	return Register{{$svc.GetName}}{{$.RegisterFuncSuffix}}Client(ctx, mux, New{{$svc.GetName}}Client(conn))
 }
 
-// Register{{$svc.GetName}}Handler registers the http handlers for service {{$svc.GetName}} to "mux".
-// The handlers forward requests to the grpc endpoint over the given implementation of "{{$svc.GetName}}Client".
+// Register{{$svc.GetName}}{{$.RegisterFuncSuffix}}Client registers the http handlers for service {{$svc.GetName}}
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "{{$svc.GetName}}Client".
 // Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "{{$svc.GetName}}Client"
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "{{$svc.GetName}}Client" to call the correct interceptors.
-func Register{{$svc.GetName}}HandlerClient(ctx context.Context, mux *runtime.ServeMux, client {{$svc.GetName}}Client) error {
+func Register{{$svc.GetName}}{{$.RegisterFuncSuffix}}Client(ctx context.Context, mux *runtime.ServeMux, client {{$svc.GetName}}Client) error {
 	{{range $m := $svc.Methods}}
 	{{range $b := $m.Bindings}}
 	mux.Handle({{$b.HTTPMethod | printf "%q"}}, pattern_{{$svc.GetName}}_{{$m.GetName}}_{{$b.Index}}, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {

--- a/protoc-gen-grpc-gateway/gengateway/template_test.go
+++ b/protoc-gen-grpc-gateway/gengateway/template_test.go
@@ -77,7 +77,7 @@ func TestApplyTemplateHeader(t *testing.T) {
 			},
 		},
 	}
-	got, err := applyTemplate(param{File: crossLinkFixture(&file)})
+	got, err := applyTemplate(param{File: crossLinkFixture(&file), RegisterFuncSuffix: "Handler"})
 	if err != nil {
 		t.Errorf("applyTemplate(%#v) failed with %v; want success", file, err)
 		return
@@ -222,7 +222,7 @@ func TestApplyTemplateRequestWithoutClientStreaming(t *testing.T) {
 				},
 			},
 		}
-		got, err := applyTemplate(param{File: crossLinkFixture(&file)})
+		got, err := applyTemplate(param{File: crossLinkFixture(&file), RegisterFuncSuffix: "Handler"})
 		if err != nil {
 			t.Errorf("applyTemplate(%#v) failed with %v; want success", file, err)
 			return
@@ -383,7 +383,7 @@ func TestApplyTemplateRequestWithClientStreaming(t *testing.T) {
 				},
 			},
 		}
-		got, err := applyTemplate(param{File: crossLinkFixture(&file)})
+		got, err := applyTemplate(param{File: crossLinkFixture(&file), RegisterFuncSuffix: "Handler"})
 		if err != nil {
 			t.Errorf("applyTemplate(%#v) failed with %v; want success", file, err)
 			return

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -24,6 +24,7 @@ import (
 var (
 	importPrefix         = flag.String("import_prefix", "", "prefix to be added to go package paths for imported proto files")
 	importPath           = flag.String("import_path", "", "used as the package if no input files declare go_package. If it contains slashes, everything up to the rightmost slash is ignored.")
+	registerFuncSuffix   = flag.String("register_func_suffix", "Handler", "used to construct names of generated Register*<Suffix> methods.")
 	useRequestContext    = flag.Bool("request_context", true, "determine whether to use http.Request's context or not")
 	allowDeleteBody      = flag.Bool("allow_delete_body", false, "unless set, HTTP DELETE methods may not have a body")
 	grpcAPIConfiguration = flag.String("grpc_api_configuration", "", "path to gRPC API Configuration in YAML format")
@@ -61,7 +62,7 @@ func main() {
 		}
 	}
 
-	g := gengateway.New(reg, *useRequestContext)
+	g := gengateway.New(reg, *useRequestContext, *registerFuncSuffix)
 
 	if *grpcAPIConfiguration != "" {
 		if err := reg.LoadGrpcAPIServiceFromYAML(*grpcAPIConfiguration); err != nil {


### PR DESCRIPTION
We have our own protoc plugin that wants to generate a `Register<ServiceName>Handler` function: https://godoc.org/github.com/fullstorydev/grpchan

If I use both the grpchan and grpc-gateway protoc plugins, they generate code that won't compile. I would really prefer the grpc-gateway functions be named `Register<ServiceName>HTTPHandler` to make the distinction more obvious from the name.

So this pull request provides an option that can be used to change the generated name. The option is `register-func-suffix` and it defaults `"Handler"` to preserve the names if the option is not used.

I can then do this in my own go:generate directive to get the desired output:

```
protoc -I $HOME/go/src \
    -I $HOME/go/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
    --go_out=plugins=grpc:$HOME/go/src \
    --grpchan_out=$HOME/go/src \
    --grpc-gateway_out=logtostderr=true,allow_delete_body=true,register_func_suffix=HTTPHandler:$HOME/go/src \
    $HOME/go/src/github.com/myorg/myrepo/mypackage/myprotocol.proto
```