### PR TITLE
Bazel expose protoc-gen-grpc-gateway

### DIFF
--- a/protoc-gen-grpc-gateway/BUILD.bazel
+++ b/protoc-gen-grpc-gateway/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
 go_binary(
     name = "protoc-gen-grpc-gateway",
     embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
 )
 
 go_proto_compiler(


### PR DESCRIPTION
Exposes go_binary() rule for protoc-gen-grpc-gateway so dependencies can be vendored for the go_proto_compiler() rule when using //vendor dependencies.