### PR TITLE
examples/integration: wait for secondary gateway

### DIFF
--- a/examples/integration/integration_test.go
+++ b/examples/integration/integration_test.go
@@ -1479,6 +1479,10 @@ func testResponseStrings(t *testing.T, port int) {
 		}
 	}()
 
+	if err := waitForGateway(ctx, 8081); err != nil {
+		t.Fatalf("waitForGateway(ctx, 8081) failed with %v; want success", err)
+	}
+
 	port = 8081
 
 	for i, spec := range []struct {


### PR DESCRIPTION
I haven't been able to reproduce #992, but this looks like a likely fix. ;)
