### PR TITLE
fix racy access of err variable

### DIFF
--- a/examples/examplepb/flow_combination.pb.gw.go
+++ b/examples/examplepb/flow_combination.pb.gw.go
@@ -105,7 +105,7 @@ func request_FlowCombination_StreamEmptyStream_0(ctx context.Context, marshaler 
 	dec := marshaler.NewDecoder(req.Body)
 	handleSend := func() error {
 		var protoReq EmptyProto
-		err = dec.Decode(&protoReq)
+		err := dec.Decode(&protoReq)
 		if err == io.EOF {
 			return err
 		}
@@ -113,7 +113,7 @@ func request_FlowCombination_StreamEmptyStream_0(ctx context.Context, marshaler 
 			grpclog.Printf("Failed to decode request: %v", err)
 			return err
 		}
-		if err = stream.Send(&protoReq); err != nil {
+		if err := stream.Send(&protoReq); err != nil {
 			grpclog.Printf("Failed to send request: %v", err)
 			return err
 		}

--- a/examples/examplepb/stream.pb.gw.go
+++ b/examples/examplepb/stream.pb.gw.go
@@ -98,7 +98,7 @@ func request_StreamService_BulkEcho_0(ctx context.Context, marshaler runtime.Mar
 	dec := marshaler.NewDecoder(req.Body)
 	handleSend := func() error {
 		var protoReq sub.StringMessage
-		err = dec.Decode(&protoReq)
+		err := dec.Decode(&protoReq)
 		if err == io.EOF {
 			return err
 		}
@@ -106,7 +106,7 @@ func request_StreamService_BulkEcho_0(ctx context.Context, marshaler runtime.Mar
 			grpclog.Printf("Failed to decode request: %v", err)
 			return err
 		}
-		if err = stream.Send(&protoReq); err != nil {
+		if err := stream.Send(&protoReq); err != nil {
 			grpclog.Printf("Failed to send request: %v", err)
 			return err
 		}

--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -268,7 +268,7 @@ var (
 	dec := marshaler.NewDecoder(req.Body)
 	handleSend := func() error {
 		var protoReq {{.Method.RequestType.GoType .Method.Service.File.GoPkg.Path}}
-		err = dec.Decode(&protoReq)
+		err := dec.Decode(&protoReq)
 		if err == io.EOF {
 			return err
 		}
@@ -276,7 +276,7 @@ var (
 			grpclog.Printf("Failed to decode request: %v", err)
 			return err
 		}
-		if err = stream.Send(&protoReq); err != nil {
+		if err := stream.Send(&protoReq); err != nil {
 			grpclog.Printf("Failed to send request: %v", err)
 			return err
 		}


### PR DESCRIPTION
Without this fix, the `handleSend` function is closing over `err` from the outer function. This trips up the Go race detector because `handleSend` gets invoked in a goroutine and there is no synchronization between that goroutine and a subsequent write to `err` after a call to `stream.Header`.

This appears to be an accidental closure -- `handleSend` doesn't actually need to share the `err` variable so can instead just create its own `err` local variable. Which clears it up.