### PR TITLE
generation one swagger file out of multiple protos

### DIFF
--- a/protoc-gen-grpc-gateway/descriptor/registry.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry.go
@@ -36,6 +36,9 @@ type Registry struct {
 
 	// allowDeleteBody permits http delete methods to have a body
 	allowDeleteBody bool
+
+	// allowMerge generation one swagger file out of multiple protos
+	allowMerge bool
 }
 
 // NewRegistry returns a new Registry.
@@ -280,6 +283,16 @@ func (r *Registry) GetAllFQENs() []string {
 // body or fail loading if encountered.
 func (r *Registry) SetAllowDeleteBody(allow bool) {
 	r.allowDeleteBody = allow
+}
+
+// SetAllowMerge controls whether generation one swagger file out of multiple protos
+func (r *Registry) SetAllowMerge(allow bool) {
+	r.allowMerge = allow
+}
+
+// IsAllowMerge whether generation one swagger file out of multiple protos
+func (r *Registry) IsAllowMerge() bool {
+	return r.allowMerge
 }
 
 // sanitizePackageName replaces unallowed character in package name

--- a/protoc-gen-swagger/main.go
+++ b/protoc-gen-swagger/main.go
@@ -19,6 +19,7 @@ var (
 	importPrefix    = flag.String("import_prefix", "", "prefix to be added to go package paths for imported proto files")
 	file            = flag.String("file", "-", "where to load data from")
 	allowDeleteBody = flag.Bool("allow_delete_body", false, "unless set, HTTP DELETE methods may not have a body")
+	allowMerge      = flag.Bool("allow_merge", false, "if set, generation one swagger file out of multiple protos")
 )
 
 func parseReq(r io.Reader) (*plugin.CodeGeneratorRequest, error) {
@@ -66,6 +67,7 @@ func main() {
 
 	reg.SetPrefix(*importPrefix)
 	reg.SetAllowDeleteBody(*allowDeleteBody)
+	reg.SetAllowMerge(*allowMerge)
 	for k, v := range pkgMap {
 		reg.AddPkgMap(k, v)
 	}


### PR DESCRIPTION
Issue: 

https://github.com/grpc-ecosystem/grpc-gateway/issues/99

Usage:
```
bash -c "protoc -I=. ./*services.proto --swagger_out=allow_delete_body=true,allow_merge=true,logtostderr=true:."
```
