### PR TITLE
Add default value for swagger 200 response

### DIFF
--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -694,7 +694,7 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
 				}
 
 				methProtoPath := protoPathIndex(reflect.TypeOf((*pbdescriptor.ServiceDescriptorProto)(nil)), "Method")
-				desc := ""
+				desc := "A successful response."
 				var responseSchema swaggerSchemaObject
 
 				if b.ResponseBody == nil || len(b.ResponseBody.FieldPath) == 0 {


### PR DESCRIPTION
Re: https://github.com/grpc-ecosystem/grpc-gateway/issues/766

This commit adds a default value to the description field of 200
responses. This is needed to meet the swagger specification requirement
of a short description for all response objects.