### PR TITLE
Use github.com/golang/protobuf/descriptor ForMessage and fix CI from not rebasing

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -23,9 +23,10 @@
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
-  digest = "1:77303a120dcd145972685b3465e58e1a0910544fcb323ca24755e073c1ea6d2c"
+  digest = "1:329b943e12961fb0c0db5bc18858433e569183178edfd0a8d99033ce032c62cc"
   name = "github.com/golang/protobuf"
   packages = [
+    "descriptor",
     "jsonpb",
     "proto",
     "protoc-gen-go",
@@ -53,7 +54,7 @@
   revision = "6724a57986aff9bff1a1770e9347036def7c89f6"
 
 [[projects]]
-  digest = "1:c0b7af9789502fec69b7ab40035a2180e43b9663c32101084ba51c844ea416e9"
+  digest = "1:505dbee0833715a72a529bb57c354826ad42a4496fad787fa143699b4de1a6d0"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -160,6 +161,7 @@
     "github.com/ghodss/yaml",
     "github.com/go-resty/resty",
     "github.com/golang/glog",
+    "github.com/golang/protobuf/descriptor",
     "github.com/golang/protobuf/jsonpb",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/protoc-gen-go",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -54,7 +54,7 @@
   revision = "6724a57986aff9bff1a1770e9347036def7c89f6"
 
 [[projects]]
-  digest = "1:505dbee0833715a72a529bb57c354826ad42a4496fad787fa143699b4de1a6d0"
+  digest = "1:c0b7af9789502fec69b7ab40035a2180e43b9663c32101084ba51c844ea416e9"
   name = "golang.org/x/net"
   packages = [
     "context",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -15,6 +15,11 @@ required = [
 
 [[constraint]]
   # Also defined in WORKSPACE
+  revision = "f8815663de1e64d57cdd4ee9e2b2fa96977a030e"
+  name = "github.com/go-resty/resty"
+
+[[constraint]]
+  # Also defined in WORKSPACE
   revision = "6724a57986aff9bff1a1770e9347036def7c89f6"
   name = "github.com/rogpeppe/fastuuid"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,5 +1,4 @@
 required = [
-  "github.com/golang/protobuf/descriptor",
   "github.com/golang/protobuf/protoc-gen-go",
 ]
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,4 +1,5 @@
 required = [
+  "github.com/golang/protobuf/descriptor",
   "github.com/golang/protobuf/protoc-gen-go",
 ]
 
@@ -12,11 +13,6 @@ required = [
   # Also defined in WORKSPACE
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   name = "github.com/ghodss/yaml"
-
-[[constraint]]
-  # Also defined in WORKSPACE
-  revision = "f8815663de1e64d57cdd4ee9e2b2fa96977a030e"
-  name = "github.com/go-resty/resty"
 
 [[constraint]]
   # Also defined in WORKSPACE

--- a/examples/proto/examplepb/stream.swagger.json
+++ b/examples/proto/examplepb/stream.swagger.json
@@ -146,7 +146,12 @@
         },
         "float_value": {
           "type": "number",
-          "format": "float"
+          "format": "float",
+          "default": "0.2",
+          "description": "Float value field",
+          "required": [
+            "float_value"
+          ]
         },
         "double_value": {
           "type": "number",
@@ -264,7 +269,9 @@
         "url": "https://github.com/grpc-ecosystem/grpc-gateway"
       },
       "required": [
-        "uuid"
+        "uuid",
+        "int64_value",
+        "double_value"
       ]
     },
     "examplepbNumericEnum": {

--- a/protoc-gen-swagger/genswagger/BUILD.bazel
+++ b/protoc-gen-swagger/genswagger/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//protoc-gen-grpc-gateway/generator:go_default_library",
         "//protoc-gen-swagger/options:go_default_library",
         "@com_github_golang_glog//:go_default_library",
+        "@com_github_golang_protobuf//descriptor:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@io_bazel_rules_go//proto/wkt:any_go_proto",
         "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -15,9 +15,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	pbdescriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
-	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
-	"github.com/golang/protobuf/ptypes/any"
-	"github.com/grpc-ecosystem/grpc-gateway/internal"
 	"github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/descriptor"
 	swagger_options "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger/options"
 )
@@ -324,28 +321,6 @@ func renderMessagesAsDefinition(messages messageMap, d swaggerDefinitionsObject,
 		}
 		d[fullyQualifiedNameToSwaggerName(msg.FQMN(), reg)] = schema
 	}
-}
-
-//AddStreamError Adds internal.StreamError and Any to registry for stream responses
-func AddStreamError(reg *descriptor.Registry) error {
-	//load internal protos
-	any, err := fileDescriptorProtoFromProtoDescriptor(&any.Any{})
-	if err != nil {
-		return err
-	}
-	streamError, err := fileDescriptorProtoFromProtoDescriptor(&internal.StreamError{})
-	if err != nil {
-		return err
-	}
-	if err := reg.Load(&plugin.CodeGeneratorRequest{
-		ProtoFile: []*pbdescriptor.FileDescriptorProto{
-			any,
-			streamError,
-		},
-	}); err != nil {
-		return err
-	}
-	return nil
 }
 
 type protoDescriptor interface {

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -1,8 +1,6 @@
 package genswagger
 
 import (
-	"bytes"
-	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -321,34 +319,6 @@ func renderMessagesAsDefinition(messages messageMap, d swaggerDefinitionsObject,
 		}
 		d[fullyQualifiedNameToSwaggerName(msg.FQMN(), reg)] = schema
 	}
-}
-
-type protoDescriptor interface {
-	Descriptor() ([]byte, []int)
-}
-
-func fileDescriptorProtoFromProtoDescriptor(pd protoDescriptor) (*pbdescriptor.FileDescriptorProto, error) {
-	pdd, _ := pd.Descriptor()
-	r, err := gzip.NewReader(bytes.NewReader(pdd))
-	if err != nil {
-		return nil, err
-	}
-	var buf bytes.Buffer
-	_, err = buf.ReadFrom(r)
-	if err != nil {
-		return nil, err
-	}
-	err = r.Close()
-	if err != nil {
-		return nil, err
-	}
-	fdp := &pbdescriptor.FileDescriptorProto{}
-	if err := proto.Unmarshal(buf.Bytes(), fdp); err != nil {
-		return nil, err
-	}
-	//hide the fact that we are loading this from the pb.go instead of the proto directly
-	fdp.SourceCodeInfo = &pbdescriptor.SourceCodeInfo{}
-	return fdp, nil
 }
 
 func renderMessagesAsStreamDefinition(messages messageMap, d swaggerDefinitionsObject, reg *descriptor.Registry) {


### PR DESCRIPTION
@johanbrandhorst this is the fix because I didn't rebase on master before you merged, also stumbled on https://godoc.org/github.com/golang/protobuf/descriptor as a replacement for the function I built to extract Descriptor