### PR TITLE
Add Continuous Fuzzing Integration via fuzzit.dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,14 @@ jobs:
       - checkout
       - run: go get golang.org/x/lint/golint
       - run: make lint
+  fuzzit:
+    docker:
+      - image: fuzzitdev/fuzzit:golang1.12-stretch-llvm9
+    working_directory: /go/src/github.com/grpc-gateway/grpc-gateway
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: ./fuzzit.sh
   bazel:
     docker:
       - image: l.gcr.io/google/bazel:latest
@@ -88,6 +96,7 @@ workflows:
     jobs:
       - build
       - test
+      - fuzzit
       - node_test
       - generate
       - lint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grpc-gateway
 
-[![release](https://img.shields.io/github/release/grpc-ecosystem/grpc-gateway.svg?style=flat-square)](https://github.com/grpc-ecosystem/grpc-gateway/releases) [![CircleCI](https://img.shields.io/circleci/project/github/grpc-ecosystem/grpc-gateway/master.svg?style=flat-square)](https://circleci.com/gh/grpc-ecosystem/grpc-gateway) [![coverage](https://img.shields.io/codecov/c/github/grpc-ecosystem/grpc-gateway/master.svg?style=flat-square)](https://codecov.io/gh/grpc-ecosystem/grpc-gateway) [![license](https://img.shields.io/github/license/grpc-ecosystem/grpc-gateway.svg?style=flat-square)](LICENSE.txt)
+[![release](https://img.shields.io/github/release/grpc-ecosystem/grpc-gateway.svg?style=flat-square)](https://github.com/grpc-ecosystem/grpc-gateway/releases) [![CircleCI](https://img.shields.io/circleci/project/github/grpc-ecosystem/grpc-gateway/master.svg?style=flat-square)](https://circleci.com/gh/grpc-ecosystem/grpc-gateway) [![fuzzit](https://app.fuzzit.dev/badge?org_id=grpc-gateway)](https://app.fuzzit.dev/orgs/grpc-gateway/dashboard) [![coverage](https://img.shields.io/codecov/c/github/grpc-ecosystem/grpc-gateway/master.svg?style=flat-square)](https://codecov.io/gh/grpc-ecosystem/grpc-gateway) [![license](https://img.shields.io/github/license/grpc-ecosystem/grpc-gateway.svg?style=flat-square)](LICENSE.txt)
 
 The grpc-gateway is a plugin of the Google protocol buffers compiler
 [protoc](https://github.com/protocolbuffers/protobuf).

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -xe
+
+# Go-fuzz doesn't support modules yet, so ensure we do everything in the old style GOPATH way
+export GO111MODULE="off"
+
+# Install go-fuzz
+go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+
+# Compiling fuzz targets in fuzz.go with go-fuzz (https://github.com/dvyukov/go-fuzz) and libFuzzer support
+# This is a workaround until go-fuzz has gomodules support https://github.com/dvyukov/go-fuzz/issues/195
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+git branch --set-upstream-to=origin/master $BRANCH
+
+go get -v -u ./protoc-gen-grpc-gateway/httprule
+go-fuzz-build -libfuzzer -o parse-http-rule.a ./protoc-gen-grpc-gateway/httprule
+clang-9 -fsanitize=fuzzer parse-http-rule.a -o parse-http-rule
+
+wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.29/fuzzit_Linux_x86_64
+chmod a+x fuzzit
+
+if [ -z "CIRCLE_PULL_REQUEST" ]; then
+    TYPE="fuzzing"
+else
+    TYPE="local-regression"
+fi
+./fuzzit create job --type ${TYPE} grpc-gateway/parse-http-rule parse-http-rule

--- a/protoc-gen-grpc-gateway/httprule/fuzz.go
+++ b/protoc-gen-grpc-gateway/httprule/fuzz.go
@@ -1,0 +1,11 @@
+// +build gofuzz
+
+package httprule
+
+func Fuzz(data []byte) int {
+	_, err := Parse(string(data))
+	if err != nil {
+		return 0
+	}
+	return 0
+}


### PR DESCRIPTION
This PR adds a continuous fuzzing integration to grpc-gateway Circle pipeline via Fuzzit service.

This means the following:

- Every time new code is pushed to master new fuzzers are built and push to fuzzit where they run continuously generate new test-cases and alerts if new crashes are found
- Every pull-request the fuzzers runs through a quick regression tests with the generated test-cases from the previous step. If something new/old bugs are introduced you will see this immediately in the Travis check.

To take ownership of the organisation, please login to https://app.fuzzit.dev and let me know your account.

This is PR relates to this issue:
https://github.com/grpc-ecosystem/grpc-gateway/issues/998

Also this PR lays the foundation with the first basic go-fuzz target function that fuzzes the http-rule.

Please review and feel free to comment/ask questions

cc @johanbrandhorst 