### PR TITLE
Translate gRPC FailedPrecondition as HTTP PreconditionFailed

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -1,10 +1,10 @@
 package runtime
 
 import (
+	"context"
 	"io"
 	"net/http"
 
-	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
@@ -38,7 +38,7 @@ func HTTPStatusFromCode(code codes.Code) int {
 	case codes.ResourceExhausted:
 		return http.StatusTooManyRequests
 	case codes.FailedPrecondition:
-		return http.StatusBadRequest
+		return http.StatusPreconditionFailed
 	case codes.Aborted:
 		return http.StatusConflict
 	case codes.OutOfRange:


### PR DESCRIPTION
After gRPC documentation (https://github.com/grpc/grpc-go/blob/master/codes/codes.go#L87-L91):
> //  (c) Use FailedPrecondition if the client should not retry until
> //      the system state has been explicitly fixed. E.g., if an "rmdir"
> //      fails because the directory is non-empty, FailedPrecondition
> //      should be returned since the client should not retry unless
> //      they have first fixed up the directory by deleting files from it.

Returning HTTP status code 400 (BadRequest) suggets that the problem is caused by the user's input, whereas it should indicate that the system is in an invalid state.