### PR TITLE
Add doc for opentracing support

### DIFF
--- a/docs/_docs/customizingyourgateway.md
+++ b/docs/_docs/customizingyourgateway.md
@@ -154,6 +154,28 @@ if err := http.ListenAndServe(":8080", tracingWrapper(mux)); err != nil {
 }
 ```
 
+Finally, don't forget to add a tracing interceptor when registering
+the services. E.g.
+
+```go
+import (
+   ...
+   "google.golang.org/grpc"
+   "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
+)
+
+opts := []grpc.DialOption{
+  grpc.WithUnaryInterceptor(
+    grpc_opentracing.UnaryClientInterceptor(
+      grpc_opentracing.WithTracer(opentracing.GlobalTracer()),
+    ),
+  ),
+}
+if err := pb.RegisterMyServiceHandlerFromEndpoint(ctx, mux, serviceEndpoint, opts); err != nil {
+	log.Fatalf("could not register HTTP service: %v", err)
+}
+```
+
 ## Error handler
 http://mycodesmells.com/post/grpc-gateway-error-handler
 


### PR DESCRIPTION
Mention the fact that the client must be initialized with an opentracing interceptor to allow the propagation of spans through the gateway.

I originally followed the doc but completely forgot about adding this interceptor to the gRPC client. Thought it might help others save time.
Please let me know if this isn't accurate enough (or wrong!).