### PR TITLE
protoc-gen-swagger: honor example field of message option

### DIFF
--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -1428,7 +1428,7 @@ func swaggerSchemaFromProtoSchema(s *swagger_options.Schema, reg *descriptor.Reg
 	ret.schemaCore = protoJSONSchemaToSwaggerSchemaCore(s.GetJsonSchema(), reg, refs)
 	updateSwaggerObjectFromJSONSchema(&ret, s.GetJsonSchema())
 
-	if s.Example != nil {
+	if s != nil && s.Example != nil {
 		ret.Example = string(s.Example.Value)
 	}
 

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 
+	"encoding/json"
+
 	"github.com/golang/protobuf/proto"
 	pbdescriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/descriptor"
@@ -274,7 +276,7 @@ func renderMessagesAsDefinition(messages messageMap, d swaggerDefinitionsObject,
 			if protoSchema.Description != "" {
 				schema.Description = protoSchema.Description
 			}
-			if protoSchema.Example != "" {
+			if protoSchema.Example != nil {
 				schema.Example = protoSchema.Example
 			}
 		}
@@ -1429,7 +1431,7 @@ func swaggerSchemaFromProtoSchema(s *swagger_options.Schema, reg *descriptor.Reg
 	updateSwaggerObjectFromJSONSchema(&ret, s.GetJsonSchema())
 
 	if s != nil && s.Example != nil {
-		ret.Example = string(s.Example.Value)
+		ret.Example = json.RawMessage(s.Example.Value)
 	}
 
 	return ret

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -1,6 +1,7 @@
 package genswagger
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
@@ -8,8 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-
-	"encoding/json"
 
 	"github.com/golang/protobuf/proto"
 	pbdescriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -274,6 +274,9 @@ func renderMessagesAsDefinition(messages messageMap, d swaggerDefinitionsObject,
 			if protoSchema.Description != "" {
 				schema.Description = protoSchema.Description
 			}
+			if protoSchema.Example != "" {
+				schema.Example = protoSchema.Example
+			}
 		}
 
 		for _, f := range msg.Fields {
@@ -1424,6 +1427,10 @@ func swaggerSchemaFromProtoSchema(s *swagger_options.Schema, reg *descriptor.Reg
 
 	ret.schemaCore = protoJSONSchemaToSwaggerSchemaCore(s.GetJsonSchema(), reg, refs)
 	updateSwaggerObjectFromJSONSchema(&ret, s.GetJsonSchema())
+
+	if s.Example != nil {
+		ret.Example = string(s.Example.Value)
+	}
 
 	return ret
 }

--- a/protoc-gen-swagger/genswagger/types.go
+++ b/protoc-gen-swagger/genswagger/types.go
@@ -133,10 +133,10 @@ type swaggerParameterObject struct {
 // core part of schema, which is common to itemsObject and schemaObject.
 // http://swagger.io/specification/#itemsObject
 type schemaCore struct {
-	Type    string `json:"type,omitempty"`
-	Format  string `json:"format,omitempty"`
-	Ref     string `json:"$ref,omitempty"`
-	Example string `json:"example,omitempty"`
+	Type    string          `json:"type,omitempty"`
+	Format  string          `json:"format,omitempty"`
+	Ref     string          `json:"$ref,omitempty"`
+	Example json.RawMessage `json:"example,omitempty"`
 
 	Items *swaggerItemsObject `json:"items,omitempty"`
 

--- a/protoc-gen-swagger/genswagger/types.go
+++ b/protoc-gen-swagger/genswagger/types.go
@@ -133,9 +133,10 @@ type swaggerParameterObject struct {
 // core part of schema, which is common to itemsObject and schemaObject.
 // http://swagger.io/specification/#itemsObject
 type schemaCore struct {
-	Type   string `json:"type,omitempty"`
-	Format string `json:"format,omitempty"`
-	Ref    string `json:"$ref,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Format  string `json:"format,omitempty"`
+	Ref     string `json:"$ref,omitempty"`
+	Example string `json:"example,omitempty"`
 
 	Items *swaggerItemsObject `json:"items,omitempty"`
 


### PR DESCRIPTION
I don't see a possibility to set example values through options. These would be shown by e.g. swagger-ui as example bodies for a POST.

```
message CreatePet {
   option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
    example: {
      value: '{SOME JSON}';
    };
  };

  string name = 1;
}
```

But it also allows setting the example field for nested messages, and the code generator will honor this and just set the nested field to the value.

One thing would be missing: setting examples for fields, i.e. for the string "name"  in the example above. sadly this would need deeper changes, as the field option uses a different data type: JSONSchema and not Schema. Schema contains the example field..
I wonder why this is the case. As far as i have seen, it's possible in Swagger to set the example field even for "primitives".

This patch makes it possible to set examples for messages. While not perfect, it can be a way out of this.
If there's a better possibility to provide examples - without editing the .json manually, please tell me ;)