### PR TITLE
Use the canonical import name for resty

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,7 +10,7 @@
 
 [[projects]]
   digest = "1:5cae6c173646d9230aecf8074c171edb4fb9a37f074c5c89ba2fece20b6703b6"
-  name = "github.com/go-resty/resty"
+  name = "gopkg.in/resty.v1"
   packages = ["."]
   pruneopts = "UT"
   revision = "f8815663de1e64d57cdd4ee9e2b2fa96977a030e"
@@ -158,7 +158,6 @@
   analyzer-version = 1
   input-imports = [
     "github.com/ghodss/yaml",
-    "github.com/go-resty/resty",
     "github.com/golang/glog",
     "github.com/golang/protobuf/jsonpb",
     "github.com/golang/protobuf/proto",
@@ -175,6 +174,7 @@
     "github.com/golang/protobuf/ptypes/wrappers",
     "github.com/rogpeppe/fastuuid",
     "golang.org/x/net/context",
+    "gopkg.in/resty.v1",
     "google.golang.org/genproto/googleapis/api/annotations",
     "google.golang.org/genproto/googleapis/rpc/errdetails",
     "google.golang.org/genproto/googleapis/rpc/status",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -16,7 +16,7 @@ required = [
 [[constraint]]
   # Also defined in WORKSPACE
   revision = "f8815663de1e64d57cdd4ee9e2b2fa96977a030e"
-  name = "github.com/go-resty/resty"
+  name = "gopkg.in/resty.v1"
 
 [[constraint]]
   # Also defined in WORKSPACE

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,7 +51,7 @@ go_repository(
 go_repository(
     name = "com_github_go_resty_resty",
     commit = "f8815663de1e64d57cdd4ee9e2b2fa96977a030e",
-    importpath = "github.com/go-resty/resty",
+    importpath = "gopkg.in/resty.v1",
 )
 
 # Also define in Gopkg.toml

--- a/examples/clients/abe/api_client.go
+++ b/examples/clients/abe/api_client.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"net/url"
 	"io/ioutil"
-	"github.com/go-resty/resty"
+	resty "gopkg.in/resty.v1"
 )
 
 type APIClient struct {

--- a/examples/clients/echo/api_client.go
+++ b/examples/clients/echo/api_client.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"net/url"
 	"io/ioutil"
-	"github.com/go-resty/resty"
+	resty "gopkg.in/resty.v1"
 )
 
 type APIClient struct {

--- a/examples/clients/responsebody/api_client.go
+++ b/examples/clients/responsebody/api_client.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"net/url"
 	"io/ioutil"
-	"github.com/go-resty/resty"
+	resty "gopkg.in/resty.v1"
 )
 
 type APIClient struct {

--- a/examples/clients/unannotatedecho/api_client.go
+++ b/examples/clients/unannotatedecho/api_client.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"net/url"
 	"io/ioutil"
-	"github.com/go-resty/resty"
+	resty "gopkg.in/resty.v1"
 )
 
 type APIClient struct {


### PR DESCRIPTION
This is more important now that resty has a go.mod file

I'm having trouble getting "make test" to work for me, so I'm hoping the github checks will do a decent job of checking for compilation errors