### PR TITLE
add protoc-gen-swagger parameter -zero_examples=true

### DIFF
--- a/protoc-gen-grpc-gateway/descriptor/registry.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry.go
@@ -57,6 +57,9 @@ type Registry struct {
 	// otherwise the original proto name is used. It's helpful for synchronizing the swagger definition
 	// with grpc-gateway response, if it uses json tags for marshaling.
 	useJSONNamesForFields bool
+
+	// emit examples w/ zero values
+	emitZeroExamples bool
 }
 
 type repeatedFieldSeparator struct {
@@ -399,6 +402,17 @@ func (r *Registry) GetUseJSONNamesForFields() bool {
 func (r *Registry) GetMergeFileName() string {
 	return r.mergeFileName
 }
+
+// SetEmitZeroExamples controls whether to emit zero value examples
+func (r *Registry) SetEmitZeroExamples(emitZeroExamples bool) {
+	r.emitZeroExamples = emitZeroExamples
+}
+
+// GetEmitZeroExamples returns emitZeroExamples
+func (r *Registry) GetEmitZeroExamples() bool {
+	return r.emitZeroExamples
+}
+
 
 // sanitizePackageName replaces unallowed character in package name
 // with allowed character.

--- a/protoc-gen-swagger/main.go
+++ b/protoc-gen-swagger/main.go
@@ -25,6 +25,7 @@ var (
 	repeatedPathParamSeparator = flag.String("repeated_path_param_separator", "csv", "configures how repeated fields should be split. Allowed values are `csv`, `pipes`, `ssv` and `tsv`.")
 	versionFlag                = flag.Bool("version", false, "print the current verison")
 	allowRepeatedFieldsInBody  = flag.Bool("allow_repeated_fields_in_body", false, "allows to use repeated field in `body` and `response_body` field of `google.api.http` annotation option")
+	emitZeroExamples           = flag.Bool("zero_examples", false, "emit zeroed examples")
 )
 
 // Variables set by goreleaser at build time
@@ -74,6 +75,7 @@ func main() {
 	reg.SetMergeFileName(*mergeFileName)
 	reg.SetUseJSONNamesForFields(*useJSONNamesForFields)
 	reg.SetAllowRepeatedFieldsInBody(*allowRepeatedFieldsInBody)
+	reg.SetEmitZeroExamples(*emitZeroExamples)
 	if err := reg.SetRepeatedPathParamSeparator(*repeatedPathParamSeparator); err != nil {
 		emitError(err)
 		return


### PR DESCRIPTION
* parameter will cause generation of swagger.json field example values w/ zero values.