### PR TITLE
'type' should be 'integer' for int64

### DIFF
--- a/examples/proto/examplepb/wrappers.swagger.json
+++ b/examples/proto/examplepb/wrappers.swagger.json
@@ -54,7 +54,7 @@
           "format": "int32"
         },
         "int64_value": {
-          "type": "string",
+          "type": "integer",
           "format": "int64"
         },
         "float_value": {

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -39,7 +39,7 @@ var wktSchemas = map[string]schemaCore{
 		Format: "int64",
 	},
 	".google.protobuf.Int64Value": schemaCore{
-		Type:   "string",
+		Type:   "integer",
 		Format: "int64",
 	},
 	".google.protobuf.UInt64Value": schemaCore{
@@ -375,7 +375,7 @@ func primitiveSchema(t pbdescriptor.FieldDescriptorProto_Type) (ftype, format st
 	case pbdescriptor.FieldDescriptorProto_TYPE_FLOAT:
 		return "number", "float", true
 	case pbdescriptor.FieldDescriptorProto_TYPE_INT64:
-		return "string", "int64", true
+		return "integer", "int64", true
 	case pbdescriptor.FieldDescriptorProto_TYPE_UINT64:
 		// 64bit integer types are marshaled as string in the default JSONPb marshaler.
 		// TODO(yugui) Add an option to declare 64bit integers as int64.

--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -898,7 +898,7 @@ func TestSchemaOfField(t *testing.T) {
 			},
 			refs: make(refMap),
 			expected: schemaCore{
-				Type:   "string",
+				Type:   "integer",
 				Format: "int64",
 			},
 		},


### PR DESCRIPTION
According to OpenAPI 2.0 spec, `"type"` should be `"integer"` for `int64`, not `"string"`
cf: <https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types>

so current protoc-gen-swagger generates invalid swagger file when `int64` is used.

This PR fix this problem, just replace `"string"` by `"integer"`.