### PR TITLE
Fix make test on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ $(RESPONSE_BODY_EXAMPLE_SRCS): $(RESPONSE_BODY_EXAMPLE_SPEC)
 		$(EXAMPLE_CLIENT_DIR)/responsebody/git_push.sh
 
 examples: $(EXAMPLE_DEPSRCS) $(EXAMPLE_SVCSRCS) $(EXAMPLE_GWSRCS) $(EXAMPLE_SWAGGERSRCS) $(EXAMPLE_CLIENT_SRCS)
-	find -type f -name *.go -exec sed -s -i 's;github.com/go-resty/resty;gopkg.in/resty.v1;g' {} +
+	find . -type f -name *.go -exec sed -s -i 's;github.com/go-resty/resty;gopkg.in/resty.v1;g' {} +
 test: examples
 	go test -race ...
 	go test -race examples/integration -args -network=unix -endpoint=test.sock


### PR DESCRIPTION
`make test` errors out on MacOS because it uses bsd find instead of gnu
find which is standard in most Linux distributions. The fix just
provides an explicit folder . which bsd find requires but gnu find has
as default.

Verifying should be as simple as running make test on a clean repo with any version of gnu `find` (i.e running on linux).
