### PR TITLE
Adding support for more well known types in descriptor

### DIFF
--- a/protoc-gen-grpc-gateway/descriptor/types.go
+++ b/protoc-gen-grpc-gateway/descriptor/types.go
@@ -451,7 +451,16 @@ var (
 	}
 
 	wellKnownTypeConv = map[string]string{
-		".google.protobuf.Timestamp": "runtime.Timestamp",
-		".google.protobuf.Duration":  "runtime.Duration",
+		".google.protobuf.Timestamp":   "runtime.Timestamp",
+		".google.protobuf.Duration":    "runtime.Duration",
+		".google.protobuf.StringValue": "runtime.StringValue",
+		".google.protobuf.BytesValue":  "runtime.BytesValue",
+		".google.protobuf.Int32Value":  "runtime.Int32Value",
+		".google.protobuf.UInt32Value": "runtime.UInt32Value",
+		".google.protobuf.Int64Value":  "runtime.Int64Value",
+		".google.protobuf.UInt64Value": "runtime.UInt64Value",
+		".google.protobuf.FloatValue":  "runtime.FloatValue",
+		".google.protobuf.DoubleValue": "runtime.DoubleValue",
+		".google.protobuf.BoolValue":   "runtime.BoolValue",
 	}
 )


### PR DESCRIPTION
This change is to support more wellknown types in "protoc-gen-grpc-gateway". It solves the following issue:
Ref: https://github.com/grpc-ecosystem/grpc-gateway/issues/808