### PR TITLE
fix: protoc-gen-swagger: get wrong second services method comments

### DIFF
--- a/examples/clients/abe/api/swagger.yaml
+++ b/examples/clients/abe/api/swagger.yaml
@@ -1624,8 +1624,6 @@ paths:
     get:
       tags:
       - "camelCaseServiceName"
-      summary: "Create a new ABitOfEverything"
-      description: "This API creates a new ABitOfEverything"
       operationId: "Empty"
       parameters: []
       responses:

--- a/examples/clients/abe/api_camel_case_service_name.go
+++ b/examples/clients/abe/api_camel_case_service_name.go
@@ -26,8 +26,7 @@ var (
 type CamelCaseServiceNameApiService service
 
 /* 
-CamelCaseServiceNameApiService Create a new ABitOfEverything
-This API creates a new ABitOfEverything
+CamelCaseServiceNameApiService
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 
 @return interface{}

--- a/examples/proto/examplepb/a_bit_of_everything.swagger.json
+++ b/examples/proto/examplepb/a_bit_of_everything.swagger.json
@@ -1926,8 +1926,6 @@
     },
     "/v2/example/empty": {
       "get": {
-        "summary": "Create a new ABitOfEverything",
-        "description": "This API creates a new ABitOfEverything",
         "operationId": "Empty",
         "responses": {
           "200": {

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -892,7 +892,7 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
 					}
 				}
 
-				methComments := protoComments(reg, svc.File, nil, "Method", int32(svcIdx), methProtoPath, int32(methIdx))
+				methComments := protoComments(reg, svc.File, nil, "Service", int32(svcIdx), methProtoPath, int32(methIdx))
 				if err := updateSwaggerDataFromComments(reg, operationObject, meth, methComments, false); err != nil {
 					panic(err)
 				}


### PR DESCRIPTION
When a service.proto have more then one services, the protoc-gen-swagger tool can not find right other(not the first one) service's method comments.
I changed protoComments's argument, then the service.swagger.json's summary field was right. 
But I'm not sure is the right way to fix it.
Please checkout, thanks.