### PR TITLE
gen-swagger: use GetJsonName for struct member names

### DIFF
--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -251,7 +251,7 @@ func renderMessagesAsDefinition(messages messageMap, d swaggerDefinitionsObject,
 				panic(err)
 			}
 
-			schema.Properties = append(schema.Properties, keyVal{f.GetName(), fieldValue})
+			schema.Properties = append(schema.Properties, keyVal{f.GetJsonName(), fieldValue})
 		}
 		d[fullyQualifiedNameToSwaggerName(msg.FQMN(), reg)] = schema
 	}


### PR DESCRIPTION
This PR fixed Swagger definition.

Currently `protoc-gen-swagger` uses `.GetName()` to get a field name.
It's wrong, since proto field `snake_case`'s generated name in `json` tag is `snakeCase` - however, generated swagger still has `snake_case` in the definition. 
`.GetJsonName()` returns field name in the right case and form.