### PR TITLE
Add missing modules to browser example

### DIFF
--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -18,6 +18,10 @@
     "jasmine": "^2.4.1",
     "phantomjs": "^2.1.7",
     "swagger-client": "^2.1.28",
-    "webpack-stream": "^3.2.0"
+    "webpack-stream": "^3.2.0",
+    "bower-logger": "^0.2.2",
+    "mout": "^1.1.0",
+    "bower-config": "^0.6.2",
+    "configstore": "^4.0.0"
   }
 }


### PR DESCRIPTION
This was failing in CI, hopefully this fixes it. See https://travis-ci.org/grpc-ecosystem/grpc-gateway/jobs/422220360.