### PR TITLE
Add filegroup for options proto files

### DIFF
--- a/protoc-gen-swagger/options/BUILD.bazel
+++ b/protoc-gen-swagger/options/BUILD.bazel
@@ -3,6 +3,20 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 package(default_visibility = ["//visibility:public"])
 
+filegroup(
+    name = "options_proto_files",
+    srcs = [
+        "annotations.proto",
+        "openapiv2.proto",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":options_go_proto"],
+    importpath = "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger/options",
+)
+
 proto_library(
     name = "options_proto",
     srcs = [
@@ -20,10 +34,4 @@ go_proto_library(
     compilers = ["@io_bazel_rules_go//proto:go_grpc"],
     importpath = "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger/options",
     proto = ":options_proto",
-)
-
-go_library(
-    name = "go_default_library",
-    embed = [":options_go_proto"],
-    importpath = "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger/options",
 )


### PR DESCRIPTION
This allows other projects to generate proto code for other languages, e.g. py_proto_library