### PR TITLE
Fix the url of gRPC timeouts on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ To use the same port for custom HTTP handlers (e.g. serving `swagger.json`), gRP
 * Mapping streaming APIs to newline-delimited JSON streams
 * Mapping HTTP headers with `Grpc-Metadata-` prefix to gRPC metadata (prefixed with `grpcgateway-`)
 * Optionally emitting API definition for [Swagger](http://swagger.io).
-* Setting [gRPC timeouts](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) through inbound HTTP `Grpc-Timeout` header.
+* Setting [gRPC timeouts](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests) through inbound HTTP `Grpc-Timeout` header.
 * Partial support for [gRPC API Configuration]((https://cloud.google.com/endpoints/docs/grpc/grpc-service-config)) files as an alternative to annotation.
 
 ### Want to support

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ To use the same port for custom HTTP handlers (e.g. serving `swagger.json`), gRP
 * Mapping streaming APIs to newline-delimited JSON streams
 * Mapping HTTP headers with `Grpc-Metadata-` prefix to gRPC metadata (prefixed with `grpcgateway-`)
 * Optionally emitting API definition for [Swagger](http://swagger.io).
-* Setting [gRPC timeouts](http://www.grpc.io/docs/guides/wire.html) through inbound HTTP `Grpc-Timeout` header.
+* Setting [gRPC timeouts](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) through inbound HTTP `Grpc-Timeout` header.
 * Partial support for [gRPC API Configuration]((https://cloud.google.com/endpoints/docs/grpc/grpc-service-config)) files as an alternative to annotation.
 
 ### Want to support


### PR DESCRIPTION
The link http://www.grpc.io/docs/guides/wire.html is no longer valid, it should be https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md .