### PR TITLE
Add support for the grpc_api_configuration option in the bazel rule.

### DIFF
--- a/protoc-gen-swagger/defs.bzl
+++ b/protoc-gen-swagger/defs.bzl
@@ -48,7 +48,6 @@ def _run_proto_gen_swagger(direct_proto_srcs, transitive_proto_srcs, actions, pr
 
 def _proto_gen_swagger_impl(ctx):
     proto = ctx.attr.proto.proto
-    grpc_api_configuration = None
     grpc_api_configuration = ctx.file.grpc_api_configuration
 
     return struct(

--- a/protoc-gen-swagger/defs.bzl
+++ b/protoc-gen-swagger/defs.bzl
@@ -1,3 +1,8 @@
+"""Generated an open-api spec for a grpc api spec.
+
+Reads the the api spec in protobuf format and generate an open-api spec. 
+Optionally applies settings from the grpc-service configuration.
+"""
 def _collect_includes(srcs):
     includes = ["."]
     for src in srcs:
@@ -7,17 +12,24 @@ def _collect_includes(srcs):
 
     return includes
 
-def _run_proto_gen_swagger(direct_proto_srcs, transitive_proto_srcs, actions, protoc, protoc_gen_swagger):
+def _run_proto_gen_swagger(direct_proto_srcs, transitive_proto_srcs, actions, protoc, protoc_gen_swagger, grpc_api_configuration):
     swagger_files = []
     for proto in direct_proto_srcs:
       swagger_file = actions.declare_file(
           "%s.swagger.json" % proto.basename[:-len(".proto")],
           sibling = proto,
       )
+      
+      inputs = direct_proto_srcs + transitive_proto_srcs + [protoc_gen_swagger]
+      
+      options=["logtostderr=true"]
+      if grpc_api_configuration:
+          options.append("grpc_api_configuration=%s" % grpc_api_configuration.path)
+          inputs.append(grpc_api_configuration)
 
       args = actions.args()
       args.add("--plugin=%s" % protoc_gen_swagger.path)
-      args.add("--swagger_out=logtostderr=true:%s" % swagger_file.dirname)
+      args.add("--swagger_out=%s:%s" % (",".join(options), swagger_file.dirname))
       args.add("-Iexternal/com_google_protobuf/src")
       args.add("-Iexternal/com_github_googleapis_googleapis")
       args.add(["-I%s" % include for include in _collect_includes(direct_proto_srcs + transitive_proto_srcs)])
@@ -25,7 +37,7 @@ def _run_proto_gen_swagger(direct_proto_srcs, transitive_proto_srcs, actions, pr
 
       actions.run(
           executable = protoc,
-          inputs = direct_proto_srcs + transitive_proto_srcs + [protoc_gen_swagger],
+          inputs = inputs,
           outputs = [swagger_file],
           arguments = [args],
       )
@@ -36,6 +48,8 @@ def _run_proto_gen_swagger(direct_proto_srcs, transitive_proto_srcs, actions, pr
 
 def _proto_gen_swagger_impl(ctx):
     proto = ctx.attr.proto.proto
+    grpc_api_configuration = None
+    grpc_api_configuration = ctx.file.grpc_api_configuration
 
     return struct(
         files=depset(
@@ -45,6 +59,7 @@ def _proto_gen_swagger_impl(ctx):
                 actions = ctx.actions,
                 protoc = ctx.executable._protoc,
                 protoc_gen_swagger = ctx.executable._protoc_gen_swagger,
+                grpc_api_configuration = grpc_api_configuration
             )
         )
     )
@@ -55,6 +70,10 @@ protoc_gen_swagger = rule(
             allow_rules = ["proto_library"],
             mandatory = True,
             providers = ['proto'],
+        ),
+        "grpc_api_configuration": attr.label(
+            allow_single_file=True,
+            mandatory=False
         ),
         "_protoc": attr.label(
             default = "@com_google_protobuf//:protoc",


### PR DESCRIPTION
PR #521 added support for grpc service configurations. Add an option to let
users specify this config in the bazel rule.

Also add a simple doc blob to the rule.