### PR TITLE
protoc-gen-swagger: check typeIndex when typeName is Method

### DIFF
--- a/examples/clients/abe/camel_case_service_name_api.go
+++ b/examples/clients/abe/camel_case_service_name_api.go
@@ -37,8 +37,7 @@ func NewCamelCaseServiceNameApiWithBasePath(basePath string) *CamelCaseServiceNa
 }
 
 /**
- * Create a new ABitOfEverything
- * This API creates a new ABitOfEverything
+ * 
  *
  * @return *interface{}
  */

--- a/examples/proto/examplepb/a_bit_of_everything.swagger.json
+++ b/examples/proto/examplepb/a_bit_of_everything.swagger.json
@@ -1153,8 +1153,6 @@
     },
     "/v2/example/empty": {
       "get": {
-        "summary": "Create a new ABitOfEverything",
-        "description": "This API creates a new ABitOfEverything",
         "operationId": "Empty",
         "responses": {
           "200": {

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -1245,7 +1245,7 @@ func isProtoPathMatches(paths []int32, outerPaths []int32, typeName string, type
 	}
 
 	if typeName == "Method" {
-		if paths[0] != serviceProtoPath || paths[2] != methodProtoPath {
+		if paths[0] != serviceProtoPath || paths[1] != typeIndex || paths[2] != methodProtoPath {
 			return false
 		}
 		paths = paths[2:]

--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -1019,3 +1019,145 @@ func TestSchemaOfField(t *testing.T) {
 		}
 	}
 }
+
+func fileFixtureServices(services []string) *descriptor.File {
+	var (
+		svcdesc  = []*protodescriptor.ServiceDescriptorProto{}
+		loc      = []*protodescriptor.SourceCodeInfo_Location{}
+		msgdesc  = []*protodescriptor.DescriptorProto{}
+		methdesc = []*protodescriptor.MethodDescriptorProto{}
+		msg      = []*descriptor.Message{}
+		svc      = []*descriptor.Service{}
+	)
+
+	for _, service := range services {
+		// loc
+		sc := &protodescriptor.SourceCodeInfo_Location{
+			LeadingComments: proto.String(fmt.Sprintf("%s message", service)),
+		}
+		loc = append(loc, sc)
+		// methdesc
+		md := &protodescriptor.MethodDescriptorProto{
+			Name:       proto.String(service),
+			InputType:  proto.String(fmt.Sprintf("%sMessage", service)),
+			OutputType: proto.String(fmt.Sprintf("%sMessage", service)),
+		}
+		methdesc = append(methdesc, md)
+		// svcdesc
+		sd := &protodescriptor.ServiceDescriptorProto{
+			Name:   proto.String(fmt.Sprintf("%sService", service)),
+			Method: []*protodescriptor.MethodDescriptorProto{md},
+		}
+		svcdesc = append(svcdesc, sd)
+		// msgdesc
+		d := &protodescriptor.DescriptorProto{
+			Name: proto.String(fmt.Sprintf("%sRequest", service)),
+		}
+		msgdesc = append(msgdesc, d)
+		// msg
+		m := &descriptor.Message{
+			DescriptorProto: d,
+		}
+		msg = append(msg, m)
+		// methods
+		meth := &descriptor.Method{
+			MethodDescriptorProto: md,
+			RequestType:           m,
+			ResponseType:          m,
+			Bindings: []*descriptor.Binding{
+				{
+					HTTPMethod: "POST",
+					Body:       &descriptor.Body{FieldPath: nil},
+					PathTmpl: httprule.Template{
+						Version:  1,
+						OpCodes:  []int{0, 0},
+						Template: fmt.Sprintf("/v1/%s", service),
+					},
+				},
+			},
+		}
+		s := &descriptor.Service{
+			ServiceDescriptorProto: sd,
+			Methods:                []*descriptor.Method{meth},
+		}
+		svc = append(svc, s)
+	}
+
+	file := descriptor.File{
+		FileDescriptorProto: &protodescriptor.FileDescriptorProto{
+			SourceCodeInfo: &protodescriptor.SourceCodeInfo{
+				Location: loc,
+			},
+			Name:        proto.String("example.proto"),
+			Package:     proto.String("example"),
+			Dependency:  []string{},
+			MessageType: msgdesc,
+			Service:     svcdesc,
+		},
+		GoPkg: descriptor.GoPackage{
+			Path: "example.com/path/to/example/example1.pb",
+			Name: "example_pb",
+		},
+		Messages: msg,
+		Services: svc,
+	}
+	return &file
+}
+
+func TestIsProtoPathMatches(t *testing.T) {
+	for _, test := range []struct {
+		path       []int32
+		outerPaths []int32
+		typeName   string
+		typeIndex  int32
+		fieldPaths []int32
+		want       bool
+	}{
+		{[]int32{6, 0, 2, 0}, []int32{}, "Method", 1, []int32{2, 0}, false},
+		{[]int32{6, 0, 2, 0, 1}, []int32{}, "Method", 1, []int32{2, 0}, false},
+		{[]int32{6, 0, 2, 0}, []int32{}, "Method", 0, []int32{2, 0}, true},
+		{[]int32{}, []int32{}, "Package", 2, []int32{}, false},
+		{[]int32{2}, []int32{}, "Package", 3, []int32{}, false},
+		{[]int32{2}, []int32{}, "Package", 2, []int32{}, true},
+		{[]int32{4, 0}, []int32{}, "MessageType", 1, []int32{}, false},
+		{[]int32{4, 0, 2, 0}, []int32{}, "MessageType", 0, []int32{4, 0}, false},
+	} {
+		got := isProtoPathMatches(test.path, test.outerPaths, test.typeName, test.typeIndex, test.fieldPaths)
+		if got != test.want {
+			t.Errorf("isProtoPathMatches(%v) got (%t) want %t", test, got, test.want)
+		}
+	}
+}
+
+func TestProtoComments(t *testing.T) {
+	for _, test := range []struct {
+		services   []string
+		startPath  []int32
+		outers     []string
+		typeName   string
+		typeIndex  int32
+		fieldPaths []int32
+		want       string
+	}{
+		{[]string{"Foo", "Bar"}, []int32{6, 0, 2, 0}, []string{}, "Method", 0, []int32{2, 0}, "Foo message"},
+		{[]string{"Foo", "Bar"}, []int32{6, 0, 2, 0}, []string{}, "Method", 1, []int32{2, 0}, "Bar message"},
+		{[]string{"Foo", "Bar"}, []int32{6, 0, 2, 0}, []string{}, "Method", 2, []int32{2, 0}, ""},
+		{[]string{"Foo", "Bar"}, []int32{4, 0, 1}, []string{}, "Method", 0, []int32{2, 0}, ""},
+		{[]string{"Foo", "Bar"}, []int32{6, 0, 1, 1}, []string{}, "Method", 0, []int32{2, 0}, ""},
+		{[]string{"Foo", "Bar", "Baz"}, []int32{6, 0, 2, 0}, []string{}, "Method", 2, []int32{2, 0}, "Baz message"},
+	} {
+		file := fileFixtureServices(test.services)
+		for i, loc := range file.SourceCodeInfo.Location {
+			test.startPath[1] = int32(i)
+			loc.Path = append(loc.Path, test.startPath...)
+		}
+		reg := descriptor.NewRegistry()
+		reg.Load(&plugin.CodeGeneratorRequest{
+			ProtoFile: []*protodescriptor.FileDescriptorProto{file.FileDescriptorProto},
+		})
+		got := protoComments(reg, file, test.outers, test.typeName, test.typeIndex, test.fieldPaths...)
+		if got != test.want {
+			t.Errorf("protoComments(%v) got (%s) want %s", test, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
isProtoPathMatches() doesn't return false if svcIdx != methIdx when typeName == Method. The results in comments belonging to other services polluting swagger spec. We noticed this regression when using protoc 3.5.1+, although I still can't say why it started.

Fixes: https://github.com/grpc-ecosystem/grpc-gateway/issues/746