### PR TITLE
Fix context leak identified by nogo linter

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -134,7 +134,8 @@ func annotateContext(ctx context.Context, mux *ServeMux, req *http.Request) (con
 	}
 
 	if timeout != 0 {
-		_, cancel := context.WithTimeout(ctx, timeout)
+		timeout_ctx, cancel := context.WithTimeout(ctx, timeout)
+		ctx = timeout_ctx
 		defer cancel()
 	}
 	if len(pairs) == 0 {

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -134,7 +134,8 @@ func annotateContext(ctx context.Context, mux *ServeMux, req *http.Request) (con
 	}
 
 	if timeout != 0 {
-		ctx, _ = context.WithTimeout(ctx, timeout)
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
 	}
 	if len(pairs) == 0 {
 		return ctx, nil, nil

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -134,7 +134,7 @@ func annotateContext(ctx context.Context, mux *ServeMux, req *http.Request) (con
 	}
 
 	if timeout != 0 {
-		ctx, cancel := context.WithTimeout(ctx, timeout)
+		_, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
 	if len(pairs) == 0 {

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -134,7 +134,7 @@ func annotateContext(ctx context.Context, mux *ServeMux, req *http.Request) (con
 	}
 
 	if timeout != 0 {
-		ctx, cancel = context.WithTimeout(ctx, timeout)
+		ctx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
 	if len(pairs) == 0 {


### PR DESCRIPTION
the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak.