### PR TITLE
Updated doc and comments to reflect Permanent HTTP header keys prefixing

### DIFF
--- a/docs/_docs/usage.md
+++ b/docs/_docs/usage.md
@@ -187,8 +187,7 @@ This parameter can be useful to pass request scoped context between the gateway 
 * [How gRPC error codes map to HTTP status codes in the response](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/runtime/errors.go#L15)
 * HTTP request source IP is added as `X-Forwarded-For` gRPC request header
 * HTTP request host is added as `X-Forwarded-Host` gRPC request header
-* HTTP `Authorization` header is added as `authorization` gRPC request header 
+* HTTP `Authorization` header is added as `authorization` gRPC request header
 * Remaining Permanent HTTP header keys (as specified by the IANA [here](http://www.iana.org/assignments/message-headers/message-headers.xhtml) are prefixed with `grpcgateway-` and added with their values to gRPC request header
-* HTTP headers that start with 'Grpc-Metadata-' are mapped to gRPC metadata (prefixed with `grpcgateway-`)
+* HTTP headers that start with 'Grpc-Metadata-' are mapped to gRPC metadata (after removing prefix 'Grpc-Metadata-')
 * While configurable, the default {un,}marshaling uses [jsonpb](https://godoc.org/github.com/golang/protobuf/jsonpb) with `OrigName: true`.
-

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -19,7 +19,8 @@ import (
 // parameters to or from a gRPC call.
 const MetadataHeaderPrefix = "Grpc-Metadata-"
 
-// MetadataPrefix is the prefix for grpc-gateway supplied custom metadata fields.
+// MetadataPrefix is prepended to permanent HTTP header keys (as specified
+// by the IANA) when added to the gRPC context.
 const MetadataPrefix = "grpcgateway-"
 
 // MetadataTrailerPrefix is prepended to gRPC metadata as it is converted to


### PR DESCRIPTION
When using the grpc-gateway the docs seemed to suggest that if I added a custom header to a HTTP request (using `Grpc-Metadata-` prefix), it would be passed to the gRPC metadata context as `grpcgateway-some-header-key`. 

It is just passed as `some-header-key`, only permanent headers are prefixed.