### PR TITLE
fix #782 Cannot return HTTP header using "Grpc-Metadata-" prefix

### DIFF
--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/textproto"
 	"strings"
 
 	"github.com/golang/protobuf/proto"
@@ -50,6 +51,7 @@ type HeaderMatcherFunc func(string) (string, bool)
 // keys (as specified by the IANA) to gRPC context with grpcgateway- prefix. HTTP headers that start with
 // 'Grpc-Metadata-' are mapped to gRPC metadata after removing prefix 'Grpc-Metadata-'.
 func DefaultHeaderMatcher(key string) (string, bool) {
+	key = textproto.CanonicalMIMEHeaderKey(key)
 	if isPermanentHTTPHeader(key) {
 		return MetadataPrefix + key, true
 	} else if strings.HasPrefix(key, MetadataHeaderPrefix) {

--- a/runtime/mux_test.go
+++ b/runtime/mux_test.go
@@ -233,3 +233,43 @@ func TestMuxServeHTTP(t *testing.T) {
 		}
 	}
 }
+
+var defaultHeaderMatcherTests = []struct {
+	name     string
+	in       string
+	outValue string
+	outValid bool
+}{
+	{
+		"permanent HTTP header should return prefixed",
+		"Accept",
+		"grpcgateway-Accept",
+		true,
+	},
+	{
+		"key prefixed with MetadataHeaderPrefix should return without the prefix",
+		"Grpc-Metadata-Custom-Header",
+		"Custom-Header",
+		true,
+	},
+	{
+		"non-permanent HTTP header key without prefix should not return",
+		"Custom-Header",
+		"",
+		false,
+	},
+}
+
+func TestDefaultHeaderMatcher(t *testing.T) {
+	for _, tt := range defaultHeaderMatcherTests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, valid := runtime.DefaultHeaderMatcher(tt.in)
+			if out != tt.outValue {
+				t.Errorf("got %v, want %v", out, tt.outValue)
+			}
+			if valid != tt.outValid {
+				t.Errorf("got %v, want %v", valid, tt.outValid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #728, supercedes #783 