### PR TITLE
Fix release script

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 builds:
   - main: ./protoc-gen-grpc-gateway/main.go
+    id: protoc-gen-grpc-gateway
     binary: protoc-gen-grpc-gateway
     env:
       - CGO_ENABLED=0
@@ -10,6 +11,7 @@ builds:
     goarch:
       - amd64
   - main: ./protoc-gen-swagger/main.go
+    id: protoc-gen-swagger
     binary: protoc-gen-swagger
     env:
       - CGO_ENABLED=0
@@ -19,9 +21,9 @@ builds:
       - windows
     goarch:
       - amd64
-archive:
-  name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
-  format: binary
-  replacements:
-    amd64: x86_64
+archives:
+  - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
+    format: binary
+    replacements:
+      amd64: x86_64
 dist: _output


### PR DESCRIPTION
Specify an "id" for each build, as this was otherwise inferred
and duplicate for our two builds.

Also remove the use of the deprecated "archive" instruction
in favour of "archives".

Fixes #981