### PR TITLE
Support creating a Swagger def with no schemes

### DIFF
--- a/examples/clients/echo/api/swagger.yaml
+++ b/examples/clients/echo/api/swagger.yaml
@@ -4,9 +4,6 @@ info:
   description: "Echo Service API consists of a single service which returns\na message."
   version: "version not set"
   title: "Echo Service"
-schemes:
-- "http"
-- "https"
 consumes:
 - "application/json"
 produces:

--- a/examples/clients/echo/configuration.go
+++ b/examples/clients/echo/configuration.go
@@ -60,7 +60,7 @@ type Configuration struct {
 
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
-		BasePath:      "http://localhost",
+		BasePath:      "https://localhost",
 		DefaultHeader: make(map[string]string),
 		UserAgent:     "Swagger-Codegen/1.0.0/go",
 	}

--- a/examples/clients/responsebody/api/swagger.yaml
+++ b/examples/clients/responsebody/api/swagger.yaml
@@ -3,9 +3,6 @@ swagger: "2.0"
 info:
   version: "version not set"
   title: "examples/proto/examplepb/response_body_service.proto"
-schemes:
-- "http"
-- "https"
 consumes:
 - "application/json"
 produces:

--- a/examples/clients/responsebody/configuration.go
+++ b/examples/clients/responsebody/configuration.go
@@ -60,7 +60,7 @@ type Configuration struct {
 
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
-		BasePath:      "http://localhost",
+		BasePath:      "https://localhost",
 		DefaultHeader: make(map[string]string),
 		UserAgent:     "Swagger-Codegen/1.0.0/go",
 	}

--- a/examples/clients/responsebody/docs/ResponseBodyServiceApi.md
+++ b/examples/clients/responsebody/docs/ResponseBodyServiceApi.md
@@ -1,6 +1,6 @@
 # \ResponseBodyServiceApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/examples/clients/unannotatedecho/api/swagger.yaml
+++ b/examples/clients/unannotatedecho/api/swagger.yaml
@@ -7,9 +7,6 @@ info:
     \ service which returns\na message."
   version: "version not set"
   title: "examples/proto/examplepb/unannotated_echo_service.proto"
-schemes:
-- "http"
-- "https"
 consumes:
 - "application/json"
 produces:

--- a/examples/clients/unannotatedecho/configuration.go
+++ b/examples/clients/unannotatedecho/configuration.go
@@ -60,7 +60,7 @@ type Configuration struct {
 
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
-		BasePath:      "http://localhost",
+		BasePath:      "https://localhost",
 		DefaultHeader: make(map[string]string),
 		UserAgent:     "Swagger-Codegen/1.0.0/go",
 	}

--- a/examples/proto/examplepb/echo_service.swagger.json
+++ b/examples/proto/examplepb/echo_service.swagger.json
@@ -5,10 +5,6 @@
     "description": "Echo Service API consists of a single service which returns\na message.",
     "version": "version not set"
   },
-  "schemes": [
-    "http",
-    "https"
-  ],
   "consumes": [
     "application/json"
   ],

--- a/examples/proto/examplepb/response_body_service.swagger.json
+++ b/examples/proto/examplepb/response_body_service.swagger.json
@@ -4,10 +4,6 @@
     "title": "examples/proto/examplepb/response_body_service.proto",
     "version": "version not set"
   },
-  "schemes": [
-    "http",
-    "https"
-  ],
   "consumes": [
     "application/json"
   ],

--- a/examples/proto/examplepb/stream.swagger.json
+++ b/examples/proto/examplepb/stream.swagger.json
@@ -4,10 +4,6 @@
     "title": "examples/proto/examplepb/stream.proto",
     "version": "version not set"
   },
-  "schemes": [
-    "http",
-    "https"
-  ],
   "consumes": [
     "application/json"
   ],

--- a/examples/proto/examplepb/unannotated_echo_service.swagger.json
+++ b/examples/proto/examplepb/unannotated_echo_service.swagger.json
@@ -5,10 +5,6 @@
     "description": "Unannotated Echo Service\nSimilar to echo_service.proto but without annotations. See\nunannotated_echo_service.yaml for the equivalent of the annotations in\ngRPC API configuration format.\n\nEcho Service API consists of a single service which returns\na message.",
     "version": "version not set"
   },
-  "schemes": [
-    "http",
-    "https"
-  ],
   "consumes": [
     "application/json"
   ],

--- a/examples/proto/examplepb/use_go_template.swagger.json
+++ b/examples/proto/examplepb/use_go_template.swagger.json
@@ -4,10 +4,6 @@
     "title": "examples/proto/examplepb/use_go_template.proto",
     "version": "version not set"
   },
-  "schemes": [
-    "http",
-    "https"
-  ],
   "consumes": [
     "application/json"
   ],

--- a/examples/proto/examplepb/wrappers.swagger.json
+++ b/examples/proto/examplepb/wrappers.swagger.json
@@ -4,10 +4,6 @@
     "title": "examples/proto/examplepb/wrappers.proto",
     "version": "version not set"
   },
-  "schemes": [
-    "http",
-    "https"
-  ],
   "consumes": [
     "application/json"
   ],

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -1047,7 +1047,6 @@ func applyTemplate(p param) (*swaggerObject, error) {
 	s := swaggerObject{
 		// Swagger 2.0 is the version of this document
 		Swagger:           "2.0",
-		Schemes:           []string{"http", "https"},
 		Consumes:          []string{"application/json"},
 		Produces:          []string{"application/json"},
 		Paths:             make(swaggerPathsObject),

--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -355,7 +355,7 @@ func TestApplyTemplateSimple(t *testing.T) {
 	if want, is, name := "", result.BasePath, "BasePath"; !reflect.DeepEqual(is, want) {
 		t.Errorf("applyTemplate(%#v).%s = %s want to be %s", file, name, is, want)
 	}
-	if want, is, name := []string{"http", "https"}, result.Schemes, "Schemes"; !reflect.DeepEqual(is, want) {
+	if want, is, name := ([]string)(nil), result.Schemes, "Schemes"; !reflect.DeepEqual(is, want) {
 		t.Errorf("applyTemplate(%#v).%s = %s want to be %s", file, name, is, want)
 	}
 	if want, is, name := []string{"application/json"}, result.Consumes, "Consumes"; !reflect.DeepEqual(is, want) {
@@ -657,7 +657,7 @@ func TestApplyTemplateRequestWithoutClientStreaming(t *testing.T) {
 	if want, got := "", result.BasePath; !reflect.DeepEqual(got, want) {
 		t.Errorf("applyTemplate(%#v).BasePath = %s want to be %s", file, got, want)
 	}
-	if want, got := []string{"http", "https"}, result.Schemes; !reflect.DeepEqual(got, want) {
+	if want, got := ([]string)(nil), result.Schemes; !reflect.DeepEqual(got, want) {
 		t.Errorf("applyTemplate(%#v).Schemes = %s want to be %s", file, got, want)
 	}
 	if want, got := []string{"application/json"}, result.Consumes; !reflect.DeepEqual(got, want) {

--- a/protoc-gen-swagger/genswagger/types.go
+++ b/protoc-gen-swagger/genswagger/types.go
@@ -59,7 +59,7 @@ type swaggerObject struct {
 	Info                swaggerInfoObject                   `json:"info"`
 	Host                string                              `json:"host,omitempty"`
 	BasePath            string                              `json:"basePath,omitempty"`
-	Schemes             []string                            `json:"schemes"`
+	Schemes             []string                            `json:"schemes,omitempty"`
 	Consumes            []string                            `json:"consumes"`
 	Produces            []string                            `json:"produces"`
 	Paths               swaggerPathsObject                  `json:"paths"`


### PR DESCRIPTION
Make it so if you do not specify the schemes then no schemes
will be present in the generated Swagger definition. The
OpenAPIv2 spec says this means to use the same scheme that
was used to access the Swagger definition itself.

Fixes #1069