### PR TITLE
Fix parameter names when using JSON names.

### DIFF
--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -143,9 +143,7 @@ func queryParams(message *descriptor.Message, field *descriptor.Field, prefix st
 
 		if reg.GetUseJSONNamesForFields() {
 			param.Name = prefix + field.GetJsonName()
-		}
-
-		if !reg.GetUseJSONNamesForFields() || param.Name == "" {
+		} else {
 			param.Name = prefix + field.GetName()
 		}
 

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -143,7 +143,9 @@ func queryParams(message *descriptor.Message, field *descriptor.Field, prefix st
 
 		if reg.GetUseJSONNamesForFields() {
 			param.Name = prefix + field.GetJsonName()
-		} else {
+		}
+
+		if !reg.GetUseJSONNamesForFields() || param.Name == "" {
 			param.Name = prefix + field.GetName()
 		}
 

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -132,7 +132,6 @@ func queryParams(message *descriptor.Message, field *descriptor.Field, prefix st
 		}
 
 		param := swaggerParameterObject{
-			Name:        prefix + field.GetName(),
 			Description: desc,
 			In:          "query",
 			Default:     schema.Default,
@@ -140,6 +139,12 @@ func queryParams(message *descriptor.Message, field *descriptor.Field, prefix st
 			Items:       schema.Items,
 			Format:      schema.Format,
 			Required:    required,
+		}
+
+		if reg.GetUseJSONNamesForFields() {
+			param.Name = prefix + field.GetJsonName()
+		} else {
+			param.Name = prefix + field.GetName()
 		}
 
 		if isEnum {

--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -197,6 +197,91 @@ func TestMessageToQueryParameters(t *testing.T) {
 	}
 }
 
+func TestMessageToQueryParametersWithJsonName(t *testing.T) {
+	type test struct {
+		MsgDescs []*protodescriptor.DescriptorProto
+		Message  string
+		Params   []swaggerParameterObject
+	}
+
+	tests := []test{
+		{
+			MsgDescs: []*protodescriptor.DescriptorProto{
+				&protodescriptor.DescriptorProto{
+					Name: proto.String("ExampleMessage"),
+					Field: []*protodescriptor.FieldDescriptorProto{
+						{
+							Name:     proto.String("test_field_a"),
+							Type:     protodescriptor.FieldDescriptorProto_TYPE_STRING.Enum(),
+							Number:   proto.Int32(1),
+							JsonName: proto.String("testFieldA"),
+						},
+						{
+							Name:   proto.String("test_field_b"),
+							Type:   protodescriptor.FieldDescriptorProto_TYPE_STRING.Enum(),
+							Number: proto.Int32(2),
+						},
+					},
+				},
+			},
+			Message: "ExampleMessage",
+			Params: []swaggerParameterObject{
+				swaggerParameterObject{
+					Name:     "testFieldA",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+				},
+				swaggerParameterObject{
+					Name:     "test_field_b",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		reg := descriptor.NewRegistry()
+		reg.SetUseJSONNamesForFields(true)
+		msgs := []*descriptor.Message{}
+		for _, msgdesc := range test.MsgDescs {
+			msgs = append(msgs, &descriptor.Message{DescriptorProto: msgdesc})
+		}
+		file := descriptor.File{
+			FileDescriptorProto: &protodescriptor.FileDescriptorProto{
+				SourceCodeInfo: &protodescriptor.SourceCodeInfo{},
+				Name:           proto.String("example.proto"),
+				Package:        proto.String("example"),
+				Dependency:     []string{},
+				MessageType:    test.MsgDescs,
+				Service:        []*protodescriptor.ServiceDescriptorProto{},
+			},
+			GoPkg: descriptor.GoPackage{
+				Path: "example.com/path/to/example/example.pb",
+				Name: "example_pb",
+			},
+			Messages: msgs,
+		}
+		reg.Load(&plugin.CodeGeneratorRequest{
+			ProtoFile: []*protodescriptor.FileDescriptorProto{file.FileDescriptorProto},
+		})
+
+		message, err := reg.LookupMsg("", ".example."+test.Message)
+		if err != nil {
+			t.Fatalf("failed to lookup message: %s", err)
+		}
+		params, err := messageToQueryParameters(message, reg, []descriptor.Parameter{})
+		if err != nil {
+			t.Fatalf("failed to convert message to query parameters: %s", err)
+		}
+		if !reflect.DeepEqual(params, test.Params) {
+			t.Errorf("expected %v, got %v", test.Params, params)
+		}
+	}
+}
+
 func TestApplyTemplateSimple(t *testing.T) {
 	msgdesc := &protodescriptor.DescriptorProto{
 		Name: proto.String("ExampleMessage"),

--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -216,11 +216,6 @@ func TestMessageToQueryParametersWithJsonName(t *testing.T) {
 							Number:   proto.Int32(1),
 							JsonName: proto.String("testFieldA"),
 						},
-						{
-							Name:   proto.String("test_field_b"),
-							Type:   protodescriptor.FieldDescriptorProto_TYPE_STRING.Enum(),
-							Number: proto.Int32(2),
-						},
 					},
 				},
 			},
@@ -228,12 +223,6 @@ func TestMessageToQueryParametersWithJsonName(t *testing.T) {
 			Params: []swaggerParameterObject{
 				swaggerParameterObject{
 					Name:     "testFieldA",
-					In:       "query",
-					Required: false,
-					Type:     "string",
-				},
-				swaggerParameterObject{
-					Name:     "test_field_b",
 					In:       "query",
 					Required: false,
 					Type:     "string",


### PR DESCRIPTION
When using `json_names_for_fields=true`, I noticed that this works fine for field names in the request body when generating Swagger definitions, but URL parameters remain `snake_case`.

I believe this should fix it. Looking forward to your feedback.