### PR TITLE
Use proto gen swagger with protos from external repository

### DIFF
--- a/protoc-gen-swagger/defs.bzl
+++ b/protoc-gen-swagger/defs.bzl
@@ -46,11 +46,15 @@ def _run_proto_gen_swagger(ctx, direct_proto_srcs, transitive_proto_srcs, action
             options.append("grpc_api_configuration=%s" % grpc_api_configuration.path)
             inputs.append(grpc_api_configuration)
 
+        output_dir = ctx.bin_dir.path
+        if proto.owner.workspace_root:
+            output_dir = "/".join([output_dir, proto.owner.workspace_root])
+
         includes = _collect_includes(ctx.genfiles_dir.path, direct_proto_srcs + transitive_proto_srcs)
 
         args = actions.args()
         args.add("--plugin=%s" % protoc_gen_swagger.path)
-        args.add("--swagger_out=%s:%s" % (",".join(options), ctx.bin_dir.path))
+        args.add("--swagger_out=%s:%s" % (",".join(options), output_dir))
         args.add_all(["-I%s" % include for include in includes])
         args.add(proto.path)
 


### PR DESCRIPTION
Currently the protoc_gen_swagger doesn't work with protos from external repositories.
The the swagger.json file is not stored at the expected place.
Example:
protoc_gen_swagger(
        name = "action_swagger",
        proto =  "@remote//proto:action_proto"
)
fails because the action.swagger.json file is written to proto/action.swagger.json and
is expected to be at the same place as the proto external/remote/proto/action.swagger.json. Bazel can't find the generated rule and fails.