### PR TITLE
WIP: openapi v3 support

### DIFF
--- a/protoc-gen-swagger/options/BUILD.bazel
+++ b/protoc-gen-swagger/options/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -13,8 +12,17 @@ filegroup(
 
 go_library(
     name = "go_default_library",
-    embed = [":options_go_proto"],
+    srcs = [
+        "annotations.pb.go",
+        "openapiv2.pb.go",
+    ],
     importpath = "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger/options",
+    deps = [
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@io_bazel_rules_go//proto/wkt:any_go_proto",
+        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
+        "@io_bazel_rules_go//proto/wkt:struct_go_proto",
+    ],
 )
 
 proto_library(
@@ -22,17 +30,11 @@ proto_library(
     srcs = [
         "annotations.proto",
         "openapiv2.proto",
+        "openapiv3.proto",
     ],
     deps = [
         "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:descriptor_proto",
         "@com_google_protobuf//:struct_proto",
     ],
-)
-
-go_proto_library(
-    name = "options_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
-    importpath = "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger/options",
-    proto = ":options_proto",
 )

--- a/protoc-gen-swagger/options/annotations_v3.proto
+++ b/protoc-gen-swagger/options/annotations_v3.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package grpc.gateway.protoc_gen_openapi.options;
+
+option go_package = "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger/options";
+
+import "protoc-gen-swagger/options/openapiv3.proto";
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.FileOptions {
+  // ID assigned by protobuf-global-extension-registry@google.com for grpc-gateway project.
+  //
+  // All IDs are the same, as assigned. It is okay that they are the same, as they extend
+  // different descriptor messages.
+  OpenAPI openapiv3 = 1042;
+}
+
+extend google.protobuf.MethodOptions {
+  // ID assigned by protobuf-global-extension-registry@google.com for grpc-gateway project.
+  //
+  // All IDs are the same, as assigned. It is okay that they are the same, as they extend
+  // different descriptor messages.
+  Operation openapiv3_operation = 1042;
+}
+
+extend google.protobuf.MessageOptions {
+  // ID assigned by protobuf-global-extension-registry@google.com for grpc-gateway project.
+  //
+  // All IDs are the same, as assigned. It is okay that they are the same, as they extend
+  // different descriptor messages.
+  Schema openapiv3_schema = 1042;
+}
+
+extend google.protobuf.FieldOptions {
+  // ID assigned by protobuf-global-extension-registry@google.com for grpc-gateway project.
+  //
+  // All IDs are the same, as assigned. It is okay that they are the same, as they extend
+  // different descriptor messages.
+  JSONSchema openapiv3_field = 1042;
+}

--- a/protoc-gen-swagger/options/openapiv3.proto
+++ b/protoc-gen-swagger/options/openapiv3.proto
@@ -128,7 +128,7 @@ message JSONSchema {
 
 message Discriminator {
   string propertyName = 1;
-  mapping map<string, string> = 2;
+  map<string, string> mapping = 2;
   map<string, google.protobuf.Value> extensions = 3;
 }
 
@@ -200,5 +200,8 @@ message ExternalDocs {
 }
 
 message SecurityRequirement {
-  map<string, repeated string> requirement = 1;
+  message SecurityRequirementValue {
+    repeated string scope = 1;
+  }
+  map<string, SecurityRequirementValue> security_requirement = 1;
 }

--- a/protoc-gen-swagger/options/openapiv3.proto
+++ b/protoc-gen-swagger/options/openapiv3.proto
@@ -11,7 +11,7 @@ message OpenAPI {
   Info info = 2;
   repeated Server servers = 3;
   Components components = 4;
-  repeated map<string, repeated string> security = 5;
+  repeated SecurityRequirement security = 5;
   repeated Tag tags = 6;
   map<string, google.protobuf.Value> extensions = 7;
 }
@@ -24,7 +24,7 @@ message Operation {
   string operation_id = 5;
   map<string, Response> responses = 6;
   bool deprecated = 7;
-  repeated map<string, repeated string> security = 8;
+  repeated SecurityRequirement security = 8;
   repeated Server servers = 9;
   map<string, google.protobuf.Value> extensions = 10;
 }
@@ -66,9 +66,9 @@ message ServerVariable {
 }
 
 message Components {
-  map<string Schema> schemas = 1;
-  map<string Response> responses = 2;
-  map<string SecurityScheme> securitySchemes = 3;
+  map<string, Schema> schemas = 1;
+  map<string, Response> responses = 2;
+  map<string, SecurityScheme> securitySchemes = 3;
   map<string, google.protobuf.Value> extensions = 4;
 }
 
@@ -128,7 +128,7 @@ message JSONSchema {
 
 message Discriminator {
   string propertyName = 1;
-  mapping map<string, string> 2;
+  mapping map<string, string> = 2;
   map<string, google.protobuf.Value> extensions = 3;
 }
 
@@ -197,4 +197,8 @@ message ExternalDocs {
   string name = 1;
   string url = 2;
   map<string, google.protobuf.Value> extensions = 3;
+}
+
+message SecurityRequirement {
+  map<string, repeated string> requirement = 1;
 }

--- a/protoc-gen-swagger/options/openapiv3.proto
+++ b/protoc-gen-swagger/options/openapiv3.proto
@@ -1,0 +1,200 @@
+syntax = "proto3";
+
+package grpc.gateway.protoc_gen_openapi.options;
+
+option go_package = "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger/options";
+
+import "google/protobuf/struct.proto";
+
+message OpenAPI {
+  string openapi = 1;
+  Info info = 2;
+  repeated Server servers = 3;
+  Components components = 4;
+  repeated map<string, repeated string> security = 5;
+  repeated Tag tags = 6;
+  map<string, google.protobuf.Value> extensions = 7;
+}
+
+message Operation {
+  repeated string tags = 1;
+  string summary = 2;
+  string description = 3;
+  ExternalDocs externalDocs = 4;
+  string operation_id = 5;
+  map<string, Response> responses = 6;
+  bool deprecated = 7;
+  repeated map<string, repeated string> security = 8;
+  repeated Server servers = 9;
+  map<string, google.protobuf.Value> extensions = 10;
+}
+
+message Info {
+  string title = 1;
+  string description = 2;
+  string terms_of_service = 3;
+  Contact contact = 4;
+  License license = 5;
+  string version = 6;
+  map<string, google.protobuf.Value> extensions = 7;
+}
+
+message Contact {
+  string name = 1;
+  string url = 2;
+  string email = 3;
+  map<string, google.protobuf.Value> extensions = 4;
+}
+
+message License {
+  string name = 1;
+  string url = 2;
+  map<string, google.protobuf.Value> extensions = 3;
+}
+
+message Servers {
+  string url = 1;
+  string description = 2;
+  map<string, google.protobuf.Value> extensions = 3;
+}
+
+message ServerVariable {
+  repeated string enum = 1;
+  string default = 2;
+  string description = 3;
+  map<string, google.protobuf.Value> extensions = 4;
+}
+
+message Components {
+  map<string Schema> schemas = 1;
+  map<string Response> responses = 2;
+  map<string SecurityScheme> securitySchemes = 3;
+  map<string, google.protobuf.Value> extensions = 4;
+}
+
+message Schema {
+  JSONSchema json_schema = 1;
+  bool nullable = 2;
+  Discriminator discriminator = 3;
+  bool read_only = 4;
+  bool writeOnly = 5;
+  ExternalDocs externalDocs = 6;
+  google.protobuf.Any example = 7;
+  bool deprecated = 8;
+  map<string, google.protobuf.Value> extensions = 9;
+}
+
+message JSONSchema {
+  // Ref is used to define an external reference to include in the message.
+  // This could be a fully qualified proto message reference, and that type must be imported
+  // into the protofile. If no message is identified, the Ref will be used verbatim in
+  // the output.
+  // For example:
+  //  `ref: ".google.protobuf.Timestamp"`.
+  string ref = 1;
+  string title = 2;
+  string description = 3;
+  string default = 4;
+  bool read_only = 5;
+  double multiple_of = 6;
+  double maximum = 7;
+  bool exclusive_maximum = 8;
+  double minimum = 9;
+  bool exclusive_minimum = 10;
+  uint64 max_length = 11;
+  uint64 min_length = 12;
+  string pattern = 13;
+  uint64 max_items = 14;
+  uint64 min_items = 15;
+  bool unique_items = 16;
+  uint64 max_properties = 17;
+  uint64 min_properties = 18;
+  repeated string required = 19;
+  repeated string array = 20;
+
+  enum JSONSchemaSimpleTypes {
+    UNKNOWN = 0;
+    ARRAY = 1;
+    BOOLEAN = 2;
+    INTEGER = 3;
+    NULL = 4;
+    NUMBER = 5;
+    OBJECT = 6;
+    STRING = 7;
+  }
+
+  repeated JSONSchemaSimpleTypes type = 21;
+}
+
+message Discriminator {
+  string propertyName = 1;
+  mapping map<string, string> 2;
+  map<string, google.protobuf.Value> extensions = 3;
+}
+
+message ExternalDocumentation {
+  string description = 1;
+  string url = 2;
+  map<string, google.protobuf.Value> extensions = 3;
+}
+
+message Response {
+  string description = 1;
+}
+
+message SecurityScheme {
+  enum Type {
+    INVALID = 0;
+    HTTP = 1;
+    API_KEY = 2;
+    OAUTH2 = 3;
+    OPENID_CONNECT = 4;
+  }
+
+  Type type = 1;
+  string description = 2;
+  string name = 3;
+
+  enum In {
+    INVALID = 0;
+    QUERY = 1;
+    HEADER = 2;
+    COOKIE = 3;
+  }
+
+  In in = 4;
+  string scheme = 5;
+  string bearerFormat = 6;
+  Flows flows = 7;
+  string openIdConnectUrl = 8;
+  map<string, google.protobuf.Value> extensions = 9;
+}
+
+message Flows {
+  message Flow {
+    string authorizationUrl = 1;
+    string tokenUrl = 2;
+    string refreshUrl = 3;
+    map <string, string> scopes = 4;
+    map<string, google.protobuf.Value> extensions = 5;
+  }
+
+  Flow implicit = 1;
+  Flow password = 2;
+  Flow clientCredentials = 3;
+  Flow authorizationCode = 4;
+  map<string, google.protobuf.Value> extensions = 5;
+}
+
+message Tag {
+  string name = 1;
+  string description = 2;
+  ExternalDocs externalDocs = 3;
+  map<string, google.protobuf.Value> extensions = 4;
+}
+
+message ExternalDocs {
+  string name = 1;
+  string url = 2;
+  map<string, google.protobuf.Value> extensions = 3;
+}


### PR DESCRIPTION
This is 100% a work in progress and is meant to be available for the rest of the community to view the progress towards supporting OPENAPI v3 mentioned in #441 

## Summary of the major changes to the proto between v2 and v3:

- `Swagger` top level key is gone, it's replace by `OpenAPI`
- Removal of all of the reserved fields that were placeholders for fields we may want to add later but never actually added (was confusing to look at and unused). A YAGNI approach
- the proto and annotations packages now end in `openapi` (bye bye swagger)
- `Servers` is a new top level key
- `extensions` have been added to all messages that support them as per the spec
- `Annotations` going to basically stay the same (missing tags right now)
- A tiny sprinkle of new fields were added like `Discriminator`
- `SecurityScheme` has seen some slight tweaks around `types` and `in` that are supported as field options.
- Most comments have been removed as it currently makes the proto a bit easier to read (they will go back in soon).

## Questions
- `Components` as a a Field has been added but it is missing quite a few fields that we could support (which do we want)

As a note - all of the fields that we supported in v2 were moved to v3 (seems like the base level of support we would need). If you see a field that is missing please ping this.
