### PR TITLE
JSONPb marshaler panics if input is nil interface

### DIFF
--- a/runtime/marshal_json_test.go
+++ b/runtime/marshal_json_test.go
@@ -84,7 +84,7 @@ func TestJSONBuiltinsnmarshal(t *testing.T) {
 func TestJSONBuiltinUnmarshalField(t *testing.T) {
 	var m runtime.JSONBuiltin
 	for _, fixt := range builtinFieldFixtures {
-		dest := reflect.New(reflect.TypeOf(fixt.data))
+		dest := alloc(reflect.TypeOf(fixt.data))
 		if err := m.Unmarshal([]byte(fixt.json), dest.Interface()); err != nil {
 			t.Errorf("m.Unmarshal(%q, dest) failed with %v; want success", fixt.json, err)
 		}
@@ -92,6 +92,14 @@ func TestJSONBuiltinUnmarshalField(t *testing.T) {
 		if got, want := dest.Elem().Interface(), fixt.data; !reflect.DeepEqual(got, want) {
 			t.Errorf("got = %#v; want = %#v; input = %q", got, want, fixt.json)
 		}
+	}
+}
+
+func alloc(t reflect.Type) reflect.Value {
+	if t == nil {
+		return reflect.ValueOf(new(interface{}))
+	} else {
+		return reflect.New(t)
 	}
 }
 
@@ -167,7 +175,7 @@ func TestJSONBuiltinDecoderFields(t *testing.T) {
 	for _, fixt := range builtinFieldFixtures {
 		r := strings.NewReader(fixt.json)
 		dec := m.NewDecoder(r)
-		dest := reflect.New(reflect.TypeOf(fixt.data))
+		dest := alloc(reflect.TypeOf(fixt.data))
 		if err := dec.Decode(dest.Interface()); err != nil {
 			t.Errorf("dec.Decode(dest) failed with %v; want success; data = %q", err, fixt.json)
 		}
@@ -204,6 +212,13 @@ var (
 		{data: (*string)(nil), json: "null"},
 		{data: new(empty.Empty), json: "{}"},
 		{data: examplepb.NumericEnum_ONE, json: "1"},
+		{data: nil, json: "null"},
+		{data: (*string)(nil), json: "null"},
+		{data: []interface{}{nil, "foo", -1.0, 1.234, true}, json: `[null,"foo",-1,1.234,true]`},
+		{
+			data: map[string]interface{}{"bar": nil, "baz": -1.0, "fiz": 1.234, "foo": true},
+			json: `{"bar":null,"baz":-1,"fiz":1.234,"foo":true}`,
+		},
 		{
 			data: (*examplepb.NumericEnum)(proto.Int32(int32(examplepb.NumericEnum_ONE))),
 			json: "1",

--- a/runtime/marshal_jsonpb.go
+++ b/runtime/marshal_jsonpb.go
@@ -21,9 +21,7 @@ func (*JSONPb) ContentType() string {
 	return "application/json"
 }
 
-// Marshal marshals "v" into JSON
-// Currently it can marshal only proto.Message.
-// TODO(yugui) Support fields of primitive types in a message.
+// Marshal marshals "v" into JSON.
 func (j *JSONPb) Marshal(v interface{}) ([]byte, error) {
 	if _, ok := v.(proto.Message); !ok {
 		return j.marshalNonProtoField(v)
@@ -55,6 +53,9 @@ func (j *JSONPb) marshalTo(w io.Writer, v interface{}) error {
 // i.e. primitive types, enums; pointers to primitives or enums; maps from
 // integer/string types to primitives/enums/pointers to messages.
 func (j *JSONPb) marshalNonProtoField(v interface{}) ([]byte, error) {
+	if v == nil {
+		return []byte("null"), nil
+	}
 	rv := reflect.ValueOf(v)
 	for rv.Kind() == reflect.Ptr {
 		if rv.IsNil() {

--- a/runtime/marshal_jsonpb_test.go
+++ b/runtime/marshal_jsonpb_test.go
@@ -121,25 +121,23 @@ func TestJSONPbMarshal(t *testing.T) {
 
 func TestJSONPbMarshalFields(t *testing.T) {
 	var m runtime.JSONPb
-	for _, spec := range []struct {
-		val  interface{}
-		want string
-	}{} {
-		buf, err := m.Marshal(spec.val)
+	m.EnumsAsInts = true // builtin fixtures include an enum, expected to be marshaled as int
+	for _, spec := range builtinFieldFixtures {
+		buf, err := m.Marshal(spec.data)
 		if err != nil {
-			t.Errorf("m.Marshal(%#v) failed with %v; want success", spec.val, err)
+			t.Errorf("m.Marshal(%#v) failed with %v; want success", spec.data, err)
 		}
-		if got, want := string(buf), spec.want; got != want {
-			t.Errorf("m.Marshal(%#v) = %q; want %q", spec.val, got, want)
+		if got, want := string(buf), spec.json; got != want {
+			t.Errorf("m.Marshal(%#v) = %q; want %q", spec.data, got, want)
 		}
 	}
 
-	m.EnumsAsInts = true
+	m.EnumsAsInts = false
 	buf, err := m.Marshal(examplepb.NumericEnum_ONE)
 	if err != nil {
 		t.Errorf("m.Marshal(%#v) failed with %v; want success", examplepb.NumericEnum_ONE, err)
 	}
-	if got, want := string(buf), "1"; got != want {
+	if got, want := string(buf), `"ONE"`; got != want {
 		t.Errorf("m.Marshal(%#v) = %q; want %q", examplepb.NumericEnum_ONE, got, want)
 	}
 }


### PR DESCRIPTION
The `JSONBuiltin` marshaler emits `"null"` when marshaling a nil interface, but `JSONPb` panics:

```
panic: reflect: call of reflect.Value.Interface on zero Value

goroutine 6 [running]:
testing.tRunner.func1(0xc4201982d0)
  /usr/local/go/src/testing/testing.go:711 +0x2d2
panic(0x1506500, 0xc4201bee20)
  /usr/local/go/src/runtime/panic.go:491 +0x283
reflect.valueInterface(0x0, 0x0, 0x0, 0x1, 0x0, 0xc4201cf340)
  /usr/local/go/src/reflect/value.go:936 +0x1bf
reflect.Value.Interface(0x0, 0x0, 0x0, 0x0, 0x0)
  /usr/local/go/src/reflect/value.go:931 +0x44
github.com/grpc-ecosystem/grpc-gateway/runtime.(*JSONPb).marshalNonProtoField(0xc420173f80, 0x0, 0x0, 0x0, 0x0, 0xc4201ccd00, 0xc4201cf368, 0x1)
  /Users/jh/go/src/github.com/grpc-ecosystem/grpc-gateway/runtime/marshal_jsonpb.go:81 +0x59e
github.com/grpc-ecosystem/grpc-gateway/runtime.(*JSONPb).Marshal(0xc420173f80, 0x0, 0x0, 0x1, 0xc4201ccd01, 0x1, 0x0, 0x0)
  /Users/jh/go/src/github.com/grpc-ecosystem/grpc-gateway/runtime/marshal_jsonpb.go:27 +0x16f
github.com/grpc-ecosystem/grpc-gateway/runtime_test.TestJSONPbMarshalFields(0xc4201982d0)
  /Users/jh/go/src/github.com/grpc-ecosystem/grpc-gateway/runtime/marshal_jsonpb_test.go:126 +0xe6
testing.tRunner(0xc4201982d0, 0x15da798)
  /usr/local/go/src/testing/testing.go:746 +0xd0
created by testing.(*T).Run
  /usr/local/go/src/testing/testing.go:789 +0x2de
```