### PR TITLE
Add support for stream google.api.HttpBody

### DIFF
--- a/runtime/marshal_httpbodyproto.go
+++ b/runtime/marshal_httpbodyproto.go
@@ -1,6 +1,9 @@
 package runtime
 
 import (
+	"reflect"
+
+	"github.com/golang/protobuf/proto"
 	"google.golang.org/genproto/googleapis/api/httpbody"
 )
 
@@ -12,9 +15,10 @@ func SetHTTPBodyMarshaler(serveMux *ServeMux) {
 }
 
 // HTTPBodyMarshaler is a Marshaler which supports marshaling of a
-// google.api.HttpBody message as the full response body if it is
-// the actual message used as the response. If not, then this will
-// simply fallback to the Marshaler specified as its default Marshaler.
+// google.api.HttpBody message as the full response body if it is the actual
+// message used as the response. Stream google.api.HttpBody message is also
+// supported. If not, then this will simply fallback to the Marshaler specified
+// as its default Marshaler.
 type HTTPBodyMarshaler struct {
 	Marshaler
 }
@@ -27,7 +31,7 @@ func (h *HTTPBodyMarshaler) ContentType() string {
 // ContentTypeFromMessage in case v is a google.api.HttpBody message it returns
 // its specified content type otherwise fall back to the default Marshaler.
 func (h *HTTPBodyMarshaler) ContentTypeFromMessage(v interface{}) string {
-	if httpBody, ok := v.(*httpbody.HttpBody); ok {
+	if httpBody := tryHttpBody(v); httpBody != nil {
 		return httpBody.GetContentType()
 	}
 	return h.Marshaler.ContentType()
@@ -36,8 +40,43 @@ func (h *HTTPBodyMarshaler) ContentTypeFromMessage(v interface{}) string {
 // Marshal marshals "v" by returning the body bytes if v is a
 // google.api.HttpBody message, otherwise it falls back to the default Marshaler.
 func (h *HTTPBodyMarshaler) Marshal(v interface{}) ([]byte, error) {
-	if httpBody, ok := v.(*httpbody.HttpBody); ok {
-		return httpBody.Data, nil
+	if httpBody := tryHttpBody(v); httpBody != nil {
+		return httpBody.GetData(), nil
 	}
 	return h.Marshaler.Marshal(v)
+}
+
+// Delimiter for encoded multi-part streams.
+func (h *HTTPBodyMarshaler) Delimiter() []byte {
+	return []byte("")
+}
+
+func tryHttpBody(v interface{}) *httpbody.HttpBody {
+	rv := reflect.ValueOf(v)
+	// The handler wraps streamed chunks in a map.
+	// If we're sending an HTTP body as a chunk, we need to unpack it.
+	if rv.Kind() == reflect.Map && rv.Type().ConvertibleTo(reflect.TypeOf(map[string]proto.Message{})) {
+		m := v.(map[string]proto.Message)
+		if r, ok := m["result"]; ok && proto.MessageName(r) == "google.api.HttpBody" {
+			return r.(*httpbody.HttpBody)
+		}
+		return nil
+	}
+	if rv.Kind() != reflect.Ptr {
+		return nil
+	}
+	for rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			rv.Set(reflect.New(rv.Type().Elem()))
+		}
+		if rv.Type().ConvertibleTo(typeProtoMessage) {
+			pb := rv.Interface().(proto.Message)
+			if proto.MessageName(pb) == "google.api.HttpBody" {
+				return v.(*httpbody.HttpBody)
+			}
+		}
+		rv = rv.Elem()
+	}
+	return nil
+
 }

--- a/runtime/marshal_httpbodyproto.go
+++ b/runtime/marshal_httpbodyproto.go
@@ -31,7 +31,7 @@ func (h *HTTPBodyMarshaler) ContentType() string {
 // ContentTypeFromMessage in case v is a google.api.HttpBody message it returns
 // its specified content type otherwise fall back to the default Marshaler.
 func (h *HTTPBodyMarshaler) ContentTypeFromMessage(v interface{}) string {
-	if httpBody := tryHttpBody(v); httpBody != nil {
+	if httpBody := tryHTTPBody(v); httpBody != nil {
 		return httpBody.GetContentType()
 	}
 	return h.Marshaler.ContentType()
@@ -40,7 +40,7 @@ func (h *HTTPBodyMarshaler) ContentTypeFromMessage(v interface{}) string {
 // Marshal marshals "v" by returning the body bytes if v is a
 // google.api.HttpBody message, otherwise it falls back to the default Marshaler.
 func (h *HTTPBodyMarshaler) Marshal(v interface{}) ([]byte, error) {
-	if httpBody := tryHttpBody(v); httpBody != nil {
+	if httpBody := tryHTTPBody(v); httpBody != nil {
 		return httpBody.GetData(), nil
 	}
 	return h.Marshaler.Marshal(v)
@@ -51,7 +51,7 @@ func (h *HTTPBodyMarshaler) Delimiter() []byte {
 	return []byte("")
 }
 
-func tryHttpBody(v interface{}) *httpbody.HttpBody {
+func tryHTTPBody(v interface{}) *httpbody.HttpBody {
 	rv := reflect.ValueOf(v)
 	// The handler wraps streamed chunks in a map.
 	// If we're sending an HTTP body as a chunk, we need to unpack it.


### PR DESCRIPTION
@theRealWardo provide a solution to support stream google.api.HttpBody for grpc-gateway (https://github.com/grpc-ecosystem/grpc-gateway/issues/958#issuecomment-557616206)

I modify his codes to adapt current master branch. The main change is:
1. Unpack stream google.apiHttpBody to get the real data.
2. Properly set the Content-Type of HTTP header when stream google.api.HttpBody response is received.