### PR TITLE
Add test case and proposed fix for path component with trailing colon (and string)

### DIFF
--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"context"
+
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"

--- a/runtime/mux_test.go
+++ b/runtime/mux_test.go
@@ -176,6 +176,38 @@ func TestMuxServeHTTP(t *testing.T) {
 			respStatus:  http.StatusOK,
 			respContent: "POST /foo:bar",
 		},
+		{
+			patterns: []stubPattern{
+				{
+					method: "GET",
+					ops:    []int{int(utilities.OpLitPush), 0, int(utilities.OpPush), 0, int(utilities.OpConcatN), 1, int(utilities.OpCapture), 1},
+					pool:   []string{"foo", "id"},
+				},
+			},
+			reqMethod: "GET",
+			reqPath:   "/foo/bar",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+			},
+			respStatus:  http.StatusOK,
+			respContent: "GET /foo/{id=*}",
+		},
+		{
+			patterns: []stubPattern{
+				{
+					method: "GET",
+					ops:    []int{int(utilities.OpLitPush), 0, int(utilities.OpPush), 0, int(utilities.OpConcatN), 1, int(utilities.OpCapture), 1},
+					pool:   []string{"foo", "id"},
+				},
+			},
+			reqMethod: "GET",
+			reqPath:   "/foo/bar:123",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+			},
+			respStatus:  http.StatusOK,
+			respContent: "GET /foo/{id=*}",
+		},
 	} {
 		mux := runtime.NewServeMux()
 		for _, p := range spec.patterns {

--- a/runtime/pattern.go
+++ b/runtime/pattern.go
@@ -144,7 +144,16 @@ func MustPattern(p Pattern, err error) Pattern {
 // If otherwise, the function returns an error.
 func (p Pattern) Match(components []string, verb string) (map[string]string, error) {
 	if p.verb != verb {
-		return nil, ErrNotMatch
+		if p.verb != "" {
+			return nil, ErrNotMatch
+		}
+		if len(components) == 0 {
+			components = []string{":" + verb}
+		} else {
+			components = append([]string{}, components...)
+			components[len(components)-1] += ":" + verb
+		}
+		verb = ""
 	}
 
 	var pos int


### PR DESCRIPTION
If a pattern has no verb, match with the verb argument appended to last component.

As I understand the implementation, parsing out a "verb" from the input path is a convenience for matching. Whether the colon and string are _actually_ a verb depends on the matching HTTP rule. This change gives a verb-less pattern a chance to match a path by assuming the colon+string suffix are a part of the final component.

There is a backwards compatibility issue here: this can change the behavior of existing rule sets. For example:
```
    option(google.api.http) = {
      get: "/users/{user_id}"
    };
    option(google.api.http) = {
      get: "/users/{user_id}:averb"
    };
```
Before this change, only the second rule matched a request for `/users/123:averb`. After this change, both rules match (correctly, by my understanding of https://github.com/googleapis/googleapis/blob/master/google/api/http.proto). Note that the spec describes a deterministic way of breaking the tie: `// **NOTE:** All service configuration rules follow "last one wins" order.` grpc-ecosystem/grpc-gateway's implementation looks buggy on this score, since it accepts the first matching handler.

Fixes #224
