### PR TITLE
Disable Windows CI Bazel

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -30,13 +30,3 @@ platforms:
     - "--test_tag_filters=-nomacos"
     test_targets:
     - "..."
-  windows:
-    build_flags:
-    - "--build_tag_filters=-nowindows"
-    build_targets:
-    - "..."
-    test_flags:
-    - "--test_tag_filters=-nowindows"
-    - "--experimental_enable_runfiles"
-    test_targets:
-    - "..."


### PR DESCRIPTION
We don't have a maintainer for Bazel windows. If you want to volunteer, send a PR
rolling this back and let's fix it.