### PR TITLE
Adding tests to the queryParamFilter String method

### DIFF
--- a/protoc-gen-grpc-gateway/gengateway/BUILD.bazel
+++ b/protoc-gen-grpc-gateway/gengateway/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     deps = [
         "//protoc-gen-grpc-gateway/descriptor:go_default_library",
         "//protoc-gen-grpc-gateway/httprule:go_default_library",
+        "//utilities:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
     ],

--- a/protoc-gen-grpc-gateway/gengateway/template_test.go
+++ b/protoc-gen-grpc-gateway/gengateway/template_test.go
@@ -8,6 +8,7 @@ import (
 	protodescriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/descriptor"
 	"github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/httprule"
+	"github.com/grpc-ecosystem/grpc-gateway/utilities"
 )
 
 func crossLinkFixture(f *descriptor.File) *descriptor.File {
@@ -400,5 +401,39 @@ func TestApplyTemplateRequestWithClientStreaming(t *testing.T) {
 		if want := `pattern_ExampleService_Echo_0 = runtime.MustPattern(runtime.NewPattern(1, []int{0, 0}, []string(nil), ""))`; !strings.Contains(got, want) {
 			t.Errorf("applyTemplate(%#v) = %s; want to contain %s", file, got, want)
 		}
+	}
+}
+
+func Test_queryParamFilter_String(t *testing.T) {
+	tests := []struct {
+		name string
+		seqs [][]string
+		want string
+	}{
+		{
+			name: "Empty queryParamFilter",
+			seqs: [][]string{},
+			want: "&utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}",
+		},
+		{
+			name: "Simple queryParamFilter",
+			seqs: [][]string{{"foo"}},
+			want: `&utilities.DoubleArray{Encoding: map[string]int{"foo": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}`,
+		},
+		{
+			name: "Full queryParamFilter",
+			seqs: [][]string{{"foo", "bar"}, {"foo", "baz"}, {"qux"}},
+			want: `&utilities.DoubleArray{Encoding: map[string]int{"foo": 0, "bar": 1, "baz": 2, "qux": 3}, Base: []int{1, 1, 1, 2, 3, 0, 0, 0}, Check: []int{0, 1, 2, 2, 1, 3, 4, 5}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := queryParamFilter{
+				DoubleArray: utilities.NewDoubleArray(tt.seqs),
+			}
+			if got := f.String(); got != tt.want {
+				t.Errorf("queryParamFilter.String() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/protoc-gen-grpc-gateway/gengateway/template_test.go
+++ b/protoc-gen-grpc-gateway/gengateway/template_test.go
@@ -11,6 +11,52 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"
 )
 
+func Test_queryParamFilter_String(t *testing.T) {
+	tests := []struct {
+		name        string
+		doubleArray *utilities.DoubleArray
+		want        string
+	}{
+		{
+			name: "Empty queryParamFilter",
+			doubleArray: &utilities.DoubleArray{
+				Encoding: map[string]int{},
+				Base:     []int(nil),
+				Check:    []int(nil),
+			},
+			want: "&utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}",
+		},
+		{
+			name: "Simple queryParamFilter",
+			doubleArray: &utilities.DoubleArray{
+				Encoding: map[string]int{"foo": 0},
+				Base:     []int{1, 1, 0},
+				Check:    []int{0, 1, 2},
+			},
+			want: `&utilities.DoubleArray{Encoding: map[string]int{"foo": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}`,
+		},
+		{
+			name: "Full queryParamFilter",
+			doubleArray: &utilities.DoubleArray{
+				Encoding: map[string]int{"bar": 1, "qux": 3, "baz": 2, "foo": 0},
+				Base:     []int{1, 1, 1, 2, 3, 0, 0, 0},
+				Check:    []int{0, 1, 2, 2, 1, 3, 4, 5},
+			},
+			want: `&utilities.DoubleArray{Encoding: map[string]int{"foo": 0, "bar": 1, "baz": 2, "qux": 3}, Base: []int{1, 1, 1, 2, 3, 0, 0, 0}, Check: []int{0, 1, 2, 2, 1, 3, 4, 5}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := queryParamFilter{
+				DoubleArray: tt.doubleArray,
+			}
+			if got := f.String(); got != tt.want {
+				t.Errorf("queryParamFilter.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func crossLinkFixture(f *descriptor.File) *descriptor.File {
 	for _, m := range f.Messages {
 		m.File = f
@@ -401,39 +447,5 @@ func TestApplyTemplateRequestWithClientStreaming(t *testing.T) {
 		if want := `pattern_ExampleService_Echo_0 = runtime.MustPattern(runtime.NewPattern(1, []int{0, 0}, []string(nil), ""))`; !strings.Contains(got, want) {
 			t.Errorf("applyTemplate(%#v) = %s; want to contain %s", file, got, want)
 		}
-	}
-}
-
-func Test_queryParamFilter_String(t *testing.T) {
-	tests := []struct {
-		name string
-		seqs [][]string
-		want string
-	}{
-		{
-			name: "Empty queryParamFilter",
-			seqs: [][]string{},
-			want: "&utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}",
-		},
-		{
-			name: "Simple queryParamFilter",
-			seqs: [][]string{{"foo"}},
-			want: `&utilities.DoubleArray{Encoding: map[string]int{"foo": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}`,
-		},
-		{
-			name: "Full queryParamFilter",
-			seqs: [][]string{{"foo", "bar"}, {"foo", "baz"}, {"qux"}},
-			want: `&utilities.DoubleArray{Encoding: map[string]int{"foo": 0, "bar": 1, "baz": 2, "qux": 3}, Base: []int{1, 1, 1, 2, 3, 0, 0, 0}, Check: []int{0, 1, 2, 2, 1, 3, 4, 5}}`,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			f := queryParamFilter{
-				DoubleArray: utilities.NewDoubleArray(tt.seqs),
-			}
-			if got := f.String(); got != tt.want {
-				t.Errorf("queryParamFilter.String() = %v, want %v", got, tt.want)
-			}
-		})
 	}
 }


### PR DESCRIPTION
I've been looking at doing some go open source work and have used grpc-gateway so thought it might be a good thing to contribute to. This PR adds a unit test to the previously untested String method on the queryParamFilter. This is just a small addition to try the PR process - if I do further work it will be more substantial.