### PR TITLE
Make operationID more unique using svc name + call name

### DIFF
--- a/examples/clients/abe/a_bit_of_everything_service_api.go
+++ b/examples/clients/abe/a_bit_of_everything_service_api.go
@@ -62,7 +62,7 @@ func NewABitOfEverythingServiceApiWithBasePath(basePath string) *ABitOfEverythin
  * @param nestedPathEnumValue 
  * @return *ExamplepbABitOfEverything
  */
-func (a ABitOfEverythingServiceApi) Create(floatValue float32, doubleValue float64, int64Value string, uint64Value string, int32Value int32, fixed64Value string, fixed32Value int64, boolValue bool, stringValue string, uint32Value int64, sfixed32Value int32, sfixed64Value string, sint32Value int32, sint64Value string, nonConventionalNameValue string, enumValue string, pathEnumValue string, nestedPathEnumValue string) (*ExamplepbABitOfEverything, *APIResponse, error) {
+func (a ABitOfEverythingServiceApi) ABitOfEverythingServiceCreate(floatValue float32, doubleValue float64, int64Value string, uint64Value string, int32Value int32, fixed64Value string, fixed32Value int64, boolValue bool, stringValue string, uint32Value int64, sfixed32Value int32, sfixed64Value string, sint32Value int32, sint64Value string, nonConventionalNameValue string, enumValue string, pathEnumValue string, nestedPathEnumValue string) (*ExamplepbABitOfEverything, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Post")
 	// create path and map variables
@@ -134,7 +134,7 @@ func (a ABitOfEverythingServiceApi) Create(floatValue float32, doubleValue float
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Create", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServiceCreate", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -153,7 +153,7 @@ func (a ABitOfEverythingServiceApi) Create(floatValue float32, doubleValue float
  * @param body 
  * @return *ExamplepbABitOfEverything
  */
-func (a ABitOfEverythingServiceApi) CreateBody(body ExamplepbABitOfEverything) (*ExamplepbABitOfEverything, *APIResponse, error) {
+func (a ABitOfEverythingServiceApi) ABitOfEverythingServiceCreateBody(body ExamplepbABitOfEverything) (*ExamplepbABitOfEverything, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Post")
 	// create path and map variables
@@ -209,7 +209,7 @@ func (a ABitOfEverythingServiceApi) CreateBody(body ExamplepbABitOfEverything) (
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "CreateBody", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServiceCreateBody", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -229,7 +229,7 @@ func (a ABitOfEverythingServiceApi) CreateBody(body ExamplepbABitOfEverything) (
  * @param body 
  * @return *ExamplepbABitOfEverything
  */
-func (a ABitOfEverythingServiceApi) DeepPathEcho(singleNestedName string, body ExamplepbABitOfEverything) (*ExamplepbABitOfEverything, *APIResponse, error) {
+func (a ABitOfEverythingServiceApi) ABitOfEverythingServiceDeepPathEcho(singleNestedName string, body ExamplepbABitOfEverything) (*ExamplepbABitOfEverything, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Post")
 	// create path and map variables
@@ -286,7 +286,7 @@ func (a ABitOfEverythingServiceApi) DeepPathEcho(singleNestedName string, body E
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "DeepPathEcho", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServiceDeepPathEcho", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -305,7 +305,7 @@ func (a ABitOfEverythingServiceApi) DeepPathEcho(singleNestedName string, body E
  * @param uuid 
  * @return *ProtobufEmpty
  */
-func (a ABitOfEverythingServiceApi) Delete(uuid string) (*ProtobufEmpty, *APIResponse, error) {
+func (a ABitOfEverythingServiceApi) ABitOfEverythingServiceDelete(uuid string) (*ProtobufEmpty, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Delete")
 	// create path and map variables
@@ -355,7 +355,7 @@ func (a ABitOfEverythingServiceApi) Delete(uuid string) (*ProtobufEmpty, *APIRes
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Delete", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServiceDelete", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -373,7 +373,7 @@ func (a ABitOfEverythingServiceApi) Delete(uuid string) (*ProtobufEmpty, *APIRes
  *
  * @return *ProtobufEmpty
  */
-func (a ABitOfEverythingServiceApi) ErrorWithDetails() (*ProtobufEmpty, *APIResponse, error) {
+func (a ABitOfEverythingServiceApi) ABitOfEverythingServiceErrorWithDetails() (*ProtobufEmpty, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -427,7 +427,7 @@ func (a ABitOfEverythingServiceApi) ErrorWithDetails() (*ProtobufEmpty, *APIResp
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "ErrorWithDetails", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServiceErrorWithDetails", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -447,7 +447,7 @@ func (a ABitOfEverythingServiceApi) ErrorWithDetails() (*ProtobufEmpty, *APIResp
  * @param body 
  * @return *ProtobufEmpty
  */
-func (a ABitOfEverythingServiceApi) GetMessageWithBody(id string, body ExamplepbBody) (*ProtobufEmpty, *APIResponse, error) {
+func (a ABitOfEverythingServiceApi) ABitOfEverythingServiceGetMessageWithBody(id string, body ExamplepbBody) (*ProtobufEmpty, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Post")
 	// create path and map variables
@@ -504,7 +504,7 @@ func (a ABitOfEverythingServiceApi) GetMessageWithBody(id string, body Examplepb
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "GetMessageWithBody", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServiceGetMessageWithBody", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -549,7 +549,7 @@ func (a ABitOfEverythingServiceApi) GetMessageWithBody(id string, body Examplepb
  * @param repeatedEnumValue repeated enum value. it is comma-separated in query.   - ZERO: ZERO means 0  - ONE: ONE means 1
  * @return *ProtobufEmpty
  */
-func (a ABitOfEverythingServiceApi) GetQuery(uuid string, singleNestedName string, singleNestedAmount int64, singleNestedOk string, floatValue float32, doubleValue float64, int64Value string, uint64Value string, int32Value int32, fixed64Value string, fixed32Value int64, boolValue bool, stringValue string, bytesValue string, uint32Value int64, enumValue string, pathEnumValue string, nestedPathEnumValue string, sfixed32Value int32, sfixed64Value string, sint32Value int32, sint64Value string, repeatedStringValue []string, oneofString string, nonConventionalNameValue string, timestampValue time.Time, repeatedEnumValue []string) (*ProtobufEmpty, *APIResponse, error) {
+func (a ABitOfEverythingServiceApi) ABitOfEverythingServiceGetQuery(uuid string, singleNestedName string, singleNestedAmount int64, singleNestedOk string, floatValue float32, doubleValue float64, int64Value string, uint64Value string, int32Value int32, fixed64Value string, fixed32Value int64, boolValue bool, stringValue string, bytesValue string, uint32Value int64, enumValue string, pathEnumValue string, nestedPathEnumValue string, sfixed32Value int32, sfixed64Value string, sint32Value int32, sint64Value string, repeatedStringValue []string, oneofString string, nonConventionalNameValue string, timestampValue time.Time, repeatedEnumValue []string) (*ProtobufEmpty, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -621,7 +621,7 @@ func (a ABitOfEverythingServiceApi) GetQuery(uuid string, singleNestedName strin
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "GetQuery", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServiceGetQuery", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -655,7 +655,7 @@ func (a ABitOfEverythingServiceApi) GetQuery(uuid string, singleNestedName strin
  * @param pathRepeatedSint64Value 
  * @return *ExamplepbABitOfEverythingRepeated
  */
-func (a ABitOfEverythingServiceApi) GetRepeatedQuery(pathRepeatedFloatValue []float32, pathRepeatedDoubleValue []float64, pathRepeatedInt64Value []string, pathRepeatedUint64Value []string, pathRepeatedInt32Value []int32, pathRepeatedFixed64Value []string, pathRepeatedFixed32Value []int64, pathRepeatedBoolValue []bool, pathRepeatedStringValue []string, pathRepeatedBytesValue []string, pathRepeatedUint32Value []int64, pathRepeatedEnumValue []string, pathRepeatedSfixed32Value []int32, pathRepeatedSfixed64Value []string, pathRepeatedSint32Value []int32, pathRepeatedSint64Value []string) (*ExamplepbABitOfEverythingRepeated, *APIResponse, error) {
+func (a ABitOfEverythingServiceApi) ABitOfEverythingServiceGetRepeatedQuery(pathRepeatedFloatValue []float32, pathRepeatedDoubleValue []float64, pathRepeatedInt64Value []string, pathRepeatedUint64Value []string, pathRepeatedInt32Value []int32, pathRepeatedFixed64Value []string, pathRepeatedFixed32Value []int64, pathRepeatedBoolValue []bool, pathRepeatedStringValue []string, pathRepeatedBytesValue []string, pathRepeatedUint32Value []int64, pathRepeatedEnumValue []string, pathRepeatedSfixed32Value []int32, pathRepeatedSfixed64Value []string, pathRepeatedSint32Value []int32, pathRepeatedSint64Value []string) (*ExamplepbABitOfEverythingRepeated, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -725,7 +725,7 @@ func (a ABitOfEverythingServiceApi) GetRepeatedQuery(pathRepeatedFloatValue []fl
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "GetRepeatedQuery", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServiceGetRepeatedQuery", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -744,7 +744,7 @@ func (a ABitOfEverythingServiceApi) GetRepeatedQuery(pathRepeatedFloatValue []fl
  * @param uuid 
  * @return *ExamplepbABitOfEverything
  */
-func (a ABitOfEverythingServiceApi) Lookup(uuid string) (*ExamplepbABitOfEverything, *APIResponse, error) {
+func (a ABitOfEverythingServiceApi) ABitOfEverythingServiceLookup(uuid string) (*ExamplepbABitOfEverything, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -799,7 +799,7 @@ func (a ABitOfEverythingServiceApi) Lookup(uuid string) (*ExamplepbABitOfEveryth
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Lookup", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServiceLookup", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -819,7 +819,7 @@ func (a ABitOfEverythingServiceApi) Lookup(uuid string) (*ExamplepbABitOfEveryth
  * @param body 
  * @return *ProtobufEmpty
  */
-func (a ABitOfEverythingServiceApi) PostWithEmptyBody(name string, body ExamplepbBody) (*ProtobufEmpty, *APIResponse, error) {
+func (a ABitOfEverythingServiceApi) ABitOfEverythingServicePostWithEmptyBody(name string, body ExamplepbBody) (*ProtobufEmpty, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Post")
 	// create path and map variables
@@ -876,7 +876,7 @@ func (a ABitOfEverythingServiceApi) PostWithEmptyBody(name string, body Examplep
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "PostWithEmptyBody", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServicePostWithEmptyBody", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -894,7 +894,7 @@ func (a ABitOfEverythingServiceApi) PostWithEmptyBody(name string, body Examplep
  *
  * @return *ProtobufEmpty
  */
-func (a ABitOfEverythingServiceApi) Timeout() (*ProtobufEmpty, *APIResponse, error) {
+func (a ABitOfEverythingServiceApi) ABitOfEverythingServiceTimeout() (*ProtobufEmpty, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -948,7 +948,7 @@ func (a ABitOfEverythingServiceApi) Timeout() (*ProtobufEmpty, *APIResponse, err
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Timeout", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServiceTimeout", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -968,7 +968,7 @@ func (a ABitOfEverythingServiceApi) Timeout() (*ProtobufEmpty, *APIResponse, err
  * @param body 
  * @return *ProtobufEmpty
  */
-func (a ABitOfEverythingServiceApi) Update(uuid string, body ExamplepbABitOfEverything) (*ProtobufEmpty, *APIResponse, error) {
+func (a ABitOfEverythingServiceApi) ABitOfEverythingServiceUpdate(uuid string, body ExamplepbABitOfEverything) (*ProtobufEmpty, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Put")
 	// create path and map variables
@@ -1025,7 +1025,7 @@ func (a ABitOfEverythingServiceApi) Update(uuid string, body ExamplepbABitOfEver
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Update", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServiceUpdate", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()

--- a/examples/clients/abe/camel_case_service_name_api.go
+++ b/examples/clients/abe/camel_case_service_name_api.go
@@ -42,7 +42,7 @@ func NewCamelCaseServiceNameApiWithBasePath(basePath string) *CamelCaseServiceNa
  *
  * @return *ProtobufEmpty
  */
-func (a CamelCaseServiceNameApi) Empty() (*ProtobufEmpty, *APIResponse, error) {
+func (a CamelCaseServiceNameApi) CamelCaseServiceNameEmpty() (*ProtobufEmpty, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -96,7 +96,7 @@ func (a CamelCaseServiceNameApi) Empty() (*ProtobufEmpty, *APIResponse, error) {
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Empty", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "CamelCaseServiceNameEmpty", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()

--- a/examples/clients/abe/echo_rpc_api.go
+++ b/examples/clients/abe/echo_rpc_api.go
@@ -44,7 +44,7 @@ func NewEchoRpcApiWithBasePath(basePath string) *EchoRpcApi {
  * @param value 
  * @return *SubStringMessage
  */
-func (a EchoRpcApi) Echo(value string) (*SubStringMessage, *APIResponse, error) {
+func (a EchoRpcApi) ABitOfEverythingServiceEcho(value string) (*SubStringMessage, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -99,7 +99,7 @@ func (a EchoRpcApi) Echo(value string) (*SubStringMessage, *APIResponse, error) 
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Echo", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServiceEcho", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -119,7 +119,7 @@ func (a EchoRpcApi) Echo(value string) (*SubStringMessage, *APIResponse, error) 
  * @param body 
  * @return *SubStringMessage
  */
-func (a EchoRpcApi) Echo2(body string) (*SubStringMessage, *APIResponse, error) {
+func (a EchoRpcApi) ABitOfEverythingServiceEcho2(body string) (*SubStringMessage, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Post")
 	// create path and map variables
@@ -175,7 +175,7 @@ func (a EchoRpcApi) Echo2(body string) (*SubStringMessage, *APIResponse, error) 
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Echo2", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServiceEcho2", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -195,7 +195,7 @@ func (a EchoRpcApi) Echo2(body string) (*SubStringMessage, *APIResponse, error) 
  * @param value 
  * @return *SubStringMessage
  */
-func (a EchoRpcApi) Echo3(value string) (*SubStringMessage, *APIResponse, error) {
+func (a EchoRpcApi) ABitOfEverythingServiceEcho3(value string) (*SubStringMessage, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -250,7 +250,7 @@ func (a EchoRpcApi) Echo3(value string) (*SubStringMessage, *APIResponse, error)
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Echo3", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServiceEcho3", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()

--- a/examples/clients/abe/echo_service_api.go
+++ b/examples/clients/abe/echo_service_api.go
@@ -44,7 +44,7 @@ func NewEchoServiceApiWithBasePath(basePath string) *EchoServiceApi {
  * @param value 
  * @return *SubStringMessage
  */
-func (a EchoServiceApi) Echo(value string) (*SubStringMessage, *APIResponse, error) {
+func (a EchoServiceApi) ABitOfEverythingServiceEcho(value string) (*SubStringMessage, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -99,7 +99,7 @@ func (a EchoServiceApi) Echo(value string) (*SubStringMessage, *APIResponse, err
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Echo", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServiceEcho", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -119,7 +119,7 @@ func (a EchoServiceApi) Echo(value string) (*SubStringMessage, *APIResponse, err
  * @param body 
  * @return *SubStringMessage
  */
-func (a EchoServiceApi) Echo2(body string) (*SubStringMessage, *APIResponse, error) {
+func (a EchoServiceApi) ABitOfEverythingServiceEcho2(body string) (*SubStringMessage, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Post")
 	// create path and map variables
@@ -175,7 +175,7 @@ func (a EchoServiceApi) Echo2(body string) (*SubStringMessage, *APIResponse, err
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Echo2", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServiceEcho2", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -195,7 +195,7 @@ func (a EchoServiceApi) Echo2(body string) (*SubStringMessage, *APIResponse, err
  * @param value 
  * @return *SubStringMessage
  */
-func (a EchoServiceApi) Echo3(value string) (*SubStringMessage, *APIResponse, error) {
+func (a EchoServiceApi) ABitOfEverythingServiceEcho3(value string) (*SubStringMessage, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -250,7 +250,7 @@ func (a EchoServiceApi) Echo3(value string) (*SubStringMessage, *APIResponse, er
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Echo3", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ABitOfEverythingServiceEcho3", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()

--- a/examples/clients/echo/echo_service_api.go
+++ b/examples/clients/echo/echo_service_api.go
@@ -44,7 +44,7 @@ func NewEchoServiceApiWithBasePath(basePath string) *EchoServiceApi {
  * @param id Id represents the message identifier.
  * @return *ExamplepbSimpleMessage
  */
-func (a EchoServiceApi) Echo(id string) (*ExamplepbSimpleMessage, *APIResponse, error) {
+func (a EchoServiceApi) EchoServiceEcho(id string) (*ExamplepbSimpleMessage, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Post")
 	// create path and map variables
@@ -85,7 +85,7 @@ func (a EchoServiceApi) Echo(id string) (*ExamplepbSimpleMessage, *APIResponse, 
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Echo", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "EchoServiceEcho", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -113,7 +113,7 @@ func (a EchoServiceApi) Echo(id string) (*ExamplepbSimpleMessage, *APIResponse, 
  * @param noNote 
  * @return *ExamplepbSimpleMessage
  */
-func (a EchoServiceApi) Echo2(id string, num string, lineNum string, lang string, statusProgress string, statusNote string, en string, noProgress string, noNote string) (*ExamplepbSimpleMessage, *APIResponse, error) {
+func (a EchoServiceApi) EchoServiceEcho2(id string, num string, lineNum string, lang string, statusProgress string, statusNote string, en string, noProgress string, noNote string) (*ExamplepbSimpleMessage, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -162,7 +162,7 @@ func (a EchoServiceApi) Echo2(id string, num string, lineNum string, lang string
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Echo2", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "EchoServiceEcho2", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -190,7 +190,7 @@ func (a EchoServiceApi) Echo2(id string, num string, lineNum string, lang string
  * @param noNote 
  * @return *ExamplepbSimpleMessage
  */
-func (a EchoServiceApi) Echo3(id string, num string, lang string, lineNum string, statusProgress string, statusNote string, en string, noProgress string, noNote string) (*ExamplepbSimpleMessage, *APIResponse, error) {
+func (a EchoServiceApi) EchoServiceEcho3(id string, num string, lang string, lineNum string, statusProgress string, statusNote string, en string, noProgress string, noNote string) (*ExamplepbSimpleMessage, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -239,7 +239,7 @@ func (a EchoServiceApi) Echo3(id string, num string, lang string, lineNum string
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Echo3", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "EchoServiceEcho3", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -266,7 +266,7 @@ func (a EchoServiceApi) Echo3(id string, num string, lang string, lineNum string
  * @param noProgress 
  * @return *ExamplepbSimpleMessage
  */
-func (a EchoServiceApi) Echo4(id string, lineNum string, statusNote string, num string, lang string, statusProgress string, en string, noProgress string) (*ExamplepbSimpleMessage, *APIResponse, error) {
+func (a EchoServiceApi) EchoServiceEcho4(id string, lineNum string, statusNote string, num string, lang string, statusProgress string, en string, noProgress string) (*ExamplepbSimpleMessage, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -314,7 +314,7 @@ func (a EchoServiceApi) Echo4(id string, lineNum string, statusNote string, num 
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Echo4", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "EchoServiceEcho4", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -341,7 +341,7 @@ func (a EchoServiceApi) Echo4(id string, lineNum string, statusNote string, num 
  * @param noProgress 
  * @return *ExamplepbSimpleMessage
  */
-func (a EchoServiceApi) Echo5(noNote string, id string, num string, lineNum string, lang string, statusProgress string, en string, noProgress string) (*ExamplepbSimpleMessage, *APIResponse, error) {
+func (a EchoServiceApi) EchoServiceEcho5(noNote string, id string, num string, lineNum string, lang string, statusProgress string, en string, noProgress string) (*ExamplepbSimpleMessage, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -389,7 +389,7 @@ func (a EchoServiceApi) Echo5(noNote string, id string, num string, lineNum stri
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Echo5", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "EchoServiceEcho5", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -408,7 +408,7 @@ func (a EchoServiceApi) Echo5(noNote string, id string, num string, lineNum stri
  * @param body 
  * @return *ExamplepbSimpleMessage
  */
-func (a EchoServiceApi) EchoBody(body ExamplepbSimpleMessage) (*ExamplepbSimpleMessage, *APIResponse, error) {
+func (a EchoServiceApi) EchoServiceEchoBody(body ExamplepbSimpleMessage) (*ExamplepbSimpleMessage, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Post")
 	// create path and map variables
@@ -450,7 +450,7 @@ func (a EchoServiceApi) EchoBody(body ExamplepbSimpleMessage) (*ExamplepbSimpleM
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "EchoBody", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "EchoServiceEchoBody", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -477,7 +477,7 @@ func (a EchoServiceApi) EchoBody(body ExamplepbSimpleMessage) (*ExamplepbSimpleM
  * @param noNote 
  * @return *ExamplepbSimpleMessage
  */
-func (a EchoServiceApi) EchoDelete(id string, num string, lineNum string, lang string, statusProgress string, statusNote string, en string, noProgress string, noNote string) (*ExamplepbSimpleMessage, *APIResponse, error) {
+func (a EchoServiceApi) EchoServiceEchoDelete(id string, num string, lineNum string, lang string, statusProgress string, statusNote string, en string, noProgress string, noNote string) (*ExamplepbSimpleMessage, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Delete")
 	// create path and map variables
@@ -526,7 +526,7 @@ func (a EchoServiceApi) EchoDelete(id string, num string, lineNum string, lang s
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "EchoDelete", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "EchoServiceEchoDelete", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()

--- a/examples/clients/responsebody/docs/ResponseBodyServiceApi.md
+++ b/examples/clients/responsebody/docs/ResponseBodyServiceApi.md
@@ -4,11 +4,11 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**GetResponseBody**](ResponseBodyServiceApi.md#GetResponseBody) | **Get** /responsebody/{data} | 
+[**ResponseBodyServiceGetResponseBody**](ResponseBodyServiceApi.md#ResponseBodyServiceGetResponseBody) | **Get** /responsebody/{data} | 
 
 
-# **GetResponseBody**
-> ExamplepbResponseBodyOutResponse GetResponseBody($data)
+# **ResponseBodyServiceGetResponseBody**
+> ExamplepbResponseBodyOutResponse ResponseBodyServiceGetResponseBody($data)
 
 
 

--- a/examples/clients/responsebody/response_body_service_api.go
+++ b/examples/clients/responsebody/response_body_service_api.go
@@ -43,7 +43,7 @@ func NewResponseBodyServiceApiWithBasePath(basePath string) *ResponseBodyService
  * @param data 
  * @return *ExamplepbResponseBodyOutResponse
  */
-func (a ResponseBodyServiceApi) GetResponseBody(data string) (*ExamplepbResponseBodyOutResponse, *APIResponse, error) {
+func (a ResponseBodyServiceApi) ResponseBodyServiceGetResponseBody(data string) (*ExamplepbResponseBodyOutResponse, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -84,7 +84,7 @@ func (a ResponseBodyServiceApi) GetResponseBody(data string) (*ExamplepbResponse
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "GetResponseBody", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "ResponseBodyServiceGetResponseBody", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()

--- a/examples/clients/unannotatedecho/unannotated_echo_service_api.go
+++ b/examples/clients/unannotatedecho/unannotated_echo_service_api.go
@@ -44,7 +44,7 @@ func NewUnannotatedEchoServiceApiWithBasePath(basePath string) *UnannotatedEchoS
  * @param id Id represents the message identifier.
  * @return *ExamplepbUnannotatedSimpleMessage
  */
-func (a UnannotatedEchoServiceApi) Echo(id string) (*ExamplepbUnannotatedSimpleMessage, *APIResponse, error) {
+func (a UnannotatedEchoServiceApi) UnannotatedEchoServiceEcho(id string) (*ExamplepbUnannotatedSimpleMessage, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Post")
 	// create path and map variables
@@ -85,7 +85,7 @@ func (a UnannotatedEchoServiceApi) Echo(id string) (*ExamplepbUnannotatedSimpleM
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Echo", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "UnannotatedEchoServiceEcho", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -107,7 +107,7 @@ func (a UnannotatedEchoServiceApi) Echo(id string) (*ExamplepbUnannotatedSimpleM
  * @param duration 
  * @return *ExamplepbUnannotatedSimpleMessage
  */
-func (a UnannotatedEchoServiceApi) Echo2(id string, num string, duration string) (*ExamplepbUnannotatedSimpleMessage, *APIResponse, error) {
+func (a UnannotatedEchoServiceApi) UnannotatedEchoServiceEcho2(id string, num string, duration string) (*ExamplepbUnannotatedSimpleMessage, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -150,7 +150,7 @@ func (a UnannotatedEchoServiceApi) Echo2(id string, num string, duration string)
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "Echo2", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "UnannotatedEchoServiceEcho2", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -169,7 +169,7 @@ func (a UnannotatedEchoServiceApi) Echo2(id string, num string, duration string)
  * @param body 
  * @return *ExamplepbUnannotatedSimpleMessage
  */
-func (a UnannotatedEchoServiceApi) EchoBody(body ExamplepbUnannotatedSimpleMessage) (*ExamplepbUnannotatedSimpleMessage, *APIResponse, error) {
+func (a UnannotatedEchoServiceApi) UnannotatedEchoServiceEchoBody(body ExamplepbUnannotatedSimpleMessage) (*ExamplepbUnannotatedSimpleMessage, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Post")
 	// create path and map variables
@@ -211,7 +211,7 @@ func (a UnannotatedEchoServiceApi) EchoBody(body ExamplepbUnannotatedSimpleMessa
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "EchoBody", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "UnannotatedEchoServiceEchoBody", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()
@@ -232,7 +232,7 @@ func (a UnannotatedEchoServiceApi) EchoBody(body ExamplepbUnannotatedSimpleMessa
  * @param duration 
  * @return *ExamplepbUnannotatedSimpleMessage
  */
-func (a UnannotatedEchoServiceApi) EchoDelete(id string, num string, duration string) (*ExamplepbUnannotatedSimpleMessage, *APIResponse, error) {
+func (a UnannotatedEchoServiceApi) UnannotatedEchoServiceEchoDelete(id string, num string, duration string) (*ExamplepbUnannotatedSimpleMessage, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Delete")
 	// create path and map variables
@@ -275,7 +275,7 @@ func (a UnannotatedEchoServiceApi) EchoDelete(id string, num string, duration st
 
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
-	var localVarAPIResponse = &APIResponse{Operation: "EchoDelete", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
+	var localVarAPIResponse = &APIResponse{Operation: "UnannotatedEchoServiceEchoDelete", Method: localVarHttpMethod, RequestURL: localVarURL.String()}
 	if localVarHttpResponse != nil {
 		localVarAPIResponse.Response = localVarHttpResponse.RawResponse
 		localVarAPIResponse.Payload = localVarHttpResponse.Body()

--- a/examples/proto/examplepb/a_bit_of_everything.swagger.json
+++ b/examples/proto/examplepb/a_bit_of_everything.swagger.json
@@ -25,7 +25,7 @@
   "paths": {
     "/v1/example/a_bit_of_everything": {
       "post": {
-        "operationId": "CreateBody",
+        "operationId": "ABitOfEverythingService.CreateBody",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -69,7 +69,7 @@
       "get": {
         "summary": "Summary: Echo rpc",
         "description": "Description Echo",
-        "operationId": "Echo",
+        "operationId": "ABitOfEverythingService.Echo",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -119,7 +119,7 @@
     },
     "/v1/example/a_bit_of_everything/query/{uuid}": {
       "get": {
-        "operationId": "GetQuery",
+        "operationId": "ABitOfEverythingService.GetQuery",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -373,7 +373,7 @@
       "post": {
         "summary": "Create a new ABitOfEverything",
         "description": "This API creates a new ABitOfEverything",
-        "operationId": "Create",
+        "operationId": "ABitOfEverythingService.Create",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -540,7 +540,7 @@
     },
     "/v1/example/a_bit_of_everything/{single_nested.name}": {
       "post": {
-        "operationId": "DeepPathEcho",
+        "operationId": "ABitOfEverythingService.DeepPathEcho",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -589,7 +589,7 @@
     },
     "/v1/example/a_bit_of_everything/{uuid}": {
       "get": {
-        "operationId": "Lookup",
+        "operationId": "ABitOfEverythingService.Lookup",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -627,7 +627,7 @@
         ]
       },
       "delete": {
-        "operationId": "Delete",
+        "operationId": "ABitOfEverythingService.Delete",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -674,7 +674,7 @@
         ]
       },
       "put": {
-        "operationId": "Update",
+        "operationId": "ABitOfEverythingService.Update",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -722,7 +722,7 @@
     },
     "/v1/example/a_bit_of_everything_repeated/{path_repeated_float_value}/{path_repeated_double_value}/{path_repeated_int64_value}/{path_repeated_uint64_value}/{path_repeated_int32_value}/{path_repeated_fixed64_value}/{path_repeated_fixed32_value}/{path_repeated_bool_value}/{path_repeated_string_value}/{path_repeated_bytes_value}/{path_repeated_uint32_value}/{path_repeated_enum_value}/{path_repeated_sfixed32_value}/{path_repeated_sfixed64_value}/{path_repeated_sint32_value}/{path_repeated_sint64_value}": {
       "get": {
-        "operationId": "GetRepeatedQuery",
+        "operationId": "ABitOfEverythingService.GetRepeatedQuery",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -953,7 +953,7 @@
       "get": {
         "summary": "Summary: Echo rpc",
         "description": "Description Echo",
-        "operationId": "Echo3",
+        "operationId": "ABitOfEverythingService.Echo3",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1003,7 +1003,7 @@
       "post": {
         "summary": "Summary: Echo rpc",
         "description": "Description Echo",
-        "operationId": "Echo2",
+        "operationId": "ABitOfEverythingService.Echo2",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1057,7 +1057,7 @@
       "get": {
         "summary": "Create a new ABitOfEverything",
         "description": "This API creates a new ABitOfEverything",
-        "operationId": "Empty",
+        "operationId": "camelCaseServiceName.Empty",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1089,7 +1089,7 @@
     },
     "/v2/example/errorwithdetails": {
       "get": {
-        "operationId": "ErrorWithDetails",
+        "operationId": "ABitOfEverythingService.ErrorWithDetails",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1121,7 +1121,7 @@
     },
     "/v2/example/postwithemptybody/{name}": {
       "post": {
-        "operationId": "PostWithEmptyBody",
+        "operationId": "ABitOfEverythingService.PostWithEmptyBody",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1169,7 +1169,7 @@
     },
     "/v2/example/timeout": {
       "get": {
-        "operationId": "Timeout",
+        "operationId": "ABitOfEverythingService.Timeout",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1201,7 +1201,7 @@
     },
     "/v2/example/withbody/{id}": {
       "post": {
-        "operationId": "GetMessageWithBody",
+        "operationId": "ABitOfEverythingService.GetMessageWithBody",
         "responses": {
           "200": {
             "description": "A successful response.",

--- a/examples/proto/examplepb/echo_service.swagger.json
+++ b/examples/proto/examplepb/echo_service.swagger.json
@@ -20,7 +20,7 @@
       "post": {
         "summary": "Echo method receives a simple message and returns it.",
         "description": "The message posted as the id parameter will also be\nreturned.",
-        "operationId": "Echo",
+        "operationId": "EchoService.Echo",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -47,7 +47,7 @@
       "get": {
         "summary": "Echo method receives a simple message and returns it.",
         "description": "The message posted as the id parameter will also be\nreturned.",
-        "operationId": "Echo2",
+        "operationId": "EchoService.Echo2",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -127,7 +127,7 @@
       "get": {
         "summary": "Echo method receives a simple message and returns it.",
         "description": "The message posted as the id parameter will also be\nreturned.",
-        "operationId": "Echo3",
+        "operationId": "EchoService.Echo3",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -207,7 +207,7 @@
       "get": {
         "summary": "Echo method receives a simple message and returns it.",
         "description": "The message posted as the id parameter will also be\nreturned.",
-        "operationId": "Echo4",
+        "operationId": "EchoService.Echo4",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -281,7 +281,7 @@
       "get": {
         "summary": "Echo method receives a simple message and returns it.",
         "description": "The message posted as the id parameter will also be\nreturned.",
-        "operationId": "Echo5",
+        "operationId": "EchoService.Echo5",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -354,7 +354,7 @@
     "/v1/example/echo_body": {
       "post": {
         "summary": "EchoBody method receives a simple message and returns it.",
-        "operationId": "EchoBody",
+        "operationId": "EchoService.EchoBody",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -381,7 +381,7 @@
     "/v1/example/echo_delete": {
       "delete": {
         "summary": "EchoDelete method receives a simple message and returns it.",
-        "operationId": "EchoDelete",
+        "operationId": "EchoService.EchoDelete",
         "responses": {
           "200": {
             "description": "A successful response.",

--- a/examples/proto/examplepb/response_body_service.swagger.json
+++ b/examples/proto/examplepb/response_body_service.swagger.json
@@ -17,7 +17,7 @@
   "paths": {
     "/responsebody/{data}": {
       "get": {
-        "operationId": "GetResponseBody",
+        "operationId": "ResponseBodyService.GetResponseBody",
         "responses": {
           "200": {
             "description": "",

--- a/examples/proto/examplepb/unannotated_echo_service.swagger.json
+++ b/examples/proto/examplepb/unannotated_echo_service.swagger.json
@@ -20,7 +20,7 @@
       "post": {
         "summary": "Echo method receives a simple message and returns it.",
         "description": "The message posted as the id parameter will also be\nreturned.",
-        "operationId": "Echo",
+        "operationId": "UnannotatedEchoService.Echo",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -47,7 +47,7 @@
       "get": {
         "summary": "Echo method receives a simple message and returns it.",
         "description": "The message posted as the id parameter will also be\nreturned.",
-        "operationId": "Echo2",
+        "operationId": "UnannotatedEchoService.Echo2",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -86,7 +86,7 @@
     "/v1/example/echo_body": {
       "post": {
         "summary": "EchoBody method receives a simple message and returns it.",
-        "operationId": "EchoBody",
+        "operationId": "UnannotatedEchoService.EchoBody",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -113,7 +113,7 @@
     "/v1/example/echo_delete": {
       "delete": {
         "summary": "EchoDelete method receives a simple message and returns it.",
-        "operationId": "EchoDelete",
+        "operationId": "UnannotatedEchoService.EchoDelete",
         "responses": {
           "200": {
             "description": "A successful response.",

--- a/examples/proto/examplepb/wrappers.swagger.json
+++ b/examples/proto/examplepb/wrappers.swagger.json
@@ -17,7 +17,7 @@
   "paths": {
     "/v1/example/wrappers": {
       "post": {
-        "operationId": "Create",
+        "operationId": "WrappersService.Create",
         "responses": {
           "200": {
             "description": "A successful response.",

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -727,10 +727,10 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
 					},
 				}
 				if bIdx == 0 {
-					operationObject.OperationID = fmt.Sprintf("%s", meth.GetName())
+					operationObject.OperationID = fmt.Sprintf("%s.%s", svc.GetName(), meth.GetName())
 				} else {
 					// OperationID must be unique in an OpenAPI v2 definition.
-					operationObject.OperationID = fmt.Sprintf("%s%d", meth.GetName(), bIdx+1)
+					operationObject.OperationID = fmt.Sprintf("%s.%s%d", svc.GetName(), meth.GetName(), bIdx+1)
 				}
 
 				// Fill reference map with referenced request messages


### PR DESCRIPTION
Following the discussion on the issue #739 
The OperationID could be more unique by default.
Ie. when a .proto is containing multiple CRUD services, operationID is duplicated in each service.
