### PR TITLE
protoc-gen-grpc-gateway: use context package from stdlib

### DIFF
--- a/examples/proto/examplepb/a_bit_of_everything.pb.gw.go
+++ b/examples/proto/examplepb/a_bit_of_everything.pb.gw.go
@@ -9,6 +9,7 @@ It translates gRPC into RESTful JSON APIs.
 package examplepb
 
 import (
+	"context"
 	"io"
 	"net/http"
 
@@ -19,7 +20,6 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/examples/proto/sub2"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"

--- a/examples/proto/examplepb/echo_service.pb.gw.go
+++ b/examples/proto/examplepb/echo_service.pb.gw.go
@@ -9,13 +9,13 @@ It translates gRPC into RESTful JSON APIs.
 package examplepb
 
 import (
+	"context"
 	"io"
 	"net/http"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"

--- a/examples/proto/examplepb/flow_combination.pb.gw.go
+++ b/examples/proto/examplepb/flow_combination.pb.gw.go
@@ -9,13 +9,13 @@ It translates gRPC into RESTful JSON APIs.
 package examplepb
 
 import (
+	"context"
 	"io"
 	"net/http"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"

--- a/examples/proto/examplepb/response_body_service.pb.gw.go
+++ b/examples/proto/examplepb/response_body_service.pb.gw.go
@@ -9,13 +9,13 @@ It translates gRPC into RESTful JSON APIs.
 package examplepb
 
 import (
+	"context"
 	"io"
 	"net/http"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"

--- a/examples/proto/examplepb/stream.pb.gw.go
+++ b/examples/proto/examplepb/stream.pb.gw.go
@@ -9,6 +9,7 @@ It translates gRPC into RESTful JSON APIs.
 package examplepb
 
 import (
+	"context"
 	"io"
 	"net/http"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/examples/proto/sub"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"

--- a/examples/proto/examplepb/unannotated_echo_service.pb.gw.go
+++ b/examples/proto/examplepb/unannotated_echo_service.pb.gw.go
@@ -9,13 +9,13 @@ It translates gRPC into RESTful JSON APIs.
 package examplepb
 
 import (
+	"context"
 	"io"
 	"net/http"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"

--- a/examples/proto/examplepb/wrappers.pb.gw.go
+++ b/examples/proto/examplepb/wrappers.pb.gw.go
@@ -9,6 +9,7 @@ It translates gRPC into RESTful JSON APIs.
 package examplepb
 
 import (
+	"context"
 	"io"
 	"net/http"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"

--- a/protoc-gen-grpc-gateway/gengateway/generator.go
+++ b/protoc-gen-grpc-gateway/gengateway/generator.go
@@ -39,12 +39,12 @@ type generator struct {
 func New(reg *descriptor.Registry, useRequestContext bool, registerFuncSuffix, pathTypeString string, allowPatchFeature bool) gen.Generator {
 	var imports []descriptor.GoPackage
 	for _, pkgpath := range []string{
+		"context",
 		"io",
 		"net/http",
 		"github.com/grpc-ecosystem/grpc-gateway/runtime",
 		"github.com/grpc-ecosystem/grpc-gateway/utilities",
 		"github.com/golang/protobuf/proto",
-		"golang.org/x/net/context",
 		"google.golang.org/grpc",
 		"google.golang.org/grpc/codes",
 		"google.golang.org/grpc/grpclog",


### PR DESCRIPTION
@johanbrandhorst this is following the discussion on https://github.com/grpc-ecosystem/grpc-gateway/issues/349