### PR TITLE
Fix HTTP Status Code returned for a `Failed Precondition` error

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -37,7 +37,8 @@ func HTTPStatusFromCode(code codes.Code) int {
 	case codes.ResourceExhausted:
 		return http.StatusTooManyRequests
 	case codes.FailedPrecondition:
-		return http.StatusPreconditionFailed
+		// Note, this deliberately doesn't translate to the similarly named '412 Precondition Failed' HTTP response status.
+		return http.StatusBadRequest
 	case codes.Aborted:
 		return http.StatusConflict
 	case codes.OutOfRange:

--- a/runtime/errors_test.go
+++ b/runtime/errors_test.go
@@ -40,7 +40,7 @@ func TestDefaultHTTPError(t *testing.T) {
 		},
 		{
 			err:     statusWithDetails.Err(),
-			status:  http.StatusPreconditionFailed,
+			status:  http.StatusBadRequest,
 			msg:     "failed precondition",
 			details: "type.googleapis.com/google.rpc.PreconditionFailure",
 		},


### PR DESCRIPTION
Fixes #972 (and reverses #657). This now returns the semantically correct `400` response, rather than a `412`. This matches the gRPC documentation.