### PR TITLE
Fix path parsing to use URL.EscapedPath() instead of Path and unescape individual components

### DIFF
--- a/protoc-gen-grpc-gateway/httprule/BUILD.bazel
+++ b/protoc-gen-grpc-gateway/httprule/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
-package(default_visibility = ["//:generators"])
+package(default_visibility = ["//:generators", "//runtime:__subpackages__"])
 
 go_library(
     name = "go_default_library",

--- a/runtime/BUILD.bazel
+++ b/runtime/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "//examples/proto/examplepb:go_default_library",
         "//runtime/internal:go_default_library",
         "//utilities:go_default_library",
+        "//protoc-gen-grpc-gateway/httprule:go_default_library",
         "@com_github_golang_protobuf//jsonpb:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library",

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -150,13 +150,7 @@ func (s *ServeMux) Handle(meth string, pat Pattern, h HandlerFunc) {
 func (s *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	var path string
-	if r.URL.RawPath == "" {
-		path = r.URL.Path
-	} else {
-		path = r.URL.RawPath
-	}
-
+	path := r.URL.EscapedPath()
 	if !strings.HasPrefix(path, "/") {
 		if s.protoErrorHandler != nil {
 			_, outboundMarshaler := MarshalerForRequest(s, r)

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -150,7 +150,13 @@ func (s *ServeMux) Handle(meth string, pat Pattern, h HandlerFunc) {
 func (s *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	path := r.URL.RawPath
+	var path string
+	if r.URL.RawPath == "" {
+		path = r.URL.Path
+	} else {
+		path = r.URL.RawPath
+	}
+
 	if !strings.HasPrefix(path, "/") {
 		if s.protoErrorHandler != nil {
 			_, outboundMarshaler := MarshalerForRequest(s, r)


### PR DESCRIPTION
This addresses issue #308.

When parsing the request URL, ServeHTTP() currently uses URL.Path instead of URL.EscapedPath(). This makes it impossible for grpc-gateway to support having slashes `/` in a path even if they are encoded (e.g. http://example.com/some%2Fpath/resource). This change will switch parsing to use URL.EscapedPath(), then unescape the individual components after they have been split by `/`.