### PR TITLE
adding build-scoping for builds on earlier go versions (<1.12)

### DIFF
--- a/protoc-gen-swagger/genswagger/BUILD.bazel
+++ b/protoc-gen-swagger/genswagger/BUILD.bazel
@@ -7,6 +7,8 @@ go_library(
     srcs = [
         "doc.go",
         "generator.go",
+        "helpers.go",
+        "helpers_go111_old.go",
         "template.go",
         "types.go",
     ],

--- a/protoc-gen-swagger/genswagger/generator.go
+++ b/protoc-gen-swagger/genswagger/generator.go
@@ -67,10 +67,6 @@ func mergeTargetFile(targets []*wrapper, mergeFileName string) *wrapper {
 	return mergedTarget
 }
 
-func fieldName(k string) string {
-	return strings.ReplaceAll(strings.Title(k), "-", "_")
-}
-
 // Q: What's up with the alias types here?
 // A: We don't want to completely override how these structs are marshaled into
 //    JSON, we only want to add fields (see below, extensionMarshalJSON).

--- a/protoc-gen-swagger/genswagger/helpers.go
+++ b/protoc-gen-swagger/genswagger/helpers.go
@@ -1,0 +1,9 @@
+//+build go1.12
+
+package genswagger
+
+import "strings"
+
+func fieldName(k string) string {
+	return strings.ReplaceAll(strings.Title(k), "-", "_")
+}

--- a/protoc-gen-swagger/genswagger/helpers_go111_old.go
+++ b/protoc-gen-swagger/genswagger/helpers_go111_old.go
@@ -1,0 +1,9 @@
+//+build !go1.12
+
+package genswagger
+
+import "strings"
+
+func fieldName(k string) string {
+	return strings.Replace(strings.Title(k), "-", "_", -1)
+}


### PR DESCRIPTION
Fixes #1061 

This PR moves the helper function using `strings.ReplaceAll` to a new file which has build tags for `go.1.12`, limiting it to `go1.12+` builds. Also added a file for `go` versions lesser than `1.12`, using `strings.Replace` in place of `strings.ReplaceAll`.