### PR TITLE
use error value for bad URI so custom error handler could treat it special

### DIFF
--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -16,6 +16,14 @@ import (
 // A HandlerFunc handles a specific pair of path pattern and HTTP method.
 type HandlerFunc func(w http.ResponseWriter, r *http.Request, pathParams map[string]string)
 
+// ErrUnknownURI is the error supplied to a custom ProtoErrorHandlerFunc when
+// a request is received with a URI path that does not match any registered
+// service method.
+//
+// Since gRPC servers return an "Unimplemented" code for requests with an
+// unrecognized URI path, this error also has a gRPC "Unimplemented" code.
+var ErrUnknownURI = status.Error(codes.Unimplemented, http.StatusText(http.StatusNotImplemented))
+
 // ServeMux is a request multiplexer for grpc-gateway.
 // It matches http requests to patterns and invokes the corresponding handler.
 type ServeMux struct {
@@ -174,8 +182,7 @@ func (s *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if idx := strings.LastIndex(components[l-1], ":"); idx == 0 {
 		if s.protoErrorHandler != nil {
 			_, outboundMarshaler := MarshalerForRequest(s, r)
-			sterr := status.Error(codes.Unimplemented, http.StatusText(http.StatusNotImplemented))
-			s.protoErrorHandler(ctx, s, outboundMarshaler, w, r, sterr)
+			s.protoErrorHandler(ctx, s, outboundMarshaler, w, r, ErrUnknownURI)
 		} else {
 			OtherErrorHandler(w, r, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 		}
@@ -235,8 +242,7 @@ func (s *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			if s.protoErrorHandler != nil {
 				_, outboundMarshaler := MarshalerForRequest(s, r)
-				sterr := status.Error(codes.Unimplemented, http.StatusText(http.StatusMethodNotAllowed))
-				s.protoErrorHandler(ctx, s, outboundMarshaler, w, r, sterr)
+				s.protoErrorHandler(ctx, s, outboundMarshaler, w, r, ErrUnknownURI)
 			} else {
 				OtherErrorHandler(w, r, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 			}
@@ -246,8 +252,7 @@ func (s *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if s.protoErrorHandler != nil {
 		_, outboundMarshaler := MarshalerForRequest(s, r)
-		sterr := status.Error(codes.Unimplemented, http.StatusText(http.StatusNotImplemented))
-		s.protoErrorHandler(ctx, s, outboundMarshaler, w, r, sterr)
+		s.protoErrorHandler(ctx, s, outboundMarshaler, w, r, ErrUnknownURI)
 	} else {
 		OtherErrorHandler(w, r, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 	}

--- a/runtime/mux_test.go
+++ b/runtime/mux_test.go
@@ -2,6 +2,7 @@ package runtime_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,8 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestMuxServeHTTP(t *testing.T) {
@@ -29,6 +32,7 @@ func TestMuxServeHTTP(t *testing.T) {
 		respContent string
 
 		disablePathLengthFallback bool
+		errHandler                runtime.ProtoErrorHandlerFunc
 	}{
 		{
 			patterns:   nil,
@@ -239,10 +243,45 @@ func TestMuxServeHTTP(t *testing.T) {
 			respStatus:  http.StatusOK,
 			respContent: "GET /foo/{id=*}:verb",
 		},
+		{
+			// mux identifying invalid path results in 'Not Found' status
+			// (with custom handler looking for ErrUnknownURI)
+			patterns: []stubPattern{
+				{
+					method: "GET",
+					ops:    []int{int(utilities.OpLitPush), 0},
+					pool:   []string{"unimplemented"},
+				},
+			},
+			reqMethod: "GET",
+			reqPath:   "/foobar",
+			respStatus:  http.StatusNotFound,
+			respContent: "GET /foobar",
+			errHandler: unknownPathIs404,
+		},
+		{
+			// server returning unimplemented results in 'Not Implemented' code
+			// even when using custom error handler
+			patterns: []stubPattern{
+				{
+					method: "GET",
+					ops:    []int{int(utilities.OpLitPush), 0},
+					pool:   []string{"unimplemented"},
+				},
+			},
+			reqMethod: "GET",
+			reqPath:   "/unimplemented",
+			respStatus:  http.StatusNotImplemented,
+			respContent: `GET /unimplemented`,
+			errHandler: unknownPathIs404,
+		},
 	} {
 		var opts []runtime.ServeMuxOption
 		if spec.disablePathLengthFallback {
 			opts = append(opts, runtime.WithDisablePathLengthFallback())
+		}
+		if spec.errHandler != nil {
+			opts = append(opts, runtime.WithProtoErrorHandler(spec.errHandler))
 		}
 		mux := runtime.NewServeMux(opts...)
 		for _, p := range spec.patterns {
@@ -252,6 +291,13 @@ func TestMuxServeHTTP(t *testing.T) {
 					t.Fatalf("runtime.NewPattern(1, %#v, %#v, %q) failed with %v; want success", p.ops, p.pool, p.verb, err)
 				}
 				mux.Handle(p.method, pat, func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+					if r.URL.Path == "/unimplemented" {
+						// simulate method returning "unimplemented" error
+						_, m := runtime.MarshalerForRequest(mux, r)
+						runtime.HTTPError(r.Context(), mux, m, w, r, status.Error(codes.Unimplemented, http.StatusText(http.StatusNotImplemented)))
+						w.WriteHeader(http.StatusNotImplemented)
+						return
+					}
 					fmt.Fprintf(w, "%s %s", p.method, pat.String())
 				})
 			}(p)
@@ -277,6 +323,17 @@ func TestMuxServeHTTP(t *testing.T) {
 			}
 		}
 	}
+}
+
+func unknownPathIs404(ctx context.Context, mux *runtime.ServeMux, m runtime.Marshaler, w http.ResponseWriter, r *http.Request, err error) {
+	if err == runtime.ErrUnknownURI {
+		w.WriteHeader(http.StatusNotFound)
+	} else {
+		stat, _ := status.FromError(err)
+		w.WriteHeader(runtime.HTTPStatusFromCode(stat.Code()))
+	}
+
+	fmt.Fprintf(w, "%s %s", r.Method, r.URL.Path)
 }
 
 var defaultHeaderMatcherTests = []struct {

--- a/runtime/mux_test.go
+++ b/runtime/mux_test.go
@@ -329,8 +329,8 @@ func unknownPathIs404(ctx context.Context, mux *runtime.ServeMux, m runtime.Mars
 	if err == runtime.ErrUnknownURI {
 		w.WriteHeader(http.StatusNotFound)
 	} else {
-		stat, _ := status.FromError(err)
-		w.WriteHeader(runtime.HTTPStatusFromCode(stat.Code()))
+		c := status.Convert(err).Code()
+		w.WriteHeader(runtime.HTTPStatusFromCode(c))
 	}
 
 	fmt.Fprintf(w, "%s %s", r.Method, r.URL.Path)


### PR DESCRIPTION
When a custom `ProtoErrorHandlerFunc` is used, it is given an error with `Unimplemented` gRPC code for cases where the server gets a request for an unrecognized URI path.

When no such handler is in place, it defaults to a "404 Not Found" error, which is what basically any REST client actually expect for such an error.

Unfortunately, there is not currently any way to distinguish between  "the server received an unrecognized URI path" and an actual "Unimplemented" error returned by a gRPC server handler. So it is not possible for a custom handler to turn those into "404 NotFound" errors, as a REST client would actually expect.

This change hoists the error out into an exported error value: `ErrUnknownURI`. That way, a custom error handler can check if `err == runtime.ErrUnknownURI` and choose to return a 404 for those errors (instead of "501 Not Implemented", which can be used for other errors with an "Unimplemented" gRPC code).