### PR TITLE
Fix hand-crafted protobuf message

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -66,12 +66,12 @@ var (
 )
 
 type errorBody struct {
-	Error string `protobuf:"bytes,1,name=error" json:"error"`
+	Error string `protobuf:"bytes,100,name=error" json:"error"`
 	// This is to make the error more compatible with users that expect errors to be Status objects:
 	// https://github.com/grpc/grpc/blob/master/src/proto/grpc/status/status.proto
 	// It should be the exact same message as the Error field.
-	Message string     `protobuf:"bytes,1,name=message" json:"message"`
-	Code    int32      `protobuf:"varint,2,name=code" json:"code"`
+	Code    int32      `protobuf:"varint,1,name=code" json:"code"`
+	Message string     `protobuf:"bytes,2,name=message" json:"message"`
 	Details []*any.Any `protobuf:"bytes,3,rep,name=details" json:"details,omitempty"`
 }
 


### PR DESCRIPTION
errorBody is an improperly hand-crafted protobuf Message.
In particular, field number 1 is used twice, causing this to
message to crash in the v2 re-implementation of Go protobufs.

This PR modifies the field numbers to be unique.
Since Error is a special field not in status.proto,
we choose a large field number to avoid conflicting with
any new field that may be added to the real Status message.
We also fix the field numbers to truly match up with Status.