### PR TITLE
add the package name to the tags field of each endpoint in protoc-gen-swagger

### DIFF
--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -821,7 +821,7 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
 					responseSchema.Ref = strings.Replace(responseSchema.Ref, `#/definitions/`, `#/x-stream-definitions/`, 1)
 				}
 				operationObject := &swaggerOperationObject{
-					Tags:       []string{svc.GetName()},
+					Tags:       []string{fmt.Sprintf("%s.%s", svc.File.GetPackage(), svc.GetName())},
 					Parameters: parameters,
 					Responses: swaggerResponsesObject{
 						"200": swaggerResponseObject{


### PR DESCRIPTION
Currently, given a path and a http method, there is no way to identify which package it is generated from. For example, since the following swagger file generated by `protoc-gen-swagger` contains only the service name `dataService` and the rpc name `GetData`, we can't derive the _package_ name in the proto file that defines `dataService` and `GetData`. 

```json
{
  ...
  "paths": {
    "/api/v1/data": {
      "get": {
          "operationId": "GetData", // <--- the rpc name
          "tags": [
            "dataService" // <--- the service name
          ]
    }
  }
  ...
}
```

This pull request prepends the package name to the `service` name in the `tags` field. For example, if the proto file includes a line `package data;`, the tags field will be `["data.dataService"]`.  Doing this allows us to trace back the origin of the `GET /api/v1/data` http request.