### PR TITLE
added additional info for custom http headers

### DIFF
--- a/docs/_docs/customizingyourgateway.md
+++ b/docs/_docs/customizingyourgateway.md
@@ -102,9 +102,14 @@ You might not like [the default mapping rule](http://godoc.org/github.com/grpc-e
   ```
 
 ## Mapping from gRPC server metadata to HTTP response headers
-ditto. Use [`WithOutgoingHeaderMatcher`](http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#WithOutgoingHeaderMatcher). See [gRPC metadata docs](https://github.com/grpc/grpc-go/blob/
-master/Documentation/grpc-metadata.md) for more info on sending / receiving gRPC metadata.
+ditto. Use [`WithOutgoingHeaderMatcher`]
+(http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#WithOutgoingHeaderMatcher).
+See [gRPC metadata docs]
+(https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md) for
+more info on sending / receiving gRPC metadata.
+
   e.g.
+
   ```go
   ...
   if appendCustomHeader {

--- a/docs/_docs/customizingyourgateway.md
+++ b/docs/_docs/customizingyourgateway.md
@@ -83,18 +83,36 @@ You might not like [the default mapping rule](http://godoc.org/github.com/grpc-e
 1. Write a [`HeaderMatcherFunc`](http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#HeaderMatcherFunc).
 2. Register the function with [`WithIncomingHeaderMatcher`](http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#WithIncomingHeaderMatcher)
 
-   e.g.
-   ```go
-   func yourMatcher(headerName string) (mdName string, ok bool) {
-   	...
-   }
-   ...
-   mux := runtime.NewServeMux(runtime.WithIncomingHeaderMatcher(yourMatcher))
+  e.g.
+  ```go
+  func CustomMatcher(key string) (string, bool) {
+    switch key {
+    case "x-custom-header1":
+      return key, true
+    case "x-custom-header2":
+      return "custom-header2", true
+    default:
+      return key, false
+    }
+  }
+  ...
 
-   ```
+  mux := runtime.NewServeMux(runtime.WithIncomingHeaderMatcher(CustomMatcher))
+
+  ```
 
 ## Mapping from gRPC server metadata to HTTP response headers
-ditto. Use [`WithOutgoingHeaderMatcher`](http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#WithOutgoingHeaderMatcher)
+ditto. Use [`WithOutgoingHeaderMatcher`](http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#WithOutgoingHeaderMatcher). See [gRPC metadata docs](https://github.com/grpc/grpc-go/blob/
+master/Documentation/grpc-metadata.md) for more info on sending / receiving gRPC metadata.
+  e.g.
+  ```go
+  ...
+  if appendCustomHeader {
+    grpc.SendHeader(ctx, metadata.New(map[string]string{
+			"x-custom-header1": "value",
+		}))
+  }
+  ```
 
 ## Mutate response messages or set response headers
 You might want to return a subset of response fields as HTTP response headers; 

--- a/docs/_docs/customizingyourgateway.md
+++ b/docs/_docs/customizingyourgateway.md
@@ -102,11 +102,9 @@ You might not like [the default mapping rule](http://godoc.org/github.com/grpc-e
   ```
 
 ## Mapping from gRPC server metadata to HTTP response headers
-ditto. Use [`WithOutgoingHeaderMatcher`]
-(http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#WithOutgoingHeaderMatcher).
-See [gRPC metadata docs]
-(https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md) for
-more info on sending / receiving gRPC metadata.
+ditto. Use [`WithOutgoingHeaderMatcher`](http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#WithOutgoingHeaderMatcher).
+See [gRPC metadata docs](https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md)
+for more info on sending / receiving gRPC metadata.
 
   e.g.
 


### PR DESCRIPTION
Hi all,

First pull request (ever). Love grpc-gateway, keep up the great work!

I've made a couple of tiny changes to the "Customizing Your Gateway" docs page:

1. Added a `HeaderMatcherFunc` example, showing a couple of ways of returning the custom header key.
2. Added a small example of sending a response header from the server using `gRPC.SendHeader()` as well as a small pointer to the gRPC metadata docs for more info.

That's it! It would have help me a little if they were there when I was setting this up for the first time, so I'm hoping this will help others. 

Thanks!