### PR TITLE
fix bug: the resource name of custom method doesn't be retained

### DIFF
--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -570,6 +570,8 @@ func isResourceName(prefix string) bool {
 	words := strings.Split(prefix, ".")
 	l := len(words)
 	field := words[l-1]
+	words = strings.Split(field, ":")
+	field = words[0]
 	return field == "parent" || field == "name"
 }
 

--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -702,6 +702,11 @@ func TestTemplateToSwaggerPath(t *testing.T) {
 		{"/{user.name=prefix/*}", "/{user.name=prefix/*}"},
 		{"/{user.name=prefix1/*/prefix2/*}", "/{user.name=prefix1/*/prefix2/*}"},
 		{"/{parent=prefix/*}/children", "/{parent=prefix/*}/children"},
+		{"/{name=prefix/*}:customMethod", "/{name=prefix/*}:customMethod"},
+		{"/{name=prefix1/*/prefix2/*}:customMethod", "/{name=prefix1/*/prefix2/*}:customMethod"},
+		{"/{user.name=prefix/*}:customMethod", "/{user.name=prefix/*}:customMethod"},
+		{"/{user.name=prefix1/*/prefix2/*}:customMethod", "/{user.name=prefix1/*/prefix2/*}:customMethod"},
+		{"/{parent=prefix/*}/children:customMethod", "/{parent=prefix/*}/children:customMethod"},
 	}
 
 	for _, data := range tests {


### PR DESCRIPTION
Last PR (#704) from me made a mistake. If someone define a custom method, the resource name in the path will not be retained.

This PR fixed the bug and added many test cases.