### PR TITLE
remove message field from the error message emitted by grpc-gateway

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -66,10 +66,6 @@ var (
 
 type errorBody struct {
 	Error   string     `protobuf:"bytes,1,name=error" json:"error"`
-	// This is to make the error more compatible with users that expect errors to be Status objects:
-	// https://github.com/grpc/grpc/blob/master/src/proto/grpc/status/status.proto
-	// It should be the exact same message as the Error field.
-	Message string     `protobuf:"bytes,1,name=message" json:"message"`
 	Code    int32      `protobuf:"varint,2,name=code" json:"code"`
 	Details []*any.Any `protobuf:"bytes,3,rep,name=details" json:"details,omitempty"`
 }
@@ -98,7 +94,6 @@ func DefaultHTTPError(ctx context.Context, mux *ServeMux, marshaler Marshaler, w
 
 	body := &errorBody{
 		Error:   s.Message(),
-		Message: s.Message(),
 		Code:    int32(s.Code()),
 		Details: s.Proto().GetDetails(),
 	}


### PR DESCRIPTION
this is just recovery of the code, the "error" filed is more meaning for than the message

more info: https://github.com/grpc-ecosystem/grpc-gateway/pull/718
