### PR TITLE
Use repo relative labels in protoc-gen-swagger

### DIFF
--- a/protoc-gen-swagger/defs.bzl
+++ b/protoc-gen-swagger/defs.bzl
@@ -66,7 +66,7 @@ protoc_gen_swagger = rule(
             allow_files = True,
         ),
         "_protoc_gen_swagger": attr.label(
-            default = Label("@grpc_ecosystem_grpc_gateway//protoc-gen-swagger:protoc-gen-swagger"),
+            default = Label("//protoc-gen-swagger:protoc-gen-swagger"),
             executable = True,
             cfg = "host",
         ),


### PR DESCRIPTION
Previously this was breaking when imported into projects which imported the project by the name `com_github_grpc_ecosystem_grpc_gateway`.