### PR TITLE
Support reserved json name and add tests

### DIFF
--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -651,15 +651,11 @@ func templateToSwaggerPath(path string, reg *descriptor.Registry, fields []*desc
 				len(jsonBuffer) > 1 {
 				jsonSnakeCaseName := string(jsonBuffer[1:])
 				jsonCamelCaseName := string(lowerCamelCase(jsonSnakeCaseName))
-				reservedJSONFeildName := ""
 				for _, oneField := range fields {
 					if oneField.GetName() == jsonSnakeCaseName {
-						reservedJSONFeildName = oneField.GetJsonName()
+						jsonCamelCaseName = oneField.GetJsonName()
 						break;
 					}
-				}
-				if reservedJSONFeildName != "" {
-					jsonCamelCaseName = reservedJSONFeildName
 				}
 				prev := string(buffer[:len(buffer)-len(jsonSnakeCaseName)-2])
 				buffer = strings.Join([]string{prev, "{", jsonCamelCaseName, "}"}, "")

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -651,15 +651,15 @@ func templateToSwaggerPath(path string, reg *descriptor.Registry, fields []*desc
 				len(jsonBuffer) > 1 {
 				jsonSnakeCaseName := string(jsonBuffer[1:])
 				jsonCamelCaseName := string(lowerCamelCase(jsonSnakeCaseName))
-				reservedJsonFeildName := ""
+				reservedJSONFeildName := ""
 				for _, oneField := range fields {
 					if oneField.GetName() == jsonSnakeCaseName {
-						reservedJsonFeildName = oneField.GetJsonName()
+						reservedJSONFeildName = oneField.GetJsonName()
 						break;
 					}
 				}
-				if reservedJsonFeildName != "" {
-					jsonCamelCaseName = reservedJsonFeildName
+				if reservedJSONFeildName != "" {
+					jsonCamelCaseName = reservedJSONFeildName
 				}
 				prev := string(buffer[:len(buffer)-len(jsonSnakeCaseName)-2])
 				buffer = strings.Join([]string{prev, "{", jsonCamelCaseName, "}"}, "")

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -650,13 +650,7 @@ func templateToSwaggerPath(path string, reg *descriptor.Registry, fields []*desc
 			if reg.GetUseJSONNamesForFields() &&
 				len(jsonBuffer) > 1 {
 				jsonSnakeCaseName := string(jsonBuffer[1:])
-				jsonCamelCaseName := string(lowerCamelCase(jsonSnakeCaseName))
-				for _, oneField := range fields {
-					if oneField.GetName() == jsonSnakeCaseName {
-						jsonCamelCaseName = oneField.GetJsonName()
-						break;
-					}
-				}
+				jsonCamelCaseName := string(lowerCamelCase(jsonSnakeCaseName, fields))
 				prev := string(buffer[:len(buffer)-len(jsonSnakeCaseName)-2])
 				buffer = strings.Join([]string{prev, "{", jsonCamelCaseName, "}"}, "")
 				jsonBuffer = ""
@@ -775,7 +769,7 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
 					}
 					parameterString := parameter.String()
 					if reg.GetUseJSONNamesForFields() {
-						parameterString = lowerCamelCase(parameterString)
+						parameterString = lowerCamelCase(parameterString, meth.RequestType.Fields)
 					}
 					parameters = append(parameters, swaggerParameterObject{
 						Name:        parameterString,
@@ -1808,8 +1802,13 @@ func addCustomRefs(d swaggerDefinitionsObject, reg *descriptor.Registry, refs re
 	addCustomRefs(d, reg, refs)
 }
 
-func lowerCamelCase(parameter string) string {
-	parameterString := gogen.CamelCase(parameter)
+func lowerCamelCase(fieldName string, fields []*descriptor.Field) string {
+	for _, oneField := range fields {
+		if oneField.GetName() == fieldName {
+			return oneField.GetJsonName()
+		}
+	}
+	parameterString := gogen.CamelCase(fieldName)
 	builder := &strings.Builder{}
 	builder.WriteString(strings.ToLower(string(parameterString[0])))
 	builder.WriteString(parameterString[1:])

--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -986,11 +986,11 @@ func TestApplyTemplateRequestWithUnusedReferences(t *testing.T) {
 	}
 }
 
-func generateFieldsForJsonReservedName() []*descriptor.Field {
+func generateFieldsForJSONReservedName() []*descriptor.Field {
 	fields := make([]*descriptor.Field, 0)
 	fieldName := string("json_name")
-	fieldJsonName := string("jsonNAME")
-	fieldDescriptor := protodescriptor.FieldDescriptorProto{Name: &fieldName, JsonName: &fieldJsonName}
+	fieldJSONName := string("jsonNAME")
+	fieldDescriptor := protodescriptor.FieldDescriptorProto{Name: &fieldName, JsonName: &fieldJSONName}
 	field := &descriptor.Field{FieldDescriptorProto: &fieldDescriptor}
 	return append(fields, field)
 }
@@ -1016,7 +1016,7 @@ func TestTemplateWithJsonCamelCase(t *testing.T) {
 	reg := descriptor.NewRegistry()
 	reg.SetUseJSONNamesForFields(true)
 	for _, data := range tests {
-		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJsonReservedName())
+		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJSONReservedName())
 		if data.expected != actual {
 			t.Errorf("Expected templateToSwaggerPath(%v) = %v, actual: %v", data.input, data.expected, actual)
 		}
@@ -1043,7 +1043,7 @@ func TestTemplateWithoutJsonCamelCase(t *testing.T) {
 	reg := descriptor.NewRegistry()
 	reg.SetUseJSONNamesForFields(false)
 	for _, data := range tests {
-		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJsonReservedName())
+		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJSONReservedName())
 		if data.expected != actual {
 			t.Errorf("Expected templateToSwaggerPath(%v) = %v, actual: %v", data.input, data.expected, actual)
 		}
@@ -1075,14 +1075,14 @@ func TestTemplateToSwaggerPath(t *testing.T) {
 	reg := descriptor.NewRegistry()
 	reg.SetUseJSONNamesForFields(false)
 	for _, data := range tests {
-		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJsonReservedName())
+		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJSONReservedName())
 		if data.expected != actual {
 			t.Errorf("Expected templateToSwaggerPath(%v) = %v, actual: %v", data.input, data.expected, actual)
 		}
 	}
 	reg.SetUseJSONNamesForFields(true)
 	for _, data := range tests {
-		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJsonReservedName())
+		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJSONReservedName())
 		if data.expected != actual {
 			t.Errorf("Expected templateToSwaggerPath(%v) = %v, actual: %v", data.input, data.expected, actual)
 		}
@@ -1097,7 +1097,7 @@ func BenchmarkTemplateToSwaggerPath(b *testing.B) {
 		reg.SetUseJSONNamesForFields(false)
 
 		for i := 0; i < b.N; i++ {
-			_ = templateToSwaggerPath(input, reg, generateFieldsForJsonReservedName())
+			_ = templateToSwaggerPath(input, reg, generateFieldsForJSONReservedName())
 		}
 	})
 
@@ -1106,7 +1106,7 @@ func BenchmarkTemplateToSwaggerPath(b *testing.B) {
 		reg.SetUseJSONNamesForFields(true)
 
 		for i := 0; i < b.N; i++ {
-			_ = templateToSwaggerPath(input, reg, generateFieldsForJsonReservedName())
+			_ = templateToSwaggerPath(input, reg, generateFieldsForJSONReservedName())
 		}
 	})
 }
@@ -1182,14 +1182,14 @@ func TestFQMNtoSwaggerName(t *testing.T) {
 	reg := descriptor.NewRegistry()
 	reg.SetUseJSONNamesForFields(false)
 	for _, data := range tests {
-		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJsonReservedName())
+		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJSONReservedName())
 		if data.expected != actual {
 			t.Errorf("Expected templateToSwaggerPath(%v) = %v, actual: %v", data.input, data.expected, actual)
 		}
 	}
 	reg.SetUseJSONNamesForFields(true)
 	for _, data := range tests {
-		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJsonReservedName())
+		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJSONReservedName())
 		if data.expected != actual {
 			t.Errorf("Expected templateToSwaggerPath(%v) = %v, actual: %v", data.input, data.expected, actual)
 		}

--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -986,6 +986,15 @@ func TestApplyTemplateRequestWithUnusedReferences(t *testing.T) {
 	}
 }
 
+func generateFieldsForJsonReservedName() []*descriptor.Field {
+	fields := make([]*descriptor.Field, 0)
+	fieldName := string("json_name")
+	fieldJsonName := string("jsonNAME")
+	fieldDescriptor := protodescriptor.FieldDescriptorProto{Name: &fieldName, JsonName: &fieldJsonName}
+	field := &descriptor.Field{FieldDescriptorProto: &fieldDescriptor}
+	return append(fields, field)
+}
+
 func TestTemplateWithJsonCamelCase(t *testing.T) {
 	var tests = []struct {
 		input    string
@@ -1002,11 +1011,12 @@ func TestTemplateWithJsonCamelCase(t *testing.T) {
 		{"test/{ab}", "test/{ab}"},
 		{"test/{a_a}", "test/{aA}"},
 		{"test/{ab_c}", "test/{abC}"},
+		{"test/{json_name}", "test/{jsonNAME}"},
 	}
 	reg := descriptor.NewRegistry()
 	reg.SetUseJSONNamesForFields(true)
 	for _, data := range tests {
-		actual := templateToSwaggerPath(data.input, reg)
+		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJsonReservedName())
 		if data.expected != actual {
 			t.Errorf("Expected templateToSwaggerPath(%v) = %v, actual: %v", data.input, data.expected, actual)
 		}
@@ -1028,11 +1038,12 @@ func TestTemplateWithoutJsonCamelCase(t *testing.T) {
 		{"test/{a}", "test/{a}"},
 		{"test/{ab}", "test/{ab}"},
 		{"test/{a_a}", "test/{a_a}"},
+		{"test/{json_name}", "test/{json_name}"},
 	}
 	reg := descriptor.NewRegistry()
 	reg.SetUseJSONNamesForFields(false)
 	for _, data := range tests {
-		actual := templateToSwaggerPath(data.input, reg)
+		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJsonReservedName())
 		if data.expected != actual {
 			t.Errorf("Expected templateToSwaggerPath(%v) = %v, actual: %v", data.input, data.expected, actual)
 		}
@@ -1064,14 +1075,14 @@ func TestTemplateToSwaggerPath(t *testing.T) {
 	reg := descriptor.NewRegistry()
 	reg.SetUseJSONNamesForFields(false)
 	for _, data := range tests {
-		actual := templateToSwaggerPath(data.input, reg)
+		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJsonReservedName())
 		if data.expected != actual {
 			t.Errorf("Expected templateToSwaggerPath(%v) = %v, actual: %v", data.input, data.expected, actual)
 		}
 	}
 	reg.SetUseJSONNamesForFields(true)
 	for _, data := range tests {
-		actual := templateToSwaggerPath(data.input, reg)
+		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJsonReservedName())
 		if data.expected != actual {
 			t.Errorf("Expected templateToSwaggerPath(%v) = %v, actual: %v", data.input, data.expected, actual)
 		}
@@ -1086,7 +1097,7 @@ func BenchmarkTemplateToSwaggerPath(b *testing.B) {
 		reg.SetUseJSONNamesForFields(false)
 
 		for i := 0; i < b.N; i++ {
-			_ = templateToSwaggerPath(input, reg)
+			_ = templateToSwaggerPath(input, reg, generateFieldsForJsonReservedName())
 		}
 	})
 
@@ -1095,7 +1106,7 @@ func BenchmarkTemplateToSwaggerPath(b *testing.B) {
 		reg.SetUseJSONNamesForFields(true)
 
 		for i := 0; i < b.N; i++ {
-			_ = templateToSwaggerPath(input, reg)
+			_ = templateToSwaggerPath(input, reg, generateFieldsForJsonReservedName())
 		}
 	})
 }
@@ -1171,14 +1182,14 @@ func TestFQMNtoSwaggerName(t *testing.T) {
 	reg := descriptor.NewRegistry()
 	reg.SetUseJSONNamesForFields(false)
 	for _, data := range tests {
-		actual := templateToSwaggerPath(data.input, reg)
+		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJsonReservedName())
 		if data.expected != actual {
 			t.Errorf("Expected templateToSwaggerPath(%v) = %v, actual: %v", data.input, data.expected, actual)
 		}
 	}
 	reg.SetUseJSONNamesForFields(true)
 	for _, data := range tests {
-		actual := templateToSwaggerPath(data.input, reg)
+		actual := templateToSwaggerPath(data.input, reg, generateFieldsForJsonReservedName())
 		if data.expected != actual {
 			t.Errorf("Expected templateToSwaggerPath(%v) = %v, actual: %v", data.input, data.expected, actual)
 		}


### PR DESCRIPTION
Support reserved JSON name and add tests.
Like: when a reserved JSON name is specified in protobuf, then the swagger doc will generate this reserved JSON name instead of a lower case camel variable name. 
Ref: https://github.com/grpc-ecosystem/grpc-gateway/issues/1084
