### PR TITLE
provide access to underlying *json.Decoder from JSONPb.NewDecoder

### DIFF
--- a/runtime/marshal_json.go
+++ b/runtime/marshal_json.go
@@ -9,6 +9,9 @@ import (
 // with the standard "encoding/json" package of Golang.
 // Although it is generally faster for simple proto messages than JSONPb,
 // it does not support advanced features of protobuf, e.g. map, oneof, ....
+//
+// The NewEncoder and NewDecoder types return *json.Encoder and
+// *json.Decoder respectively.
 type JSONBuiltin struct{}
 
 // ContentType always Returns "application/json".

--- a/runtime/marshal_jsonpb.go
+++ b/runtime/marshal_jsonpb.go
@@ -14,6 +14,9 @@ import (
 // JSONPb is a Marshaler which marshals/unmarshals into/from JSON
 // with the "github.com/golang/protobuf/jsonpb".
 // It supports fully functionality of protobuf unlike JSONBuiltin.
+//
+// The NewDecoder method returns a DecoderWrapper, so the underlying
+// *json.Decoder methods can be used.
 type JSONPb jsonpb.Marshaler
 
 // ContentType always returns "application/json".
@@ -84,8 +87,6 @@ func (j *JSONPb) marshalNonProtoField(v interface{}) ([]byte, error) {
 }
 
 // Unmarshal unmarshals JSON "data" into "v"
-// Currently it can marshal only proto.Message.
-// TODO(yugui) Support fields of primitive types in a message.
 func (j *JSONPb) Unmarshal(data []byte, v interface{}) error {
 	return unmarshalJSONPb(data, v)
 }
@@ -93,7 +94,19 @@ func (j *JSONPb) Unmarshal(data []byte, v interface{}) error {
 // NewDecoder returns a Decoder which reads JSON stream from "r".
 func (j *JSONPb) NewDecoder(r io.Reader) Decoder {
 	d := json.NewDecoder(r)
-	return DecoderFunc(func(v interface{}) error { return decodeJSONPb(d, v) })
+	return DecoderWrapper{Decoder: d}
+}
+
+// DecoderWrapper is a wrapper around a *json.Decoder that adds
+// support for protos to the Decode method.
+type DecoderWrapper struct {
+	*json.Decoder
+}
+
+// Decode wraps the embedded decoder's Decode method to support
+// protos using a jsonpb.Unmarshaler.
+func (d DecoderWrapper) Decode(v interface{}) error {
+	return decodeJSONPb(d.Decoder, v)
 }
 
 // NewEncoder returns an Encoder which writes JSON stream into "w".


### PR DESCRIPTION
I am using the `JSONPb` marshaler in non-grpc-gateway server code to handle a mix of proto and non-proto types for JSON encoding/decoding.

I need to be able to control the underlying `*json.Decoder`, such as calling its `UseNumber()` method and being able to access its `Buffered()` data to resume reading from a stream after a JSON value has been decoded from it.