### PR TITLE
protoc-gen-swagger: add flag to disable default errors

### DIFF
--- a/protoc-gen-grpc-gateway/descriptor/registry.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry.go
@@ -75,6 +75,10 @@ type Registry struct {
 	// useGoTemplate determines whether you want to use GO templates
 	// in your protofile comments
 	useGoTemplate bool
+
+	// disableDefaultErrors disables the generation of the default error types.
+	// This is useful for users who have defined custom error handling.
+	disableDefaultErrors bool
 }
 
 type repeatedFieldSeparator struct {
@@ -458,6 +462,16 @@ func (r *Registry) SetUseGoTemplate(use bool) {
 // GetUseGoTemplate returns useGoTemplate
 func (r *Registry) GetUseGoTemplate() bool {
 	return r.useGoTemplate
+}
+
+// SetDisableDefaultErrors sets disableDefaultErrors
+func (r *Registry) SetDisableDefaultErrors(use bool) {
+	r.disableDefaultErrors = use
+}
+
+// GetDisableDefaultErrors returns disableDefaultErrors
+func (r *Registry) GetDisableDefaultErrors() bool {
+	return r.disableDefaultErrors
 }
 
 // sanitizePackageName replaces unallowed character in package name

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -882,16 +882,18 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
 							Description: desc,
 							Schema:      responseSchema,
 						},
-						// https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#responses-object
-						"default": swaggerResponseObject{
-							Description: "An unexpected error response",
-							Schema: swaggerSchemaObject{
-								schemaCore: schemaCore{
-									Ref: fmt.Sprintf("#/definitions/%s", fullyQualifiedNameToSwaggerName(".grpc.gateway.runtime.Error", reg)),
-								},
+					},
+				}
+				if !reg.GetDisableDefaultErrors() {
+					// https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#responses-object
+					operationObject.Responses["default"] = swaggerResponseObject{
+						Description: "An unexpected error response",
+						Schema: swaggerSchemaObject{
+							schemaCore: schemaCore{
+								Ref: fmt.Sprintf("#/definitions/%s", fullyQualifiedNameToSwaggerName(".grpc.gateway.runtime.Error", reg)),
 							},
 						},
-					},
+					}
 				}
 				if bIdx == 0 {
 					operationObject.OperationID = fmt.Sprintf("%s", meth.GetName())
@@ -1052,13 +1054,15 @@ func applyTemplate(p param) (*swaggerObject, error) {
 	streamingMessages := messageMap{}
 	enums := enumMap{}
 
-	// Add the error type to the message map
-	runtimeError, err := p.reg.LookupMsg(".grpc.gateway.runtime", "Error")
-	if err == nil {
-		messages[fullyQualifiedNameToSwaggerName(".grpc.gateway.runtime.Error", p.reg)] = runtimeError
-	} else {
-		// just in case there is an error looking up runtimeError
-		glog.Error(err)
+	if !p.reg.GetDisableDefaultErrors() {
+		// Add the error type to the message map
+		runtimeError, err := p.reg.LookupMsg(".grpc.gateway.runtime", "Error")
+		if err == nil {
+			messages[fullyQualifiedNameToSwaggerName(".grpc.gateway.runtime.Error", p.reg)] = runtimeError
+		} else {
+			// just in case there is an error looking up runtimeError
+			glog.Error(err)
+		}
 	}
 
 	// Find all the service's messages and enumerations that are defined (recursively)

--- a/protoc-gen-swagger/main.go
+++ b/protoc-gen-swagger/main.go
@@ -28,6 +28,7 @@ var (
 	includePackageInTags       = flag.Bool("include_package_in_tags", false, "if unset, the gRPC service name is added to the `Tags` field of each operation. if set and the `package` directive is shown in the proto file, the package name will be prepended to the service name")
 	useFQNForSwaggerName       = flag.Bool("fqn_for_swagger_name", false, "if set, the object's swagger names will use the fully qualify name from the proto definition (ie my.package.MyMessage.MyInnerMessage")
 	useGoTemplate              = flag.Bool("use_go_templates", false, "if set, you can use Go templates in protofile comments")
+	disableDefaultErrors       = flag.Bool("disable_default_errors", false, "if set, disables generation of default errors. This is useful if you have defined custom error handling")
 )
 
 // Variables set by goreleaser at build time
@@ -80,6 +81,7 @@ func main() {
 	reg.SetIncludePackageInTags(*includePackageInTags)
 	reg.SetUseFQNForSwaggerName(*useFQNForSwaggerName)
 	reg.SetUseGoTemplate(*useGoTemplate)
+	reg.SetDisableDefaultErrors(*disableDefaultErrors)
 	if err := reg.SetRepeatedPathParamSeparator(*repeatedPathParamSeparator); err != nil {
 		emitError(err)
 		return


### PR DESCRIPTION

The new flag disable_default_errors can be used to disable
the generation of the default error types. This is suitable
for users that define their own error formatting.