### PR TITLE
Add message field to the error message emitted by grpc-gateway

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -66,8 +66,9 @@ var (
 
 type errorBody struct {
 	Error   string     `protobuf:"bytes,1,name=error" json:"error"`
-	// This is to make the error more compatible with users that expect errors to be Status objects. It should be
-	// the exact same message as the Error field.
+	// This is to make the error more compatible with users that expect errors to be Status objects:
+	// https://github.com/grpc/grpc/blob/master/src/proto/grpc/status/status.proto
+	// It should be the exact same message as the Error field.
 	Message string     `protobuf:"bytes,1,name=message" json:"message"`
 	Code    int32      `protobuf:"varint,2,name=code" json:"code"`
 	Details []*any.Any `protobuf:"bytes,3,rep,name=details" json:"details,omitempty"`

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -66,6 +66,9 @@ var (
 
 type errorBody struct {
 	Error   string     `protobuf:"bytes,1,name=error" json:"error"`
+  // This is to make the error more compatible with users that expect errors to be Status objects. It should be
+  // the exact same message as the Error field.
+	Message string     `protobuf:"bytes,1,name=message" json:"message"`
 	Code    int32      `protobuf:"varint,2,name=code" json:"code"`
 	Details []*any.Any `protobuf:"bytes,3,rep,name=details" json:"details,omitempty"`
 }
@@ -94,6 +97,7 @@ func DefaultHTTPError(ctx context.Context, mux *ServeMux, marshaler Marshaler, w
 
 	body := &errorBody{
 		Error:   s.Message(),
+		Message: s.Message(),
 		Code:    int32(s.Code()),
 		Details: s.Proto().GetDetails(),
 	}

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -66,8 +66,8 @@ var (
 
 type errorBody struct {
 	Error   string     `protobuf:"bytes,1,name=error" json:"error"`
-  // This is to make the error more compatible with users that expect errors to be Status objects. It should be
-  // the exact same message as the Error field.
+	// This is to make the error more compatible with users that expect errors to be Status objects. It should be
+	// the exact same message as the Error field.
 	Message string     `protobuf:"bytes,1,name=message" json:"message"`
 	Code    int32      `protobuf:"varint,2,name=code" json:"code"`
 	Details []*any.Any `protobuf:"bytes,3,rep,name=details" json:"details,omitempty"`

--- a/runtime/errors_test.go
+++ b/runtime/errors_test.go
@@ -65,6 +65,9 @@ func TestDefaultHTTPError(t *testing.T) {
 		if got, want := body["error"].(string), spec.msg; !strings.Contains(got, want) {
 			t.Errorf(`body["error"] = %q; want %q; on spec.err=%v`, got, want, spec.err)
 		}
+		if got, want := body["message"].(string), spec.msg; !strings.Contains(got, want) {
+			t.Errorf(`body["message"] = %q; want %q; on spec.err=%v`, got, want, spec.err)
+		}
 
 		if spec.details != "" {
 			details, ok := body["details"].([]interface{})


### PR DESCRIPTION
This is to make it more consistent with the Status proto message in order to make the error more consistent between grpc and json.

We currently use grpc-gateway for local developement and ESP in production and having to deal with the message in two different fields is a bit annoying. This makes the behaviour of grpc-gateway a bit more consistent with ESP.