### PR TITLE
marshal_jsonpb: Added nil slice default value

### DIFF
--- a/examples/server/responsebody.go
+++ b/examples/server/responsebody.go
@@ -33,6 +33,11 @@ func (s *responseBodyServer) ListResponseBodies(ctx context.Context, req *exampl
 }
 
 func (s *responseBodyServer) ListResponseStrings(ctx context.Context, req *examples.ResponseBodyIn) (*examples.RepeatedResponseStrings, error) {
+	if req.Data == "empty" {
+		return &examples.RepeatedResponseStrings{
+			Values: []string{},
+		}, nil
+	}
 	return &examples.RepeatedResponseStrings{
 		Values: []string{"hello", req.Data},
 	}, nil

--- a/runtime/marshal_jsonpb.go
+++ b/runtime/marshal_jsonpb.go
@@ -67,6 +67,12 @@ func (j *JSONPb) marshalNonProtoField(v interface{}) ([]byte, error) {
 		rv = rv.Elem()
 	}
 
+	if rv.Kind() == reflect.Slice {
+		if rv.IsNil() && j.EmitDefaults {
+			return []byte("[]"), nil
+		}
+	}
+
 	if rv.Kind() == reflect.Map {
 		m := make(map[string]*json.RawMessage)
 		for _, k := range rv.MapKeys() {

--- a/runtime/marshal_jsonpb.go
+++ b/runtime/marshal_jsonpb.go
@@ -67,10 +67,8 @@ func (j *JSONPb) marshalNonProtoField(v interface{}) ([]byte, error) {
 		rv = rv.Elem()
 	}
 
-	if rv.Kind() == reflect.Slice {
-		if rv.IsNil() && j.EmitDefaults {
-			return []byte("[]"), nil
-		}
+	if rv.Kind() == reflect.Slice && rv.IsNil() && j.EmitDefaults {
+		return []byte("[]"), nil
 	}
 
 	if rv.Kind() == reflect.Map {

--- a/runtime/marshal_jsonpb_test.go
+++ b/runtime/marshal_jsonpb_test.go
@@ -3,6 +3,7 @@ package runtime_test
 import (
 	"bytes"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -614,3 +615,132 @@ var (
 		// TODO(yugui) Add other well-known types once jsonpb supports them
 	}
 )
+
+func TestJSONPbMarshalResponseBodies(t *testing.T) {
+	for i, spec := range []struct {
+		input        interface{}
+		emitDefaults bool
+		verifier     func(json string)
+	}{
+		{
+			input: &examplepb.ResponseBodyOut{
+				Response: &examplepb.ResponseBodyOut_Response{Data: "abcdef"},
+			},
+			verifier: func(json string) {
+				expected := `{"response":{"data":"abcdef"}}`
+				if json != expected {
+					t.Errorf("json not equal (%q, %q)", json, expected)
+				}
+			},
+		},
+		{
+			emitDefaults: true,
+			input:        &examplepb.ResponseBodyOut{},
+			verifier: func(json string) {
+				expected := `{"response":null}`
+				if json != expected {
+					t.Errorf("json not equal (%q, %q)", json, expected)
+				}
+			},
+		},
+		{
+			input: &examplepb.RepeatedResponseBodyOut_Response{},
+			verifier: func(json string) {
+				expected := `{}`
+				if json != expected {
+					t.Errorf("json not equal (%q, %q)", json, expected)
+				}
+			},
+		},
+		{
+			emitDefaults: true,
+			input:        &examplepb.RepeatedResponseBodyOut_Response{},
+			verifier: func(json string) {
+				expected := `{"data":""}`
+				if json != expected {
+					t.Errorf("json not equal (%q, %q)", json, expected)
+				}
+			},
+		},
+		{
+			input: ([]*examplepb.RepeatedResponseBodyOut_Response)(nil),
+			verifier: func(json string) {
+				expected := `null`
+				if json != expected {
+					t.Errorf("json not equal (%q, %q)", json, expected)
+				}
+			},
+		},
+		{
+			emitDefaults: true,
+			input:        ([]*examplepb.RepeatedResponseBodyOut_Response)(nil),
+			verifier: func(json string) {
+				expected := `[]`
+				if json != expected {
+					t.Errorf("json not equal (%q, %q)", json, expected)
+				}
+			},
+		},
+		{
+			input: []*examplepb.RepeatedResponseBodyOut_Response{},
+			verifier: func(json string) {
+				expected := `[]`
+				if json != expected {
+					t.Errorf("json not equal (%q, %q)", json, expected)
+				}
+			},
+		},
+		{
+			input: []string{"something"},
+			verifier: func(json string) {
+				expected := `["something"]`
+				if json != expected {
+					t.Errorf("json not equal (%q, %q)", json, expected)
+				}
+			},
+		},
+		{
+			input: []string{},
+			verifier: func(json string) {
+				expected := `[]`
+				if json != expected {
+					t.Errorf("json not equal (%q, %q)", json, expected)
+				}
+			},
+		},
+		{
+			input: ([]string)(nil),
+			verifier: func(json string) {
+				expected := `null`
+				if json != expected {
+					t.Errorf("json not equal (%q, %q)", json, expected)
+				}
+			},
+		},
+		{
+			emitDefaults: true,
+			input:        ([]string)(nil),
+			verifier: func(json string) {
+				expected := `[]`
+				if json != expected {
+					t.Errorf("json not equal (%q, %q)", json, expected)
+				}
+			},
+		},
+	} {
+
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			m := runtime.JSONPb{
+				EmitDefaults: spec.emitDefaults,
+			}
+			val := spec.input
+			buf, err := m.Marshal(val)
+			if err != nil {
+				t.Errorf("m.Marshal(%v) failed with %v; want success; spec=%v", val, err, spec)
+			}
+			if spec.verifier != nil {
+				spec.verifier(string(buf))
+			}
+		})
+	}
+}


### PR DESCRIPTION
I noticed that when using the repeated response body, that when an empty array is returned from the grpc server, it is translated to a nil object `([]*examplepb.RepeatedResponseBodyOut_Response)(nil)`, which does not implement the `proto.Message` interface, and therefore is marshalled locally in the `runtime.JSONPb` implementation as `null` even if `EmitDefaults` is set on the marshaller.

I updated the marshaller to check for the case mentioned above and to make sure it behaves according to the `EmitDefaults` option correctly.  Let me know if I missed anything on it.

Thanks!