### PR TITLE
Adding bazel BUILD files for third party google protobuf dependencies

### DIFF
--- a/third_party/googleapis/google/api/BUILD
+++ b/third_party/googleapis/google/api/BUILD
@@ -14,7 +14,6 @@ proto_library(
     name = "http_proto",
     strip_import_prefix="/third_party/googleapis",
     srcs = ["http.proto"],
-    deps = [],
 )
 
 proto_library(

--- a/third_party/googleapis/google/api/BUILD
+++ b/third_party/googleapis/google/api/BUILD
@@ -1,0 +1,28 @@
+proto_library(
+    visibility = ["//visibility:public"],
+    name = "annotations_proto",
+    srcs = ["annotations.proto"],
+    strip_import_prefix="/third_party/googleapis",
+    deps = [
+      ":http_proto",
+      "@com_google_protobuf//:descriptor_proto",
+    ],
+)
+
+proto_library(
+    visibility = ["//visibility:public"],
+    name = "http_proto",
+    strip_import_prefix="/third_party/googleapis",
+    srcs = ["http.proto"],
+    deps = [],
+)
+
+proto_library(
+    visibility = ["//visibility:public"],
+    name = "httpbody_proto",
+    strip_import_prefix="/third_party/googleapis",
+    srcs = ["httpbody.proto"],
+    deps = [
+      "@com_google_protobuf//:any_proto"
+    ],
+)

--- a/third_party/googleapis/google/rpc/BUILD
+++ b/third_party/googleapis/google/rpc/BUILD
@@ -1,0 +1,29 @@
+proto_library(
+    visibility = ["//visibility:public"],
+    name = "code_proto",
+    srcs = ["code.proto"],
+    strip_import_prefix="/third_party/googleapis",
+    deps = [
+      
+    ],
+)
+
+proto_library(
+    visibility = ["//visibility:public"],
+    name = "error_details_proto",
+    srcs = ["error_details.proto"],
+    strip_import_prefix="/third_party/googleapis",
+    deps = [
+      "@com_google_protobuf//:duration_proto",
+    ],
+)
+
+proto_library(
+    visibility = ["//visibility:public"],
+    name = "status_proto",
+    srcs = ["status.proto"],
+    strip_import_prefix="/third_party/googleapis",
+    deps = [
+      "@com_google_protobuf//:any_proto",
+    ],
+)

--- a/third_party/googleapis/google/rpc/BUILD
+++ b/third_party/googleapis/google/rpc/BUILD
@@ -3,9 +3,6 @@ proto_library(
     name = "code_proto",
     srcs = ["code.proto"],
     strip_import_prefix="/third_party/googleapis",
-    deps = [
-      
-    ],
 )
 
 proto_library(


### PR DESCRIPTION
This PR adds `proto_library` declarations for the HTTP rule protobuf annotations. This makes it a easier to build proto rules with bazel which use the GPRC gateway.

## Motivation
While the permanent home of `annoations.proto` and `http.proto` appears to be [googleapis/googleapis](https://github.com/googleapis/googleapis) many projects, including [grpc-gateway](grpc-ecosystem/grpc-gateway) and [stackb](https://github.com/stackb) still have them checked in to third party/vendor folders. When depending on projects which use the annotations an end user is required to track down a copy of the googleapis annotations, even if they are only building regular grpc bindings.

I personally ran into this issue trying to build [googleforgames/open-match](https://github.com/googleforgames/open-match)

## Usage Example
### WORKSPACE File
```python
http_archive(
    name = "grpc_gateway",
    sha256 = "2ab54450b70b526a1d26ebd2ff02c9a2e8cbdaae3ed0a1d550230dbe098fc6cb",
    strip_prefix = "grpc-gateway-21f5e5895efe7cad510ff5b9a77659c77b9a8856",
    urls = ["https://github.com/cgrinker/grpc-gateway/archive/21f5e5895efe7cad510ff5b9a77659c77b9a8856.zip"],
)
```

### BUILD File
```python
proto_library(
    visibility = ["//visibility:public"],
    name = "endpoint_proto",
    srcs = ["endpoint.proto"],
    deps = [
        "@grpc_gateway//protoc-gen-swagger/options:options_proto",
        "@grpc_gateway//third_party/googleapis/google/api:annotations_proto",
    ],
)
```
### Proto File
```protobuf
option (grpc.gateway.protoc_gen_swagger.options.openapiv2_swagger) = {
  info: {
    title: "Backend"
    version: "1.0"
    contact: {
      name: "Clar Rinker"
      url: "https://github.com/cgrinker"
      email: "cgrinker@gmail.com"
    }
    license: {
      name: "Apache 2.0 License"
      url: "https://github.com/googleforgames/open-match/blob/master/LICENSE"
    }
  }
  schemes: HTTP
  schemes: HTTPS
  consumes: "application/json"
  produces: "application/json"
  responses: {
    key: "404"
    value: {
      description: "Returned when the resource does not exist."
      schema: { json_schema: { type: STRING } }
    }
  }
};

message NothingRequest {
    string nothing = 1;
}

message NothingResponse {
    string nothing = 1;
}

service Backend {
  rpc FetchNothing(FetchMatchesRequest) returns (NothingResponse) {
    option (google.api.http) = {
      post: "/v1/endpoint/endpoint:fetch"
      body: "*"
    };
  }
}
```

