### PR TITLE
Make Bazel CI failures clearer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,23 +50,32 @@ jobs:
       - run: dep ensure --vendor-only
       - run: go get golang.org/x/lint/golint
       - run: make lint
-  bazel_lint:
+  bazel:
     docker:
       - image: l.gcr.io/google/bazel:latest
     working_directory: /go/src/github.com/grpc-ecosystem/grpc-gateway
     steps:
       - checkout
-      - run: 'bazel --output_base=$HOME/.cache/_grpc_gateway_bazel run //:buildifier_check ||
-              (echo "Bazel files not formatted, please run \`bazel run :buildifier\`"; exit 1)'
-      - run: 'test -z "$(bazel --output_base=$HOME/.cache/_grpc_gateway_bazel run //:gazelle_diff)" ||
-              (echo "Bazel files out-of-date, please run \`bazel run :gazelle_diff\`"; exit 1)'
-  bazel_test:
-    docker:
-      - image: l.gcr.io/google/bazel:latest
-    working_directory: /go/src/github.com/grpc-ecosystem/grpc-gateway
-    steps:
-      - checkout
-      - run: bazel --output_base=$HOME/.cache/_grpc_gateway_bazel test --test_output=errors --features=race //...
+      - run:
+          name: Create Bazel config file (.bazelrc)
+          command: |
+            cat > .bazelrc << EOF
+            startup --output_base $HOME/.cache/_grpc_gateway_bazel
+            build --test_output errors
+            build --features race
+            EOF
+      - run:
+          name: Check that Bazel BUILD files are up-to-date
+          command: 'test -z "$(bazel run //:gazelle_diff)" ||
+          (echo "ERROR: Bazel files out-of-date, please run \`bazel run :gazelle_fix\`" >&2; exit 1)'
+      - run:
+          name: Run tests with Bazel
+          command: bazel test //...
+      - run:
+          name: Check formatting of Bazel BUILD files
+          command: 'bazel run //:buildifier_check ||
+          (echo "ERROR: Bazel files not formatted, please run \`bazel run :buildifier\`" >&2; exit 1)'
+          when: always
   build_linux_release:
     docker:
       - image: jfbrandhorst/grpc-gateway-build-env
@@ -153,8 +162,7 @@ workflows:
       - node_test
       - generate
       - lint
-      - bazel_lint
-      - bazel_test
+      - bazel
       - build_linux_release:
           filters:
             branches:

--- a/BUILD
+++ b/BUILD
@@ -11,6 +11,7 @@ buildifier(
 )
 
 # gazelle:exclude third_party
+# gazelle:exclude vendor
 
 gazelle(
     name = "gazelle_diff",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,10 +24,12 @@ All submissions, including submissions by project members, require review.
 Great, it should be as simple as thus (run from the root of the directory):
 
 ```bash
-$ docker run -v $(pwd):/go/src/github.com/grpc-ecosystem/grpc-gateway --rm jfbrandhorst/grpc-gateway-build-env \
+docker run -v $(pwd):/go/src/github.com/grpc-ecosystem/grpc-gateway --rm jfbrandhorst/grpc-gateway-build-env \
     /bin/bash -c 'cd /go/src/github.com/grpc-ecosystem/grpc-gateway && \
         make realclean && \
         make examples SWAGGER_CODEGEN="${SWAGGER_CODEGEN}"'
+docker run -itv $(pwd):/grpc-gateway -w /grpc-gateway --entrypoint /bin/bash --rm \
+    l.gcr.io/google/bazel -c 'bazel run :gazelle_fix; bazel run :buildifier'
 ```
 
 If this has resulted in some file changes in the repo, please ensure you check those in with your merge request.


### PR DESCRIPTION
- don't try to run tests if the BUILD files are out-of-date
- run buildifier even if the tests fail, as it may still be useful
- use a parameter to hold Bazel config to simplify config.yml
- use default output_base (hopefully it works, this is because it's hard
  to have nested envvars with CircleCL)
- ignore the vendor/ directory when running Gazelle
  (otherwise it will fail if you've used `dep` to create vendor/)