### PR TITLE
ci: add job for building binaries for releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: "jfbrandhorst/grpc-gateway-build-env"
+      - image: jfbrandhorst/grpc-gateway-build-env
     working_directory: /go/src/github.com/grpc-ecosystem/grpc-gateway
     steps:
       - checkout
@@ -10,7 +10,7 @@ jobs:
       - run: go build ./...
   test:
     docker:
-      - image: "jfbrandhorst/grpc-gateway-build-env"
+      - image: jfbrandhorst/grpc-gateway-build-env
     working_directory: /go/src/github.com/grpc-ecosystem/grpc-gateway
     environment:
       GLOG_logtostderr: "1"
@@ -21,7 +21,7 @@ jobs:
       - run: bash <(curl -s https://codecov.io/bash)
   node_test:
     docker:
-      - image: "jfbrandhorst/grpc-gateway-build-env"
+      - image: jfbrandhorst/grpc-gateway-build-env
     working_directory: /go/src/github.com/grpc-ecosystem/grpc-gateway
     steps:
       - checkout
@@ -34,7 +34,7 @@ jobs:
           ./node_modules/.bin/gulp
   generate:
     docker:
-      - image: "jfbrandhorst/grpc-gateway-build-env"
+      - image: jfbrandhorst/grpc-gateway-build-env
     working_directory: /go/src/github.com/grpc-ecosystem/grpc-gateway
     steps:
       - checkout
@@ -43,7 +43,7 @@ jobs:
       - run: git diff --exit-code
   lint:
     docker:
-      - image: "jfbrandhorst/grpc-gateway-build-env"
+      - image: jfbrandhorst/grpc-gateway-build-env
     working_directory: /go/src/github.com/grpc-ecosystem/grpc-gateway
     steps:
       - checkout
@@ -52,18 +52,95 @@ jobs:
       - run: make lint
   bazel_build:
     docker:
-      - image: "l.gcr.io/google/bazel:latest"
+      - image: l.gcr.io/google/bazel:latest
     working_directory: /go/src/github.com/grpc-ecosystem/grpc-gateway
     steps:
       - checkout
       - run: bazel --batch --output_base=$HOME/.cache/_grpc_gateway_bazel --host_jvm_args=-Xmx500m --host_jvm_args=-Xms500m build --local_resources=400,1,1.0 //...
   bazel_test:
     docker:
-      - image: "l.gcr.io/google/bazel:latest"
+      - image: l.gcr.io/google/bazel:latest
     working_directory: /go/src/github.com/grpc-ecosystem/grpc-gateway
     steps:
       - checkout
       - run: bazel --batch --output_base=$HOME/.cache/_grpc_gateway_bazel --host_jvm_args=-Xmx500m --host_jvm_args=-Xms500m test --local_resources=400,1,1.0 --test_output=errors --features=race //...
+  build_linux_release:
+    docker:
+      - image: jfbrandhorst/grpc-gateway-build-env
+    working_directory: /go/src/github.com/grpc-ecosystem/grpc-gateway
+    environment:
+      CGO_ENABLED: "0"
+      GOOS: "linux"
+      GOARCH: "amd64"
+    steps:
+      - checkout
+      - run: mkdir -p release
+      - run: dep ensure --vendor-only
+      - run: |
+          VERSION=$(git describe --tags --abbrev=0)
+          go build -o ./release/protoc-gen-grpc-gateway-${VERSION}-linux-x86_64 ./protoc-gen-grpc-gateway/
+      - run: |
+          VERSION=$(git describe --tags --abbrev=0)
+          go build -o ./release/protoc-gen-swagger-${VERSION}-linux-x86_64 ./protoc-gen-swagger/
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - release
+  build_darwin_release:
+    docker:
+      - image: jfbrandhorst/grpc-gateway-build-env
+    working_directory: /go/src/github.com/grpc-ecosystem/grpc-gateway
+    environment:
+      CGO_ENABLED: "0"
+      GOOS: "darwin"
+      GOARCH: "amd64"
+    steps:
+      - checkout
+      - run: mkdir -p release
+      - run: dep ensure --vendor-only
+      - run: |
+          VERSION=$(git describe --tags --abbrev=0)
+          go build -o ./release/protoc-gen-grpc-gateway-${VERSION}-darwin-x86_64 ./protoc-gen-grpc-gateway/
+      - run: |
+          VERSION=$(git describe --tags --abbrev=0)
+          go build -o ./release/protoc-gen-swagger-${VERSION}-darwin-x86_64 ./protoc-gen-swagger/
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - release
+  build_windows_release:
+    docker:
+      - image: jfbrandhorst/grpc-gateway-build-env
+    working_directory: /go/src/github.com/grpc-ecosystem/grpc-gateway
+    environment:
+      CGO_ENABLED: "0"
+      GOOS: "windows"
+      GOARCH: "amd64"
+    steps:
+      - checkout
+      - run: mkdir -p release
+      - run: dep ensure --vendor-only
+      - run: |
+          VERSION=$(git describe --tags --abbrev=0)
+          go build -o ./release/protoc-gen-grpc-gateway-${VERSION}-windows-x86_64.exe ./protoc-gen-grpc-gateway/
+      - run: |
+          VERSION=$(git describe --tags --abbrev=0)
+          go build -o ./release/protoc-gen-swagger-${VERSION}-windows-x86_64.exe ./protoc-gen-swagger/
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - release
+  publish_github_release:
+    docker:
+      - image: cibuilds/github:0.10
+    steps:
+      - attach_workspace:
+          at: ./release
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            VERSION=$(git describe --tags --abbrev=0)
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${VERSION} ./release/
 workflows:
   version: 2
   all:
@@ -75,3 +152,31 @@ workflows:
       - lint
       - bazel_build
       - bazel_test
+      - build_linux_release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+$/
+      - build_windows_release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+$/
+      - build_darwin_release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+$/
+      - publish_github_release:
+          requires:
+            - build_linux_release
+            - build_darwin_release
+            - build_windows_release
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+$/


### PR DESCRIPTION
This will trigger a build of a linux, darwin and windows
build of protoc-gen-grpc-gateway and protoc-gen-swagger
on every new tag matching the semver regex.

Fixes #790 