### PR TITLE
add allow_get_body option to allow send body with GET request

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -36,6 +36,7 @@
     "ptypes/wrappers"
   ]
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/rogpeppe/fastuuid"
@@ -115,6 +116,7 @@
     "transport"
   ]
   revision = "d11072e7ca9811b1100b80ca0269ac831f06d024"
+  version = "v1.11.3"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"
@@ -124,6 +126,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e3a3d005ebf93db02b6c7ddc886adc39342b492105fc1b6c4d0c362a43e6adf6"
+  inputs-digest = "1508d82cab329bb51f5e8352d9620039220df467bd0084fde1cfaab8fb51cf17"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/protoc-gen-grpc-gateway/descriptor/registry.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry.go
@@ -38,6 +38,9 @@ type Registry struct {
 	// allowDeleteBody permits http delete methods to have a body
 	allowDeleteBody bool
 
+	// allowGetBody permits http get methods to have a body
+	allowGetBody bool
+
 	// externalHttpRules is a mapping from fully qualified service method names to additional HttpRules applicable besides the ones found in annotations.
 	externalHTTPRules map[string][]*annotations.HttpRule
 
@@ -321,6 +324,12 @@ func (r *Registry) GetAllFQENs() []string {
 // body or fail loading if encountered.
 func (r *Registry) SetAllowDeleteBody(allow bool) {
 	r.allowDeleteBody = allow
+}
+
+// SetAllowGetBody controls whether http get methods may have a body
+// or fail loading if encountered.
+func (r *Registry) SetAllowGetBody(allow bool) {
+	r.allowGetBody = allow
 }
 
 // SetAllowMerge controls whether generation one swagger file out of multiple protos

--- a/protoc-gen-grpc-gateway/descriptor/services.go
+++ b/protoc-gen-grpc-gateway/descriptor/services.go
@@ -78,7 +78,7 @@ func (r *Registry) newMethod(svc *Service, md *descriptor.MethodDescriptorProto,
 		case opts.GetGet() != "":
 			httpMethod = "GET"
 			pathTemplate = opts.GetGet()
-			if opts.Body != "" {
+			if opts.Body != "" && !r.allowGetBody {
 				return nil, fmt.Errorf("must not set request body when http method is GET: %s", md.GetName())
 			}
 

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -27,6 +27,7 @@ var (
 	registerFuncSuffix         = flag.String("register_func_suffix", "Handler", "used to construct names of generated Register*<Suffix> methods.")
 	useRequestContext          = flag.Bool("request_context", true, "determine whether to use http.Request's context or not")
 	allowDeleteBody            = flag.Bool("allow_delete_body", false, "unless set, HTTP DELETE methods may not have a body")
+	allowGetBody               = flag.Bool("allow_get_body", false, "unless set, HTTP GET methods may not have a body")
 	grpcAPIConfiguration       = flag.String("grpc_api_configuration", "", "path to gRPC API Configuration in YAML format")
 	pathType                   = flag.String("paths", "", "specifies how the paths of generated files are structured")
 	allowRepeatedFieldsInBody  = flag.Bool("allow_repeated_fields_in_body", false, "allows to use repeated field in `body` and `response_body` field of `google.api.http` annotation option")
@@ -77,6 +78,7 @@ func main() {
 	reg.SetPrefix(*importPrefix)
 	reg.SetImportPath(*importPath)
 	reg.SetAllowDeleteBody(*allowDeleteBody)
+	reg.SetAllowGetBody(*allowGetBody)
 	reg.SetAllowRepeatedFieldsInBody(*allowRepeatedFieldsInBody)
 	if err := reg.SetRepeatedPathParamSeparator(*repeatedPathParamSeparator); err != nil {
 		emitError(err)

--- a/protoc-gen-swagger/main.go
+++ b/protoc-gen-swagger/main.go
@@ -18,6 +18,7 @@ var (
 	importPrefix               = flag.String("import_prefix", "", "prefix to be added to go package paths for imported proto files")
 	file                       = flag.String("file", "-", "where to load data from")
 	allowDeleteBody            = flag.Bool("allow_delete_body", false, "unless set, HTTP DELETE methods may not have a body")
+	allowGetBody               = flag.Bool("allow_get_body", false, "unless set, HTTP GET methods may not have a body")
 	grpcAPIConfiguration       = flag.String("grpc_api_configuration", "", "path to gRPC API Configuration in YAML format")
 	allowMerge                 = flag.Bool("allow_merge", false, "if set, generation one swagger file out of multiple protos")
 	mergeFileName              = flag.String("merge_file_name", "apidocs", "target swagger file name prefix after merge")
@@ -56,6 +57,7 @@ func main() {
 
 	reg.SetPrefix(*importPrefix)
 	reg.SetAllowDeleteBody(*allowDeleteBody)
+	reg.SetAllowGetBody(*allowGetBody)
 	reg.SetAllowMerge(*allowMerge)
 	reg.SetMergeFileName(*mergeFileName)
 	reg.SetUseJSONNamesForFields(*useJSONNamesForFields)


### PR DESCRIPTION
I have meet a case that every request has a requestId in request body, and the response should reply with that body. but it seems not support with method GET. This PR enable this

Signed-off-by: forrestchen <forrestchen@tencent.com>