### PR TITLE
Fix query.go to avoid invalid protobuf assumptions

### DIFF
--- a/runtime/query.go
+++ b/runtime/query.go
@@ -202,103 +202,102 @@ func populateField(f reflect.Value, value string, props *proto.Properties) error
 	i := f.Addr().Interface()
 
 	// Handle protobuf well known types
-	type wkt interface {
-		XXX_WellKnownType() string
-	}
-	if wkt, ok := i.(wkt); ok {
-		switch wkt.XXX_WellKnownType() {
-		case "Timestamp":
-			if value == "null" {
-				f.Field(0).SetInt(0)
-				f.Field(1).SetInt(0)
-				return nil
-			}
-
-			t, err := time.Parse(time.RFC3339Nano, value)
-			if err != nil {
-				return fmt.Errorf("bad Timestamp: %v", err)
-			}
-			f.Field(0).SetInt(int64(t.Unix()))
-			f.Field(1).SetInt(int64(t.Nanosecond()))
-			return nil
-		case "Duration":
-			if value == "null" {
-				f.Field(0).SetInt(0)
-				f.Field(1).SetInt(0)
-				return nil
-			}
-			d, err := time.ParseDuration(value)
-			if err != nil {
-				return fmt.Errorf("bad Duration: %v", err)
-			}
-
-			ns := d.Nanoseconds()
-			s := ns / 1e9
-			ns %= 1e9
-			f.Field(0).SetInt(s)
-			f.Field(1).SetInt(ns)
-			return nil
-		case "DoubleValue":
-			fallthrough
-		case "FloatValue":
-			float64Val, err := strconv.ParseFloat(value, 64)
-			if err != nil {
-				return fmt.Errorf("bad DoubleValue: %s", value)
-			}
-			f.Field(0).SetFloat(float64Val)
-			return nil
-		case "Int64Value":
-			fallthrough
-		case "Int32Value":
-			int64Val, err := strconv.ParseInt(value, 10, 64)
-			if err != nil {
-				return fmt.Errorf("bad DoubleValue: %s", value)
-			}
-			f.Field(0).SetInt(int64Val)
-			return nil
-		case "UInt64Value":
-			fallthrough
-		case "UInt32Value":
-			uint64Val, err := strconv.ParseUint(value, 10, 64)
-			if err != nil {
-				return fmt.Errorf("bad DoubleValue: %s", value)
-			}
-			f.Field(0).SetUint(uint64Val)
-			return nil
-		case "BoolValue":
-			if value == "true" {
-				f.Field(0).SetBool(true)
-			} else if value == "false" {
-				f.Field(0).SetBool(false)
-			} else {
-				return fmt.Errorf("bad BoolValue: %s", value)
-			}
-			return nil
-		case "StringValue":
-			f.Field(0).SetString(value)
-			return nil
-		case "BytesValue":
-			bytesVal, err := base64.StdEncoding.DecodeString(value)
-			if err != nil {
-				return fmt.Errorf("bad BytesValue: %s", value)
-			}
-			f.Field(0).SetBytes(bytesVal)
-			return nil
+	var name string
+	switch m := i.(type) {
+	case interface{ XXX_WellKnownType() string }:
+		name = m.XXX_WellKnownType()
+	case proto.Message:
+		const wktPrefix = "google.protobuf."
+		if fullName := proto.MessageName(m); strings.HasPrefix(fullName, wktPrefix) {
+			name = fullName[len(wktPrefix):]
 		}
 	}
-
-	// Handle google well known types
-	if gwkt, ok := i.(proto.Message); ok {
-		switch proto.MessageName(gwkt) {
-		case "google.protobuf.FieldMask":
-			p := f.Field(0)
-			for _, v := range strings.Split(value, ",") {
-				if v != "" {
-					p.Set(reflect.Append(p, reflect.ValueOf(v)))
-				}
-			}
+	switch name {
+	case "Timestamp":
+		if value == "null" {
+			f.FieldByName("Seconds").SetInt(0)
+			f.FieldByName("Nanos").SetInt(0)
 			return nil
 		}
+
+		t, err := time.Parse(time.RFC3339Nano, value)
+		if err != nil {
+			return fmt.Errorf("bad Timestamp: %v", err)
+		}
+		f.FieldByName("Seconds").SetInt(int64(t.Unix()))
+		f.FieldByName("Nanos").SetInt(int64(t.Nanosecond()))
+		return nil
+	case "Duration":
+		if value == "null" {
+			f.FieldByName("Seconds").SetInt(0)
+			f.FieldByName("Nanos").SetInt(0)
+			return nil
+		}
+		d, err := time.ParseDuration(value)
+		if err != nil {
+			return fmt.Errorf("bad Duration: %v", err)
+		}
+
+		ns := d.Nanoseconds()
+		s := ns / 1e9
+		ns %= 1e9
+		f.FieldByName("Seconds").SetInt(s)
+		f.FieldByName("Nanos").SetInt(ns)
+		return nil
+	case "DoubleValue":
+		fallthrough
+	case "FloatValue":
+		float64Val, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return fmt.Errorf("bad DoubleValue: %s", value)
+		}
+		f.FieldByName("Value").SetFloat(float64Val)
+		return nil
+	case "Int64Value":
+		fallthrough
+	case "Int32Value":
+		int64Val, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return fmt.Errorf("bad DoubleValue: %s", value)
+		}
+		f.FieldByName("Value").SetInt(int64Val)
+		return nil
+	case "UInt64Value":
+		fallthrough
+	case "UInt32Value":
+		uint64Val, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return fmt.Errorf("bad DoubleValue: %s", value)
+		}
+		f.FieldByName("Value").SetUint(uint64Val)
+		return nil
+	case "BoolValue":
+		if value == "true" {
+			f.FieldByName("Value").SetBool(true)
+		} else if value == "false" {
+			f.FieldByName("Value").SetBool(false)
+		} else {
+			return fmt.Errorf("bad BoolValue: %s", value)
+		}
+		return nil
+	case "StringValue":
+		f.FieldByName("Value").SetString(value)
+		return nil
+	case "BytesValue":
+		bytesVal, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return fmt.Errorf("bad BytesValue: %s", value)
+		}
+		f.FieldByName("Value").SetBytes(bytesVal)
+		return nil
+	case "FieldMask":
+		p := f.FieldByName("Paths")
+		for _, v := range strings.Split(value, ",") {
+			if v != "" {
+				p.Set(reflect.Append(p, reflect.ValueOf(v)))
+			}
+		}
+		return nil
 	}
 
 	// Handle Time and Duration stdlib types


### PR DESCRIPTION
The golang/protobuf compatibility agreement reserves the right add/remove
XXX fields and methods.

Fix this code to avoid assuming:
* that XXX_WellKnownType always exists (it won't in the future).
Instead, it should determine whether a message is a well-known type
based on its full name.
* that Go struct field indexes are stable (they aren't).
An internal field may be added to the front of the message,
causing the current assumptions to be invalidated.
Instead, access the struct field by name, which will not change.