### PR TITLE
Lock versions to tags where possible

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -33,7 +33,7 @@ required = [
 [[constraint]]
   # Also defined in bazelbuild/rules_go
   # https://github.com/bazelbuild/rules_go/blob/436452edc29a2f1e0edc22d180fbb57c27e6d0af/go/private/repositories.bzl#L75
-  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "1.1.0"
   name = "github.com/golang/protobuf"
 
 [[constraint]]
@@ -45,7 +45,7 @@ required = [
 [[constraint]]
   # Also defined in bazelbuild/rules_go
   # https://github.com/bazelbuild/rules_go/blob/436452edc29a2f1e0edc22d180fbb57c27e6d0af/go/private/repositories.bzl#L123
-  revision = "d11072e7ca9811b1100b80ca0269ac831f06d024"
+  version = "1.10.3"
   name = "google.golang.org/grpc"
 
 [[constraint]]


### PR DESCRIPTION
Using an exact revisions in `Gopkg.toml` prevents `dep` from detecting equivalence between constraints in the case where one dependency depends on, for example, golang/protobuf v1.1.0 and another depends on the revision that is tagged with that version. Using tagged versions should help with this.