### PR TITLE
[not ready] Port more build steps onto Bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,4 +50,11 @@ go_repository(
 
 load("//:repositories.bzl", "repositories")
 
+maven_jar(
+    name = "io_swagger_swagger_codegen_cli",
+    # Should be consistent with .travis.yaml
+    artifact = "io.swagger:swagger-codegen-cli:2.2.2",
+    sha1 = "a5b48219c1f9898b0a1f639e0cb89396d5f8e0d1",
+)
+
 repositories()

--- a/examples/clients/BUILD.bazel
+++ b/examples/clients/BUILD.bazel
@@ -1,0 +1,15 @@
+# Helper application for the subpackages
+java_binary(
+    name = "swagger-codegen-cli",
+    licenses = ["notice"],  # apache
+    main_class = "io.swagger.codegen.SwaggerCodegen",
+    visibility = ["//examples/clients:__subpackages__"],
+    runtime_deps = [
+        "@io_swagger_swagger_codegen_cli//jar",
+    ],
+)
+
+exports_files(
+    ["diff_test.sh"],
+    visibility = ["//examples/clients:__subpackages__"],
+)

--- a/examples/clients/abe/BUILD.bazel
+++ b/examples/clients/abe/BUILD.bazel
@@ -1,25 +1,51 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load(
+    "//examples/clients:clients.bzl",
+    "swagger_codegen",
+    "gen_file_integrity_test",
+)
 
 package(default_visibility = ["//visibility:public"])
 
+# keep
 go_library(
     name = "go_default_library",
     srcs = [
-        "a_bit_of_everything_nested.go",
-        "a_bit_of_everything_service_api.go",
-        "api_client.go",
-        "api_response.go",
-        "camel_case_service_name_api.go",
-        "configuration.go",
-        "echo_rpc_api.go",
-        "echo_service_api.go",
-        "examplepb_a_bit_of_everything.go",
-        "examplepb_body.go",
-        "examplepb_numeric_enum.go",
-        "nested_deep_enum.go",
-        "protobuf_empty.go",
-        "sub_string_message.go",
+        ":gen_client",
     ],
     importpath = "github.com/grpc-ecosystem/grpc-gateway/examples/clients/abe",
     deps = ["@com_github_go_resty_resty//:go_default_library"],
+)
+
+SRCS = [
+    "a_bit_of_everything_nested.go",
+    "a_bit_of_everything_service_api.go",
+    "api_client.go",
+    "api_response.go",
+    "camel_case_service_name_api.go",
+    "configuration.go",
+    "echo_rpc_api.go",
+    "echo_service_api.go",
+    "examplepb_a_bit_of_everything.go",
+    "examplepb_body.go",
+    "examplepb_numeric_enum.go",
+    "nested_deep_enum.go",
+    "protobuf_empty.go",
+    "sub_string_message.go",
+]
+
+swagger_codegen(
+    name = "gen_client",
+    package_name = "abe",
+    out_dir = "gen",
+    outputs = ["gen/%s" % f for f in SRCS],
+    spec = "//examples/proto/examplepb:a_bit_of_everything.swagger.json",
+)
+
+gen_file_integrity_test(
+    name = "generated_files_test",
+    size = "small",
+    generated_dir = "gen",
+    generated_files = ["gen/%s" % f for f in SRCS],
+    golden_dir = ".",
 )

--- a/examples/clients/clients.bzl
+++ b/examples/clients/clients.bzl
@@ -1,0 +1,53 @@
+def swagger_codegen(name, spec, package_name, outputs, out_dir=".", **kwarg):
+  out_dir_spec = "$(@D)"
+  if out_dir != ".":
+    out_dir_spec += "/" + out_dir
+    for out in outputs:
+      if not out.startswith(out_dir + "/"):
+        fail("%s must reside in the out_dir %s" % (out, out_dir), "outputs")
+
+  native.genrule(
+      name = name,
+      srcs = [spec],
+      outs = outputs,
+      cmd = " ".join([
+          "$(location //examples/clients:swagger-codegen-cli)",
+          "generate",
+          "-i", "$<",
+          "-l", "go",
+          "-o", out_dir_spec,
+          "--additional-properties",
+          "packageName=%s" % package_name,
+      ]),
+      tools = [
+          "//examples/clients:swagger-codegen-cli",
+      ],
+      **kwarg
+  )
+
+def gen_file_integrity_test(name, generated_files, generated_dir, golden_dir, **kwargs):
+  golden_prefix = _prefix(golden_dir)
+  generated_prefix = _prefix(generated_dir)
+
+  args = []
+  data = []
+  for gen in generated_files:
+    if not gen.startswith(generated_prefix):
+      fail("%s must reside in dir %s" % (gen, generated_dir))
+    else:
+      golden = golden_prefix + gen[len(generated_prefix):]
+      data.extend([gen, golden])
+      args.extend(["$(location %s)" % f for f in [gen, golden]])
+
+  native.sh_test(
+      name = name,
+      srcs = ["//examples/clients:diff_test.sh"],
+      args = args,
+      data = data,
+      **kwargs
+  )
+
+def _prefix(dir):
+  if dir == ".":
+    return ""
+  return dir + "/"

--- a/examples/clients/diff_test.sh
+++ b/examples/clients/diff_test.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+
+while test $# -gt 0; do
+  file=$1
+  golden=$2
+  shift; shift
+  echo $file >&2
+  diff -qN "$file" "$golden"
+done

--- a/examples/clients/echo/BUILD.bazel
+++ b/examples/clients/echo/BUILD.bazel
@@ -1,17 +1,43 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load(
+    "//examples/clients:clients.bzl",
+    "swagger_codegen",
+    "gen_file_integrity_test",
+)
 
 package(default_visibility = ["//visibility:public"])
 
+# keep
 go_library(
     name = "go_default_library",
     srcs = [
-        "api_client.go",
-        "api_response.go",
-        "configuration.go",
-        "echo_service_api.go",
-        "examplepb_embedded.go",
-        "examplepb_simple_message.go",
+        ":gen_client",
     ],
     importpath = "github.com/grpc-ecosystem/grpc-gateway/examples/clients/echo",
     deps = ["@com_github_go_resty_resty//:go_default_library"],
+)
+
+SRCS = [
+    "api_client.go",
+    "api_response.go",
+    "configuration.go",
+    "echo_service_api.go",
+    "examplepb_embedded.go",
+    "examplepb_simple_message.go",
+]
+
+swagger_codegen(
+    name = "gen_client",
+    package_name = "echo",
+    out_dir = "gen",
+    outputs = ["gen/%s" % f for f in SRCS],
+    spec = "//examples/proto/examplepb:echo_service.swagger.json",
+)
+
+gen_file_integrity_test(
+    name = "generated_files_test",
+    size = "small",
+    generated_dir = "gen",
+    generated_files = ["gen/%s" % f for f in SRCS],
+    golden_dir = ".",
 )

--- a/examples/clients/unannotatedecho/BUILD.bazel
+++ b/examples/clients/unannotatedecho/BUILD.bazel
@@ -1,16 +1,42 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load(
+    "//examples/clients:clients.bzl",
+    "swagger_codegen",
+    "gen_file_integrity_test",
+)
 
 package(default_visibility = ["//visibility:public"])
 
+# keep
 go_library(
     name = "go_default_library",
     srcs = [
-        "api_client.go",
-        "api_response.go",
-        "configuration.go",
-        "examplepb_unannotated_simple_message.go",
-        "unannotated_echo_service_api.go",
+        ":gen_client",
     ],
     importpath = "github.com/grpc-ecosystem/grpc-gateway/examples/clients/unannotatedecho",
     deps = ["@com_github_go_resty_resty//:go_default_library"],
+)
+
+SRCS = [
+    "api_client.go",
+    "api_response.go",
+    "configuration.go",
+    "examplepb_unannotated_simple_message.go",
+    "unannotated_echo_service_api.go",
+]
+
+swagger_codegen(
+    name = "gen_client",
+    package_name = "unannotatedecho",
+    out_dir = "gen",
+    outputs = ["gen/%s" % f for f in SRCS],
+    spec = "//examples/proto/examplepb:unannotated_echo_service.swagger.json",
+)
+
+gen_file_integrity_test(
+    name = "generated_files_test",
+    size = "small",
+    generated_dir = "gen",
+    generated_files = ["gen/%s" % f for f in SRCS],
+    golden_dir = ".",
 )

--- a/examples/proto/examplepb/BUILD.bazel
+++ b/examples/proto/examplepb/BUILD.bazel
@@ -4,10 +4,20 @@ load("@grpc_ecosystem_grpc_gateway//protoc-gen-swagger:defs.bzl", "protoc_gen_sw
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(
+    [
+        "echo_service.swagger.json",
+        "a_bit_of_everything.swagger.json",
+        "unannotated_echo_service.swagger.json",
+    ],
+    visibility = ["//examples/clients:__subpackages__"],
+)
+
 # gazelle:exclude a_bit_of_everything.pb.gw.go
 # gazelle:exclude echo_service.pb.gw.go
 # gazelle:exclude flow_combination.pb.gw.go
 # gazelle:exclude stream.pb.gw.go
+# gazelle:exclude unannotated_echo_service.pb.gw.go
 # gazelle:exclude wrappers.pb.gw.go
 
 proto_library(


### PR DESCRIPTION
Generates example go clients with swagger in the build process with
Bazel and let the integration test use the generated clients.