### PR TITLE
EOF on send

### DIFF
--- a/examples/integration/integration_test.go
+++ b/examples/integration/integration_test.go
@@ -561,7 +561,7 @@ func testABEBulkCreateWithError(t *testing.T, port int) {
 			}
 		}()
 		for _, val := range []string{
-			"foo",
+			"foo", "bar", "baz", "qux", "quux",
 		} {
 			time.Sleep(1 * time.Millisecond)
 

--- a/examples/integration/integration_test.go
+++ b/examples/integration/integration_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
@@ -263,6 +264,7 @@ func TestABE(t *testing.T) {
 	testABECreate(t, 8080)
 	testABECreateBody(t, 8080)
 	testABEBulkCreate(t, 8080)
+	testABEBulkCreateWithError(t, 8080)
 	testABELookup(t, 8080)
 	testABELookupNotFound(t, 8080)
 	testABEList(t, 8080)
@@ -546,6 +548,65 @@ func testABEBulkCreate(t *testing.T, port int) {
 	}
 	if got, want := resp.Trailer.Get("Grpc-Trailer-Bar"), "bar2"; got != want {
 		t.Errorf("Grpc-Trailer-Bar was %q, wanted %q", got, want)
+	}
+}
+
+func testABEBulkCreateWithError(t *testing.T, port int) {
+	count := 0
+	r, w := io.Pipe()
+	go func(w io.WriteCloser) {
+		defer func() {
+			if cerr := w.Close(); cerr != nil {
+				t.Errorf("w.Close() failed with %v; want success", cerr)
+			}
+		}()
+		for _, val := range []string{
+			"foo",
+		} {
+			time.Sleep(1 * time.Millisecond)
+
+			want := gw.ABitOfEverything{
+				StringValue: fmt.Sprintf("strprefix/%s", val),
+			}
+			var m jsonpb.Marshaler
+			if err := m.Marshal(w, &want); err != nil {
+				t.Fatalf("m.Marshal(%#v, w) failed with %v; want success", want, err)
+			}
+			if _, err := io.WriteString(w, "\n"); err != nil {
+				t.Errorf("w.Write(%q) failed with %v; want success", "\n", err)
+				return
+			}
+			count++
+		}
+	}(w)
+
+	apiURL := fmt.Sprintf("http://localhost:%d/v1/example/a_bit_of_everything/bulk", port)
+	request, err := http.NewRequest("POST", apiURL, r)
+	if err != nil {
+		t.Fatalf("http.NewRequest(%q, %q, nil) failed with %v; want success", "POST", apiURL, err)
+	}
+	request.Header.Add("Grpc-Metadata-error", "some error")
+
+	resp, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Errorf("http.Post(%q) failed with %v; want success", apiURL, err)
+		return
+	}
+	defer resp.Body.Close()
+	buf, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		return
+	}
+
+	if got, want := resp.StatusCode, http.StatusBadRequest; got != want {
+		t.Errorf("resp.StatusCode = %d; want %d", got, want)
+		t.Logf("%s", buf)
+	}
+
+	var msg errorBody
+	if err := json.Unmarshal(buf, &msg); err != nil {
+		t.Fatalf("json.Unmarshal(%s, &msg) failed with %v; want success", buf, err)
 	}
 }
 

--- a/examples/proto/examplepb/flow_combination.pb.gw.go
+++ b/examples/proto/examplepb/flow_combination.pb.gw.go
@@ -73,6 +73,9 @@ func request_FlowCombination_StreamEmptyRpc_0(ctx context.Context, marshaler run
 			return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
+			if err == io.EOF {
+				break
+			}
 			grpclog.Infof("Failed to send request: %v", err)
 			return nil, metadata, err
 		}

--- a/examples/proto/examplepb/stream.pb.gw.go
+++ b/examples/proto/examplepb/stream.pb.gw.go
@@ -49,6 +49,9 @@ func request_StreamService_BulkCreate_0(ctx context.Context, marshaler runtime.M
 			return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
+			if err == io.EOF {
+				break
+			}
 			grpclog.Infof("Failed to send request: %v", err)
 			return nil, metadata, err
 		}

--- a/examples/server/a_bit_of_everything.go
+++ b/examples/server/a_bit_of_everything.go
@@ -65,8 +65,15 @@ func (s *_ABitOfEverythingServer) CreateBody(ctx context.Context, msg *examples.
 }
 
 func (s *_ABitOfEverythingServer) BulkCreate(stream examples.StreamService_BulkCreateServer) error {
-	count := 0
 	ctx := stream.Context()
+
+	if header, ok := metadata.FromIncomingContext(ctx); ok {
+		if v, ok := header["error"]; ok {
+			return status.Errorf(codes.InvalidArgument, "error metadata: %v", v)
+		}
+	}
+
+	count := 0
 	for {
 		msg, err := stream.Recv()
 		if err == io.EOF {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,6 @@ require (
 	google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
 	google.golang.org/grpc v1.19.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/resty.v1 v1.12.0
+	gopkg.in/resty.v1 v1.12.0 // indirect
 	gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,6 @@ require (
 	google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
 	google.golang.org/grpc v1.19.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/resty.v1 v1.12.0 // indirect
+	gopkg.in/resty.v1 v1.12.0
 	gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7 // indirect
 )

--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -254,6 +254,9 @@ func request_{{.Method.Service.GetName}}_{{.Method.GetName}}_{{.Index}}(ctx cont
 			return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
+			if err == io.EOF {
+				break
+			}
 			grpclog.Infof("Failed to send request: %v", err)
 			return nil, metadata, err
 		}


### PR DESCRIPTION
As we suggested on #961, add a verification for `io.EOF` on the generated code template, along with an integration test