### PR TITLE
newline between JSON messages

### DIFF
--- a/runtime/marshal_jsonpb.go
+++ b/runtime/marshal_jsonpb.go
@@ -151,7 +151,15 @@ func (d DecoderWrapper) Decode(v interface{}) error {
 
 // NewEncoder returns an Encoder which writes JSON stream into "w".
 func (j *JSONPb) NewEncoder(w io.Writer) Encoder {
-	return EncoderFunc(func(v interface{}) error { return j.marshalTo(w, v) })
+	return EncoderFunc(func(v interface{}) error {
+		if err := j.marshalTo(w, v); err != nil {
+			return err
+		}
+		// mimic json.Encoder by adding a newline (makes output
+		// easier to read when it contains multiple encoded items)
+		_, err := w.Write([]byte("\n"))
+		return err
+	})
 }
 
 func unmarshalJSONPb(data []byte, v interface{}) error {

--- a/runtime/marshal_jsonpb.go
+++ b/runtime/marshal_jsonpb.go
@@ -157,7 +157,7 @@ func (j *JSONPb) NewEncoder(w io.Writer) Encoder {
 		}
 		// mimic json.Encoder by adding a newline (makes output
 		// easier to read when it contains multiple encoded items)
-		_, err := w.Write([]byte("\n"))
+		_, err := w.Write(j.Delimiter())
 		return err
 	})
 }

--- a/runtime/marshal_jsonpb_test.go
+++ b/runtime/marshal_jsonpb_test.go
@@ -278,6 +278,9 @@ func TestJSONPbEncoder(t *testing.T) {
 	}{
 		{
 			verifier: func(json string) {
+				// remove trailing delimiter before verifying
+				json = strings.TrimSuffix(json, "\n")
+
 				if strings.ContainsAny(json, " \t\r\n") {
 					t.Errorf("strings.ContainsAny(%q, %q) = true; want false", json, " \t\r\n")
 				}
@@ -356,7 +359,7 @@ func TestJSONPbEncoderFields(t *testing.T) {
 		if err := enc.Encode(fixt.data); err != nil {
 			t.Errorf("enc.Encode(%#v) failed with %v; want success", fixt.data, err)
 		}
-		if got, want := buf.String(), fixt.json; got != want {
+		if got, want := buf.String(), fixt.json + string(m.Delimiter()); got != want {
 			t.Errorf("enc.Encode(%#v) = %q; want %q", fixt.data, got, want)
 		}
 	}


### PR DESCRIPTION
This updates `JSONPb` so that its encoder function delimits output messages with a newline, just like `Encoder` in `"encoding/json"` does.