### PR TITLE
nitpick spacing in other proto files

### DIFF
--- a/examples/proto/examplepb/response_body_service.pb.go
+++ b/examples/proto/examplepb/response_body_service.pb.go
@@ -50,7 +50,7 @@ func (x RepeatedResponseBodyOut_Response_ResponseType) String() string {
 	return proto.EnumName(RepeatedResponseBodyOut_Response_ResponseType_name, int32(x))
 }
 func (RepeatedResponseBodyOut_Response_ResponseType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_response_body_service_d3778d99bb1173be, []int{2, 0, 0}
+	return fileDescriptor_response_body_service_dd1070a6693ff118, []int{2, 0, 0}
 }
 
 type ResponseBodyIn struct {
@@ -64,7 +64,7 @@ func (m *ResponseBodyIn) Reset()         { *m = ResponseBodyIn{} }
 func (m *ResponseBodyIn) String() string { return proto.CompactTextString(m) }
 func (*ResponseBodyIn) ProtoMessage()    {}
 func (*ResponseBodyIn) Descriptor() ([]byte, []int) {
-	return fileDescriptor_response_body_service_d3778d99bb1173be, []int{0}
+	return fileDescriptor_response_body_service_dd1070a6693ff118, []int{0}
 }
 func (m *ResponseBodyIn) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ResponseBodyIn.Unmarshal(m, b)
@@ -102,7 +102,7 @@ func (m *ResponseBodyOut) Reset()         { *m = ResponseBodyOut{} }
 func (m *ResponseBodyOut) String() string { return proto.CompactTextString(m) }
 func (*ResponseBodyOut) ProtoMessage()    {}
 func (*ResponseBodyOut) Descriptor() ([]byte, []int) {
-	return fileDescriptor_response_body_service_d3778d99bb1173be, []int{1}
+	return fileDescriptor_response_body_service_dd1070a6693ff118, []int{1}
 }
 func (m *ResponseBodyOut) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ResponseBodyOut.Unmarshal(m, b)
@@ -140,7 +140,7 @@ func (m *ResponseBodyOut_Response) Reset()         { *m = ResponseBodyOut_Respon
 func (m *ResponseBodyOut_Response) String() string { return proto.CompactTextString(m) }
 func (*ResponseBodyOut_Response) ProtoMessage()    {}
 func (*ResponseBodyOut_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_response_body_service_d3778d99bb1173be, []int{1, 0}
+	return fileDescriptor_response_body_service_dd1070a6693ff118, []int{1, 0}
 }
 func (m *ResponseBodyOut_Response) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ResponseBodyOut_Response.Unmarshal(m, b)
@@ -178,7 +178,7 @@ func (m *RepeatedResponseBodyOut) Reset()         { *m = RepeatedResponseBodyOut
 func (m *RepeatedResponseBodyOut) String() string { return proto.CompactTextString(m) }
 func (*RepeatedResponseBodyOut) ProtoMessage()    {}
 func (*RepeatedResponseBodyOut) Descriptor() ([]byte, []int) {
-	return fileDescriptor_response_body_service_d3778d99bb1173be, []int{2}
+	return fileDescriptor_response_body_service_dd1070a6693ff118, []int{2}
 }
 func (m *RepeatedResponseBodyOut) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RepeatedResponseBodyOut.Unmarshal(m, b)
@@ -217,7 +217,7 @@ func (m *RepeatedResponseBodyOut_Response) Reset()         { *m = RepeatedRespon
 func (m *RepeatedResponseBodyOut_Response) String() string { return proto.CompactTextString(m) }
 func (*RepeatedResponseBodyOut_Response) ProtoMessage()    {}
 func (*RepeatedResponseBodyOut_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_response_body_service_d3778d99bb1173be, []int{2, 0}
+	return fileDescriptor_response_body_service_dd1070a6693ff118, []int{2, 0}
 }
 func (m *RepeatedResponseBodyOut_Response) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RepeatedResponseBodyOut_Response.Unmarshal(m, b)
@@ -262,7 +262,7 @@ func (m *RepeatedResponseStrings) Reset()         { *m = RepeatedResponseStrings
 func (m *RepeatedResponseStrings) String() string { return proto.CompactTextString(m) }
 func (*RepeatedResponseStrings) ProtoMessage()    {}
 func (*RepeatedResponseStrings) Descriptor() ([]byte, []int) {
-	return fileDescriptor_response_body_service_d3778d99bb1173be, []int{3}
+	return fileDescriptor_response_body_service_dd1070a6693ff118, []int{3}
 }
 func (m *RepeatedResponseStrings) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RepeatedResponseStrings.Unmarshal(m, b)
@@ -438,10 +438,10 @@ var _ResponseBodyService_serviceDesc = grpc.ServiceDesc{
 }
 
 func init() {
-	proto.RegisterFile("examples/proto/examplepb/response_body_service.proto", fileDescriptor_response_body_service_d3778d99bb1173be)
+	proto.RegisterFile("examples/proto/examplepb/response_body_service.proto", fileDescriptor_response_body_service_dd1070a6693ff118)
 }
 
-var fileDescriptor_response_body_service_d3778d99bb1173be = []byte{
+var fileDescriptor_response_body_service_dd1070a6693ff118 = []byte{
 	// 441 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x94, 0xcf, 0xaa, 0xd3, 0x40,
 	0x14, 0xc6, 0x9d, 0xb4, 0x5e, 0x6f, 0x27, 0x72, 0x6f, 0x99, 0x2b, 0xf7, 0x86, 0x22, 0x1a, 0x07,

--- a/examples/proto/examplepb/response_body_service.proto
+++ b/examples/proto/examplepb/response_body_service.proto
@@ -5,50 +5,54 @@ package grpc.gateway.examples.examplepb;
 
 import "google/api/annotations.proto";
 
-message ResponseBodyIn { string data = 1; }
+message ResponseBodyIn {
+	string data = 1;
+}
 
 message ResponseBodyOut {
-  message Response { string data = 1; }
-  Response response = 2;
+	message Response {
+		string data = 1;
+	}
+	Response response = 2;
 }
 
 message RepeatedResponseBodyOut {
-  message Response {
-    string data = 1;
-    enum ResponseType {
-      // UNKNOWN
-      UNKNOWN = 0;
-      // A is 1
-      A = 1;
-      // B is 2
-      B = 2;
-    }
-    ResponseType type = 3;
-  }
-  repeated Response response = 2;
+	message Response {
+		string data = 1;
+		enum ResponseType {
+			// UNKNOWN
+			UNKNOWN = 0;
+			// A is 1
+			A = 1;
+			// B is 2
+			B = 2;
+		}
+		ResponseType type = 3;
+	}
+	repeated Response response = 2;
 }
 
-message RepeatedResponseStrings { repeated string values = 1; }
+message RepeatedResponseStrings {
+	repeated string values = 1;
+}
 
 service ResponseBodyService {
-  rpc GetResponseBody(ResponseBodyIn) returns (ResponseBodyOut) {
-    option (google.api.http) = {
-      get : "/responsebody/{data}"
-      response_body : "response"
-    };
-  }
-
-  rpc ListResponseBodies(ResponseBodyIn) returns (RepeatedResponseBodyOut) {
-    option (google.api.http) = {
-      get : "/responsebodies/{data}"
-      response_body : "response"
-    };
-  }
-
-  rpc ListResponseStrings(ResponseBodyIn) returns (RepeatedResponseStrings) {
-    option (google.api.http) = {
-      get : "/responsestrings/{data}"
-      response_body : "values"
-    };
-  }
+	rpc GetResponseBody(ResponseBodyIn) returns (ResponseBodyOut) {
+		option (google.api.http) = {
+			get : "/responsebody/{data}"
+			response_body : "response"
+		};
+	}
+	rpc ListResponseBodies(ResponseBodyIn) returns (RepeatedResponseBodyOut) {
+		option (google.api.http) = {
+			get : "/responsebodies/{data}"
+			response_body : "response"
+		};
+	}
+	rpc ListResponseStrings(ResponseBodyIn) returns (RepeatedResponseStrings) {
+		option (google.api.http) = {
+			get : "/responsestrings/{data}"
+			response_body : "values"
+		};
+	}
 }

--- a/examples/proto/examplepb/unannotated_echo_service.proto
+++ b/examples/proto/examplepb/unannotated_echo_service.proto
@@ -28,10 +28,10 @@ service UnannotatedEchoService {
 	// The message posted as the id parameter will also be
 	// returned.
 	rpc Echo(UnannotatedSimpleMessage) returns (UnannotatedSimpleMessage);
-    
+
 	// EchoBody method receives a simple message and returns it.
 	rpc EchoBody(UnannotatedSimpleMessage) returns (UnannotatedSimpleMessage);
 	
-        // EchoDelete method receives a simple message and returns it.
+	// EchoDelete method receives a simple message and returns it.
 	rpc EchoDelete(UnannotatedSimpleMessage) returns (UnannotatedSimpleMessage);
 }

--- a/examples/proto/examplepb/wrappers.pb.go
+++ b/examples/proto/examplepb/wrappers.pb.go
@@ -45,7 +45,7 @@ func (m *Wrappers) Reset()         { *m = Wrappers{} }
 func (m *Wrappers) String() string { return proto.CompactTextString(m) }
 func (*Wrappers) ProtoMessage()    {}
 func (*Wrappers) Descriptor() ([]byte, []int) {
-	return fileDescriptor_wrappers_1614a2b17737abd3, []int{0}
+	return fileDescriptor_wrappers_357c0312be7b0bb0, []int{0}
 }
 func (m *Wrappers) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Wrappers.Unmarshal(m, b)
@@ -535,10 +535,10 @@ var _WrappersService_serviceDesc = grpc.ServiceDesc{
 }
 
 func init() {
-	proto.RegisterFile("examples/proto/examplepb/wrappers.proto", fileDescriptor_wrappers_1614a2b17737abd3)
+	proto.RegisterFile("examples/proto/examplepb/wrappers.proto", fileDescriptor_wrappers_357c0312be7b0bb0)
 }
 
-var fileDescriptor_wrappers_1614a2b17737abd3 = []byte{
+var fileDescriptor_wrappers_357c0312be7b0bb0 = []byte{
 	// 578 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x95, 0xdd, 0x6e, 0xd3, 0x30,
 	0x14, 0xc7, 0xd5, 0x31, 0xca, 0xea, 0x0c, 0xc6, 0x0c, 0x82, 0xcd, 0x9b, 0x18, 0xca, 0x0d, 0xb0,

--- a/examples/proto/examplepb/wrappers.proto
+++ b/examples/proto/examplepb/wrappers.proto
@@ -26,64 +26,64 @@ service WrappersService {
 		};
 	}
 
-  rpc CreateStringValue(google.protobuf.StringValue) returns (google.protobuf.StringValue) {
-    option (google.api.http) = {
-      post: "/v1/testString"
-      body: "*"
-    };
-  }
-  rpc CreateInt32Value(google.protobuf.Int32Value) returns (google.protobuf.Int32Value) {
-    option (google.api.http) = {
-      post: "/v1/testInt32"
-      body: "*"
-    };
-  }
-  rpc CreateInt64Value(google.protobuf.Int64Value) returns (google.protobuf.Int64Value){
-    option (google.api.http) = {
-      post: "/v1/testInt64"
-      body: "*"
-    };
-  }
-  rpc CreateFloatValue(google.protobuf.FloatValue) returns (google.protobuf.FloatValue){
-    option (google.api.http) = {
-      post: "/v1/testFloat"
-      body: "*"
-    };
-  }
-  rpc CreateDoubleValue(google.protobuf.DoubleValue) returns (google.protobuf.DoubleValue){
-    option (google.api.http) = {
-      post: "/v1/testDouble"
-      body: "*"
-    };
-  }
-  rpc CreateBoolValue(google.protobuf.BoolValue) returns (google.protobuf.BoolValue){
-    option (google.api.http) = {
-      post: "/v1/testBool"
-      body: "*"
-    };
-  }
-  rpc CreateUInt32Value(google.protobuf.UInt32Value) returns (google.protobuf.UInt32Value){
-    option (google.api.http) = {
-      post: "/v1/testUint32"
-      body: "*"
-    };
-  }
-  rpc CreateUInt64Value(google.protobuf.UInt64Value) returns (google.protobuf.UInt64Value){
-    option (google.api.http) = {
-      post: "/v1/testUint64"
-      body: "*"
-    };
-  }
-  rpc CreateBytesValue(google.protobuf.BytesValue) returns (google.protobuf.BytesValue){
-    option (google.api.http) = {
-      post: "/v1/testBytes"
-      body: "*"
-    };
-  }
-  rpc CreateEmpty(google.protobuf.Empty) returns (google.protobuf.Empty){
-    option (google.api.http) = {
-      post: "/v1/testEmpty"
-      body: "*"
-    };
-  }
+	rpc CreateStringValue(google.protobuf.StringValue) returns (google.protobuf.StringValue) {
+		option (google.api.http) = {
+			post: "/v1/testString"
+			body: "*"
+		};
+	}
+	rpc CreateInt32Value(google.protobuf.Int32Value) returns (google.protobuf.Int32Value) {
+		option (google.api.http) = {
+			post: "/v1/testInt32"
+			body: "*"
+		};
+	}
+	rpc CreateInt64Value(google.protobuf.Int64Value) returns (google.protobuf.Int64Value){
+		option (google.api.http) = {
+			post: "/v1/testInt64"
+			body: "*"
+		};
+	}
+	rpc CreateFloatValue(google.protobuf.FloatValue) returns (google.protobuf.FloatValue){
+		option (google.api.http) = {
+			post: "/v1/testFloat"
+			body: "*"
+		};
+	}
+	rpc CreateDoubleValue(google.protobuf.DoubleValue) returns (google.protobuf.DoubleValue){
+		option (google.api.http) = {
+			post: "/v1/testDouble"
+			body: "*"
+		};
+	}
+	rpc CreateBoolValue(google.protobuf.BoolValue) returns (google.protobuf.BoolValue){
+		option (google.api.http) = {
+			post: "/v1/testBool"
+			body: "*"
+		};
+	}
+	rpc CreateUInt32Value(google.protobuf.UInt32Value) returns (google.protobuf.UInt32Value){
+		option (google.api.http) = {
+			post: "/v1/testUint32"
+			body: "*"
+		};
+	}
+	rpc CreateUInt64Value(google.protobuf.UInt64Value) returns (google.protobuf.UInt64Value){
+		option (google.api.http) = {
+			post: "/v1/testUint64"
+			body: "*"
+		};
+	}
+	rpc CreateBytesValue(google.protobuf.BytesValue) returns (google.protobuf.BytesValue){
+		option (google.api.http) = {
+			post: "/v1/testBytes"
+			body: "*"
+		};
+	}
+	rpc CreateEmpty(google.protobuf.Empty) returns (google.protobuf.Empty){
+		option (google.api.http) = {
+			post: "/v1/testEmpty"
+			body: "*"
+		};
+	}
 }


### PR DESCRIPTION
@johanbrandhorst was asking for it 😉 

I'm not sure why `examples/proto/examplepb/unannotated_echo_service.pb.go` wasn't rebuilt, though. 🤔 