### PR TITLE
Updated Service, Method, Message Identifiers to be CamelCased

### DIFF
--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -112,7 +112,6 @@ func (b binding) FieldMaskField() string {
 			fieldMaskField = f
 		}
 	}
-
 	if fieldMaskField != nil {
 		return generator2.CamelCase(fieldMaskField.GetName())
 	}
@@ -145,13 +144,18 @@ func applyTemplate(p param, reg *descriptor.Registry) (string, error) {
 		return "", err
 	}
 	var targetServices []*descriptor.Service
+
+	for _, msg := range p.Messages {
+		msgName := generator2.CamelCase(*msg.Name)
+		msg.Name = &msgName
+	}
 	for _, svc := range p.Services {
 		var methodWithBindingsSeen bool
-		svcName := strings.Title(*svc.Name)
+		svcName := generator2.CamelCase(*svc.Name)
 		svc.Name = &svcName
 		for _, meth := range svc.Methods {
 			glog.V(2).Infof("Processing %s.%s", svc.GetName(), meth.GetName())
-			methName := strings.Title(*meth.Name)
+			methName := generator2.CamelCase(*meth.Name)
 			meth.Name = &methName
 			for _, b := range meth.Bindings {
 				methodWithBindingsSeen = true

--- a/protoc-gen-grpc-gateway/gengateway/template_test.go
+++ b/protoc-gen-grpc-gateway/gengateway/template_test.go
@@ -481,3 +481,98 @@ func TestAllowPatchFeature(t *testing.T) {
 		}
 	}
 }
+
+func TestIdentifierCapitalization(t *testing.T){
+	msgdesc1 := &protodescriptor.DescriptorProto{
+		Name: proto.String("Exam_pleRequest"),
+	}
+	msgdesc2 := &protodescriptor.DescriptorProto{
+		Name: proto.String("example_response"),
+	}
+	meth1 := &protodescriptor.MethodDescriptorProto{
+		Name:       proto.String("ExampleGe2t"),
+		InputType:  proto.String("Exam_pleRequest"),
+		OutputType: proto.String("example_response"),	
+	}
+	meth2 := &protodescriptor.MethodDescriptorProto{
+		Name:       proto.String("Exampl_eGet"),
+		InputType:  proto.String("Exam_pleRequest"),
+		OutputType: proto.String("example_response"),	
+	}
+	svc := &protodescriptor.ServiceDescriptorProto{
+		Name:   proto.String("Example"),
+		Method: []*protodescriptor.MethodDescriptorProto{meth1, meth2},
+	}
+	msg1 := &descriptor.Message{
+		DescriptorProto: msgdesc1,
+	}
+	msg2 := &descriptor.Message{
+		DescriptorProto: msgdesc2,
+	}
+	file := descriptor.File{
+		FileDescriptorProto: &protodescriptor.FileDescriptorProto{
+			Name:        proto.String("example.proto"),
+			Package:     proto.String("example"),
+			Dependency:  []string{"a.example/b/c.proto", "a.example/d/e.proto"},
+			MessageType: []*protodescriptor.DescriptorProto{msgdesc1, msgdesc2},
+			Service:     []*protodescriptor.ServiceDescriptorProto{svc},
+		},
+		GoPkg: descriptor.GoPackage{
+			Path: "example.com/path/to/example/example.pb",
+			Name: "example_pb",
+		},
+		Messages: []*descriptor.Message{msg1, msg2},
+		Services: []*descriptor.Service{
+			{
+				ServiceDescriptorProto: svc,
+				Methods: []*descriptor.Method{
+					{
+						MethodDescriptorProto: meth1,
+						RequestType:           msg1,
+						ResponseType:          msg1,
+						Bindings: []*descriptor.Binding{
+							{
+								HTTPMethod: "GET",
+								Body:       &descriptor.Body{FieldPath: nil},
+							},
+						},
+					},
+				},
+			},
+			{
+				ServiceDescriptorProto: svc,
+				Methods: []*descriptor.Method{
+					{
+						MethodDescriptorProto: meth2,
+						RequestType:           msg2,
+						ResponseType:          msg2,
+						Bindings: []*descriptor.Binding{
+							{
+								HTTPMethod: "GET",
+								Body:       &descriptor.Body{FieldPath: nil},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := applyTemplate(param{File: crossLinkFixture(&file), RegisterFuncSuffix: "Handler", AllowPatchFeature: true}, descriptor.NewRegistry())
+	if err != nil {
+		t.Errorf("applyTemplate(%#v) failed with %v; want success", file, err)
+		return
+	}
+	if want := `msg, err := client.ExampleGe2T(ctx, &protoReq, grpc.Header(&metadata.HeaderMD)`; !strings.Contains(got, want) {
+		t.Errorf("applyTemplate(%#v) = %s; want to contain %s", file, got, want)
+	}
+	if want := `msg, err := client.ExamplEGet(ctx, &protoReq, grpc.Header(&metadata.HeaderMD)`; !strings.Contains(got, want) {
+		t.Errorf("applyTemplate(%#v) = %s; want to contain %s", file, got, want)
+	}
+	if want := `var protoReq ExamPleRequest`; !strings.Contains(got, want) {
+		t.Errorf("applyTemplate(%#v) = %s; want to contain %s", file, got, want)
+	}
+	if want := `var protoReq ExampleResponse`; !strings.Contains(got, want) {
+		t.Errorf("applyTemplate(%#v) = %s; want to contain %s", file, got, want)
+	}
+}


### PR DESCRIPTION
The incompatibility caused between the generated .pb.gw.go
and .pb.go files due to inconsistent identifier capitalization
has been fixed here.

Logic from protoc-gen-go for the Message, Service and Method
Names is ported to protoc-gen-grpc-gateway.

Have made changes in the template.go file and have written a
test so we don't regress this in the future.

This fixes #683