### PR TITLE
docs need type assertion on proto.Message

### DIFF
--- a/docs/_docs/customizingyourgateway.md
+++ b/docs/_docs/customizingyourgateway.md
@@ -104,7 +104,7 @@ Or you might want to mutate the response messages to be returned.
 1. Write a filter function.
    ```go
    func myFilter(ctx context.Context, w http.ResponseWriter, resp proto.Message) error {
-        t, ok := resp.(*external.Tokenizer)
+        t, ok := resp.(*externalpb.Tokenizer)
 
 	if ok {
 	  w.Header().Set("X-My-Tracking-Token", t.Token)

--- a/docs/_docs/customizingyourgateway.md
+++ b/docs/_docs/customizingyourgateway.md
@@ -104,8 +104,13 @@ Or you might want to mutate the response messages to be returned.
 1. Write a filter function.
    ```go
    func myFilter(ctx context.Context, w http.ResponseWriter, resp proto.Message) error {
-   	w.Header().Set("X-My-Tracking-Token", resp.Token)
-   	resp.Token = ""
+        t, ok := resp.(*external.Tokenizer)
+
+	if ok {
+	  w.Header().Set("X-My-Tracking-Token", t.Token)
+	  t.Token = ""
+	}
+
    	return nil
    }
    ```


### PR DESCRIPTION
makes a bit more sense with the type assertion and not using the `proto.Message` directly.