### PR TITLE
Camel case backward compatible in Swagger doc

### DIFF
--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -626,7 +626,7 @@ func templateToSwaggerPath(path string, reg *descriptor.Registry) string {
 			buffer += string(char)
 			if reg.GetUseJSONNamesForFields() &&
 				len(jsonBuffer) > 1 {
-				jsonSnakeCaseName := string(jsonBuffer[1 : len(buffer)-1])
+				jsonSnakeCaseName := string(jsonBuffer[1:])
 				jsonCamelCaseName := string(lowerCamelCase(jsonSnakeCaseName))
 				prev := string(buffer[:len(buffer)-len(jsonSnakeCaseName)-2])
 				buffer = strings.Join([]string{prev, "{", jsonCamelCaseName, "}"}, "")
@@ -641,6 +641,7 @@ func templateToSwaggerPath(path string, reg *descriptor.Registry) string {
 				continue
 			}
 			buffer += string(char)
+			jsonBuffer += string(char)
 		default:
 			buffer += string(char)
 			jsonBuffer += string(char)

--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -914,6 +914,14 @@ func TestTemplateToSwaggerPath(t *testing.T) {
 		{"/{parent=prefix/*}/children:customMethod", "/{parent=prefix/*}/children:customMethod"},
 	}
 	reg := descriptor.NewRegistry()
+	reg.SetUseJSONNamesForFields(false)
+	for _, data := range tests {
+		actual := templateToSwaggerPath(data.input, reg)
+		if data.expected != actual {
+			t.Errorf("Expected templateToSwaggerPath(%v) = %v, actual: %v", data.input, data.expected, actual)
+		}
+	}
+	reg.SetUseJSONNamesForFields(true)
 	for _, data := range tests {
 		actual := templateToSwaggerPath(data.input, reg)
 		if data.expected != actual {
@@ -991,6 +999,14 @@ func TestFQMNtoSwaggerName(t *testing.T) {
 		{"/{test1}/{test2}/", "/{test1}/{test2}/"},
 	}
 	reg := descriptor.NewRegistry()
+	reg.SetUseJSONNamesForFields(false)
+	for _, data := range tests {
+		actual := templateToSwaggerPath(data.input, reg)
+		if data.expected != actual {
+			t.Errorf("Expected templateToSwaggerPath(%v) = %v, actual: %v", data.input, data.expected, actual)
+		}
+	}
+	reg.SetUseJSONNamesForFields(true)
 	for _, data := range tests {
 		actual := templateToSwaggerPath(data.input, reg)
 		if data.expected != actual {


### PR DESCRIPTION
Hi @johanbrandhorst,
In the PR, https://github.com/grpc-ecosystem/grpc-gateway/pull/985, the snake case arguments will be converted to lower camel case when the `json_names_for_fields ` is enabled.
Now, I noticed that there is a backward compatible use case may need to support, which is `/` could be inside `{}`, for example, `"/{user.name=prefix/*}:customMethod"`. (Sorry I did not notice that)
Also, when calculating `jsonSnakeCaseName`, if the name includes `/`, then it could cause `out of range` potentially. So, fixed it too.
Sorry for about.
