### PR TITLE
fix(protoc-gen-swagger): Windows compatibility

### DIFF
--- a/protoc-gen-swagger/defs.bzl
+++ b/protoc-gen-swagger/defs.bzl
@@ -57,7 +57,7 @@ def _run_proto_gen_swagger(ctx, direct_proto_srcs, transitive_proto_srcs, action
         options.append("merge_file_name=%s" % ctx.attr.name)
 
         args = actions.args()
-        args.add("--plugin=%s" % protoc_gen_swagger.path)
+        args.add("--plugin=protoc-gen-swagger=%s" % protoc_gen_swagger.path)
         args.add("--swagger_out=%s:%s" % (",".join(options), output_dir))
         args.add_all(["-I%s" % include for include in includes])
         args.add_all([src.path for src in direct_proto_srcs])
@@ -86,7 +86,7 @@ def _run_proto_gen_swagger(ctx, direct_proto_srcs, transitive_proto_srcs, action
                 output_dir = "/".join([output_dir, proto.owner.workspace_root])
 
             args = actions.args()
-            args.add("--plugin=%s" % protoc_gen_swagger.path)
+            args.add("--plugin=protoc-gen-swagger=%s" % protoc_gen_swagger.path)
             args.add("--swagger_out=%s:%s" % (",".join(options), output_dir))
             args.add_all(["-I%s" % include for include in includes])
             args.add(proto.path)


### PR DESCRIPTION
Inspired by protobuf.bzl from the main bazel repo:
https://github.com/bazelbuild/bazel/blob/deeeba3fc8003cbbcc73e04f14fc5b5275e72e5d/third_party/protobuf/3.6.1/protobuf.bzl#L108

This PR introducing a windows mapping from protoc-gen-swagger to the binary's actual path.