### PR TITLE
protoc-gen-swagger: correctly type struct.proto types

### DIFF
--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -62,6 +62,21 @@ var wktSchemas = map[string]schemaCore{
 		Format: "boolean",
 	},
 	".google.protobuf.Empty": schemaCore{},
+	".google.protobuf.Struct": schemaCore{
+		Type: "object",
+	},
+	".google.protobuf.Value": schemaCore{
+		Type: "object",
+	},
+	".google.protobuf.ListValue": schemaCore{
+		Type: "array",
+		Items: (*swaggerItemsObject)(&schemaCore{
+			Type: "object",
+		}),
+	},
+	".google.protobuf.NullValue": schemaCore{
+		Type: "string",
+	},
 }
 
 func listEnumNames(enum *descriptor.Enum) (names []string) {

--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -1196,6 +1196,61 @@ func TestSchemaOfField(t *testing.T) {
 		{
 			field: &descriptor.Field{
 				FieldDescriptorProto: &protodescriptor.FieldDescriptorProto{
+					Name:     proto.String("wrapped_field"),
+					TypeName: proto.String(".google.protobuf.Struct"),
+					Type:     protodescriptor.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+				},
+			},
+			refs: make(refMap),
+			expected: schemaCore{
+				Type: "object",
+			},
+		},
+		{
+			field: &descriptor.Field{
+				FieldDescriptorProto: &protodescriptor.FieldDescriptorProto{
+					Name:     proto.String("wrapped_field"),
+					TypeName: proto.String(".google.protobuf.Value"),
+					Type:     protodescriptor.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+				},
+			},
+			refs: make(refMap),
+			expected: schemaCore{
+				Type: "object",
+			},
+		},
+		{
+			field: &descriptor.Field{
+				FieldDescriptorProto: &protodescriptor.FieldDescriptorProto{
+					Name:     proto.String("wrapped_field"),
+					TypeName: proto.String(".google.protobuf.ListValue"),
+					Type:     protodescriptor.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+				},
+			},
+			refs: make(refMap),
+			expected: schemaCore{
+				Type: "array",
+				Items: (*swaggerItemsObject)(&schemaCore{
+					Type: "object",
+				}),
+			},
+		},
+		{
+			field: &descriptor.Field{
+				FieldDescriptorProto: &protodescriptor.FieldDescriptorProto{
+					Name:     proto.String("wrapped_field"),
+					TypeName: proto.String(".google.protobuf.NullValue"),
+					Type:     protodescriptor.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+				},
+			},
+			refs: make(refMap),
+			expected: schemaCore{
+				Type: "string",
+			},
+		},
+		{
+			field: &descriptor.Field{
+				FieldDescriptorProto: &protodescriptor.FieldDescriptorProto{
 					Name:     proto.String("message_field"),
 					TypeName: proto.String(".example.Message"),
 					Type:     protodescriptor.FieldDescriptorProto_TYPE_MESSAGE.Enum(),


### PR DESCRIPTION
Fixes #989 

The NullValue, Value and List types are not accurately describable, but this is better than it was.

I've tested all 4 of these definitions with https://editor.swagger.io/ so I'm confident it produces correct output.