### PR TITLE
Fixed empty path bug

### DIFF
--- a/protoc-gen-grpc-gateway/httprule/parse.go
+++ b/protoc-gen-grpc-gateway/httprule/parse.go
@@ -231,8 +231,8 @@ const (
 func (p *parser) accept(term termType) (string, error) {
 	t := p.tokens[0]
 	switch term {
-	case "*", "**", ".", "=", "{", "}":
-		if t != string(term) {
+	case "/", "*", "**", ".", "=", "{", "}":
+		if t != string(term) && t != "/" {
 			return "", fmt.Errorf("expected %q but got %q", term, t)
 		}
 	case typeEOF:

--- a/protoc-gen-grpc-gateway/httprule/parse.go
+++ b/protoc-gen-grpc-gateway/httprule/parse.go
@@ -231,7 +231,7 @@ const (
 func (p *parser) accept(term termType) (string, error) {
 	t := p.tokens[0]
 	switch term {
-	case "/", "*", "**", ".", "=", "{", "}":
+	case "*", "**", ".", "=", "{", "}":
 		if t != string(term) {
 			return "", fmt.Errorf("expected %q but got %q", term, t)
 		}

--- a/protoc-gen-grpc-gateway/httprule/parse_test.go
+++ b/protoc-gen-grpc-gateway/httprule/parse_test.go
@@ -113,6 +113,12 @@ func TestParseSegments(t *testing.T) {
 				literal("v1"),
 			},
 		},
+        {
+            tokens: []string{"/", eof},
+            want: []segment{
+                wildcard{},
+            },
+        },
 		{
 			tokens: []string{"-._~!$&'()*+,;=:@", eof},
 			want: []segment{
@@ -246,9 +252,9 @@ func TestParseSegmentsWithErrors(t *testing.T) {
 		tokens []string
 	}{
 		{
-			// double slash
-			tokens: []string{"/", eof},
-		},
+            // double slash
+            tokens: []string{"//", eof},
+        },
 		{
 			// invalid literal
 			tokens: []string{"a?b", eof},

--- a/protoc-gen-grpc-gateway/httprule/parse_test.go
+++ b/protoc-gen-grpc-gateway/httprule/parse_test.go
@@ -113,12 +113,12 @@ func TestParseSegments(t *testing.T) {
 				literal("v1"),
 			},
 		},
-        {
-            tokens: []string{"/", eof},
-            want: []segment{
-                wildcard{},
-            },
-        },
+		{
+			tokens: []string{"/", eof},
+			want: []segment{
+				wildcard{},
+			},
+		},
 		{
 			tokens: []string{"-._~!$&'()*+,;=:@", eof},
 			want: []segment{
@@ -252,9 +252,9 @@ func TestParseSegmentsWithErrors(t *testing.T) {
 		tokens []string
 	}{
 		{
-            // double slash
-            tokens: []string{"//", eof},
-        },
+			// double slash
+			tokens: []string{"//", eof},
+		},
 		{
 			// invalid literal
 			tokens: []string{"a?b", eof},


### PR DESCRIPTION
Fixes this issue: https://github.com/grpc-ecosystem/grpc-gateway/issues/414
Where "/" is not allowed.

Also added a test to verify this behaviour.

There was a previous test that prevented this behaviour. Despite the comment it was never really testing double slash, it was testing single slash.