### PR TITLE
Use newer Bazel repo rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,7 @@
 workspace(name = "grpc_ecosystem_grpc_gateway")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "io_bazel_rules_go",
     url = "https://github.com/bazelbuild/rules_go/releases/download/0.12.1/rules_go-0.12.1.tar.gz",
@@ -12,7 +14,11 @@ http_archive(
     sha256 = "d03625db67e9fb0905bbd206fa97e32ae9da894fe234a493e7517fd25faec914",
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_repository")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()
+
+load("@bazel_gazelle//:def.bzl", "go_repository")
 load("//:repositories.bzl", "repositories")
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 
@@ -56,7 +62,3 @@ repositories()
 go_rules_dependencies()
 
 go_register_toolchains()
-
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
-
-gazelle_dependencies()


### PR DESCRIPTION
This uses the new go_repository and http_archive rules. Using the former
avoids a warning:

DEPRECATED: the rules_go version of go_repository is deprecated. Migrate
to the new version in @bazel_gazelle//def.bzl instead.

The latter will avoid breakage when the native http_archive rule is
disabled by default in a future version of Bazel.