### PR TITLE
Fixes file integrity errors on TravisCI

### DIFF
--- a/examples/examplepb/a_bit_of_everything.pb.go
+++ b/examples/examplepb/a_bit_of_everything.pb.go
@@ -15,7 +15,7 @@ import google_protobuf3 "github.com/golang/protobuf/ptypes/timestamp"
 import _ "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger/options"
 
 import (
-	context "context"
+	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 )
 

--- a/examples/examplepb/echo_service.pb.go
+++ b/examples/examplepb/echo_service.pb.go
@@ -36,7 +36,7 @@ import math "math"
 import _ "google.golang.org/genproto/googleapis/api/annotations"
 
 import (
-	context "context"
+	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 )
 

--- a/examples/examplepb/flow_combination.pb.go
+++ b/examples/examplepb/flow_combination.pb.go
@@ -9,7 +9,7 @@ import math "math"
 import _ "google.golang.org/genproto/googleapis/api/annotations"
 
 import (
-	context "context"
+	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 )
 

--- a/examples/examplepb/stream.pb.go
+++ b/examples/examplepb/stream.pb.go
@@ -11,7 +11,7 @@ import google_protobuf1 "github.com/golang/protobuf/ptypes/empty"
 import grpc_gateway_examples_sub "github.com/grpc-ecosystem/grpc-gateway/examples/sub"
 
 import (
-	context "context"
+	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 )
 

--- a/examples/examplepb/wrappers.pb.go
+++ b/examples/examplepb/wrappers.pb.go
@@ -10,7 +10,7 @@ import _ "google.golang.org/genproto/googleapis/api/annotations"
 import google_protobuf5 "github.com/golang/protobuf/ptypes/wrappers"
 
 import (
-	context "context"
+	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 )
 


### PR DESCRIPTION
Partially reverts 37660b1a4ff83f0ac3672ff7976223a859859e2f to fix
CI issues like
https://travis-ci.org/grpc-ecosystem/grpc-gateway/jobs/370802179.

Keep using the old "golang.org/x/net/context" in these files until
protoc-gen-go adopts the standard "context".