### PR TITLE
Add constant behavior to protoc-gen-swagger Duplicate for #819

### DIFF
--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -560,6 +560,16 @@ func templateToSwaggerPath(path string) string {
 		if isResourceName(prefix) {
 			continue
 		}
+
+		if strings.Contains(part, "=") {
+			v := strings.Split(strings.TrimSuffix(strings.TrimPrefix(part, "{"), "}"), "=")
+			if len(v) == 2 {
+				part = v[1]
+			}
+			parts[index] = part
+			continue
+		}
+
 		parts[index] = re.ReplaceAllString(part, "{$1}")
 	}
 

--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -693,8 +693,8 @@ func TestTemplateToSwaggerPath(t *testing.T) {
 	}{
 		{"/test", "/test"},
 		{"/{test}", "/{test}"},
-		{"/{test=prefix/*}", "/{test}"},
-		{"/{test=prefix/that/has/multiple/parts/to/it/*}", "/{test}"},
+		{"/{test=prefix/*}", "/prefix/*"},
+		{"/{test=prefix/that/has/multiple/parts/to/it/*}", "/prefix/that/has/multiple/parts/to/it/*"},
 		{"/{test1}/{test2}", "/{test1}/{test2}"},
 		{"/{test1}/{test2}/", "/{test1}/{test2}/"},
 		{"/{name=prefix/*}", "/{name=prefix/*}"},
@@ -766,8 +766,8 @@ func TestFQMNtoSwaggerName(t *testing.T) {
 	}{
 		{"/test", "/test"},
 		{"/{test}", "/{test}"},
-		{"/{test=prefix/*}", "/{test}"},
-		{"/{test=prefix/that/has/multiple/parts/to/it/*}", "/{test}"},
+		{"/{test=prefix/*}", "/prefix/*"},
+		{"/{test=prefix/that/has/multiple/parts/to/it/*}", "/prefix/that/has/multiple/parts/to/it/*"},
 		{"/{test1}/{test2}", "/{test1}/{test2}"},
 		{"/{test1}/{test2}/", "/{test1}/{test2}/"},
 	}


### PR DESCRIPTION
This PR should cover the use case when we map path to a payload data, but it is not properly reflected in generated swagger schema.

Lets assume we have following in proto:

message Id {
  string app_name = 1;
  string resource_type = 2;
}
and following gateway mappings for some of the rpcs:

post: /{id.app_name=app}/{id.resource_type=foo}
...
post: /{id.app_name=app}/{id.resource_type=bar}
In swagger schema it will look like /{id.app_name}/{id.resource_type} in both cases

This PR will make plugin to generate /app/foo and /app/bar respectively which seems to be more correct. At the same time it will generate /{id.app_name}/{id.resource_type} is there is no = assignments in proto.

Thanks

It duplicate #819  because 