### PR TITLE
Replace complicated circle CI release with goreleaser.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,94 +76,14 @@ jobs:
           command: 'bazel run //:buildifier_check ||
           (echo "ERROR: Bazel files not formatted, please run \`bazel run :buildifier\`" >&2; exit 1)'
           when: always
-  write_release_version:
-    docker:
-      - image: docker:git
-    working_directory: /src
-    steps:
-      - checkout
-      - run: git describe --tags --abbrev=0 > VERSION
-      - persist_to_workspace:
-          root: ./
-          paths:
-            - VERSION
-  build_linux_release:
+  release:
     docker:
       - image: jfbrandhorst/grpc-gateway-build-env
     working_directory: /go/src/github.com/grpc-ecosystem/grpc-gateway
-    environment:
-      CGO_ENABLED: "0"
-      GOOS: "linux"
-      GOARCH: "amd64"
     steps:
       - checkout
-      - run: mkdir -p release
       - run: dep ensure --vendor-only
-      - run: |
-          VERSION=$(git describe --tags --abbrev=0)
-          go build -o ./release/protoc-gen-grpc-gateway-${VERSION}-linux-x86_64 ./protoc-gen-grpc-gateway/
-      - run: |
-          VERSION=$(git describe --tags --abbrev=0)
-          go build -o ./release/protoc-gen-swagger-${VERSION}-linux-x86_64 ./protoc-gen-swagger/
-      - persist_to_workspace:
-          root: ./
-          paths:
-            - release
-  build_darwin_release:
-    docker:
-      - image: jfbrandhorst/grpc-gateway-build-env
-    working_directory: /go/src/github.com/grpc-ecosystem/grpc-gateway
-    environment:
-      CGO_ENABLED: "0"
-      GOOS: "darwin"
-      GOARCH: "amd64"
-    steps:
-      - checkout
-      - run: mkdir -p release
-      - run: dep ensure --vendor-only
-      - run: |
-          VERSION=$(git describe --tags --abbrev=0)
-          go build -o ./release/protoc-gen-grpc-gateway-${VERSION}-darwin-x86_64 ./protoc-gen-grpc-gateway/
-      - run: |
-          VERSION=$(git describe --tags --abbrev=0)
-          go build -o ./release/protoc-gen-swagger-${VERSION}-darwin-x86_64 ./protoc-gen-swagger/
-      - persist_to_workspace:
-          root: ./
-          paths:
-            - release
-  build_windows_release:
-    docker:
-      - image: jfbrandhorst/grpc-gateway-build-env
-    working_directory: /go/src/github.com/grpc-ecosystem/grpc-gateway
-    environment:
-      CGO_ENABLED: "0"
-      GOOS: "windows"
-      GOARCH: "amd64"
-    steps:
-      - checkout
-      - run: mkdir -p release
-      - run: dep ensure --vendor-only
-      - run: |
-          VERSION=$(git describe --tags --abbrev=0)
-          go build -o ./release/protoc-gen-grpc-gateway-${VERSION}-windows-x86_64.exe ./protoc-gen-grpc-gateway/
-      - run: |
-          VERSION=$(git describe --tags --abbrev=0)
-          go build -o ./release/protoc-gen-swagger-${VERSION}-windows-x86_64.exe ./protoc-gen-swagger/
-      - persist_to_workspace:
-          root: ./
-          paths:
-            - release
-  publish_github_release:
-    docker:
-      - image: cibuilds/github:0.10
-    steps:
-      - attach_workspace:
-          at: /workspace
-      - run:
-          name: "Publish Release on GitHub"
-          command: |
-            VERSION=$(cat /workspace/VERSION)
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} /workspace/release/
+      - run: curl -sL https://git.io/goreleaser | bash
 workflows:
   version: 2
   all:
@@ -174,38 +94,9 @@ workflows:
       - generate
       - lint
       - bazel
-      - write_release_version:
+      - release:
           filters:
             branches:
               ignore: /.*/
             tags:
-              only: /^v\d+\.\d+\.\d+$/
-      - build_linux_release:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-      - build_windows_release:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-      - build_darwin_release:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-#      - publish_github_release:
-#          requires:
-#            - write_release_version
-#            - build_linux_release
-#            - build_darwin_release
-#            - build_windows_release
-#          filters:
-#            branches:
-#              ignore: /.*/
-#            tags:
-#              only: /^v\d+\.\d+\.\d+$/
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,27 @@
+builds:
+  - main: ./protoc-gen-grpc-gateway/main.go
+    binary: protoc-gen-grpc-gateway
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+  - main: ./protoc-gen-swagger/main.go
+    binary: protoc-gen-swagger
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+archive:
+  name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
+  format: binary
+  replacements:
+    amd64: x86_64
+dist: _output

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -10,6 +10,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"strings"
 
@@ -31,11 +32,24 @@ var (
 	pathType                   = flag.String("paths", "", "specifies how the paths of generated files are structured")
 	allowRepeatedFieldsInBody  = flag.Bool("allow_repeated_fields_in_body", false, "allows to use repeated field in `body` and `response_body` field of `google.api.http` annotation option")
 	repeatedPathParamSeparator = flag.String("repeated_path_param_separator", "csv", "configures how repeated fields should be split. Allowed values are `csv`, `pipes`, `ssv` and `tsv`.")
+	versionFlag                = flag.Bool("version", false, "print the current verison")
+)
+
+// Variables set by goreleaser at build time
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
 )
 
 func main() {
 	flag.Parse()
 	defer glog.Flush()
+
+	if *versionFlag {
+		fmt.Printf("Version %v, commit %v, built at %v\n", version, commit, date)
+		os.Exit(0)
+	}
 
 	reg := descriptor.NewRegistry()
 

--- a/protoc-gen-swagger/main.go
+++ b/protoc-gen-swagger/main.go
@@ -23,11 +23,24 @@ var (
 	mergeFileName              = flag.String("merge_file_name", "apidocs", "target swagger file name prefix after merge")
 	useJSONNamesForFields      = flag.Bool("json_names_for_fields", false, "if it sets Field.GetJsonName() will be used for generating swagger definitions, otherwise Field.GetName() will be used")
 	repeatedPathParamSeparator = flag.String("repeated_path_param_separator", "csv", "configures how repeated fields should be split. Allowed values are `csv`, `pipes`, `ssv` and `tsv`.")
+	versionFlag                = flag.Bool("version", false, "print the current verison")
+)
+
+// Variables set by goreleaser at build time
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
 )
 
 func main() {
 	flag.Parse()
 	defer glog.Flush()
+
+	if *versionFlag {
+		fmt.Printf("Version %v, commit %v, built at %v\n", version, commit, date)
+		os.Exit(0)
+	}
 
 	reg := descriptor.NewRegistry()
 


### PR DESCRIPTION
Replace complicated circle CI release with goreleaser.

This job will only run on new tag creation and will automatically upload the binaries and create a changelog, however I think we'll manually want to copy the changelog from the one generated by the makefile job. Haven't found a way to turn off the changelog generation of gorelease but everything else is great so it's not that big of a problem.