### PR TITLE
Fix #1143: Support multiple error handlers.

### DIFF
--- a/docs/_docs/customizingyourgateway.md
+++ b/docs/_docs/customizingyourgateway.md
@@ -234,7 +234,24 @@ if err := pb.RegisterMyServiceHandlerFromEndpoint(ctx, mux, serviceEndpoint, opt
 ```
 
 ## Error handler
-http://mycodesmells.com/post/grpc-gateway-error-handler
+The gateway uses two different error handlers for non-streaming requests:
+
+ * `runtime.HTTPError` is called for errors from backend calls
+ * `runtime.OtherErrorHandler` is called for errors from parsing and routing client requests
+
+To override all error handling for a `*runtime.ServeMux`, use the
+`runtime.WithProtoErrorHandler` serve option.
+
+Alternatively, you can override the global default `HTTPError` handling by
+setting `runtime.GlobalHTTPErrorHandler` to a custom function, and override
+the global default `OtherErrorHandler` by setting `runtime.OtherErrorHandler`
+to a custom function.
+
+You should not set `runtime.HTTPError` directly, because that might break
+any `ServeMux` set up with the `WithProtoErrorHandler` option.
+
+See https://mycodesmells.com/post/grpc-gateway-error-handler for an example
+of writing a custom error handler function.
 
 ## Stream Error Handler
 The error handler described in the previous section applies only

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -5,10 +5,10 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/grpc-ecosystem/grpc-gateway/internal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/status"
-	"github.com/grpc-ecosystem/grpc-gateway/internal"
 )
 
 // HTTPStatusFromCode converts a gRPC error code into the corresponding HTTP response status.
@@ -57,12 +57,51 @@ func HTTPStatusFromCode(code codes.Code) int {
 }
 
 var (
-	// HTTPError replies to the request with the error.
+	// HTTPError replies to the request with an error.
+	//
+	// HTTPError is called:
+	//  - From generated per-endpoint gateway handler code, when calling the backend results in an error.
+	//  - From gateway runtime code, when forwarding the response message results in an error.
+	//
+	// The default value for HTTPError calls the custom error handler configured on the ServeMux via the
+	// WithProtoErrorHandler serve option if that option was used, calling GlobalHTTPErrorHandler otherwise.
+	//
+	// To customize the error handling of a particular ServeMux instance, use the WithProtoErrorHandler
+	// serve option.
+	//
+	// To customize the error format for all ServeMux instances not using the WithProtoErrorHandler serve
+	// option, set GlobalHTTPErrorHandler to a custom function.
+	//
+	// Setting this variable directly to customize error format is deprecated.
+	HTTPError = MuxOrGlobalHTTPError
+
+	// GlobalHTTPErrorHandler is the HTTPError handler for all ServeMux instances not using the
+	// WithProtoErrorHandler serve option.
+	//
 	// You can set a custom function to this variable to customize error format.
-	HTTPError = DefaultHTTPError
-	// OtherErrorHandler handles the following error used by the gateway: StatusMethodNotAllowed StatusNotFound and StatusBadRequest
+	GlobalHTTPErrorHandler = DefaultHTTPError
+
+	// OtherErrorHandler handles gateway errors from parsing and routing client requests for all
+	// ServeMux instances not using the WithProtoErrorHandler serve option.
+	//
+	// It returns the following error codes: StatusMethodNotAllowed StatusNotFound StatusBadRequest
+	//
+	// To customize parsing and routing error handling of a particular ServeMux instance, use the
+	// WithProtoErrorHandler serve option.
+	//
+	// To customize parsing and routing error handling of all ServeMux instances not using the
+	// WithProtoErrorHandler serve option, set a custom function to this variable.
 	OtherErrorHandler = DefaultOtherErrorHandler
 )
+
+// MuxOrGlobalHTTPError uses the mux-configured error handler, falling back to GlobalErrorHandler.
+func MuxOrGlobalHTTPError(ctx context.Context, mux *ServeMux, marshaler Marshaler, w http.ResponseWriter, r *http.Request, err error) {
+	if mux.protoErrorHandler != nil {
+		mux.protoErrorHandler(ctx, mux, marshaler, w, r, err)
+	} else {
+		GlobalHTTPErrorHandler(ctx, mux, marshaler, w, r, err)
+	}
+}
 
 // DefaultHTTPError is the default implementation of HTTPError.
 // If "err" is an error from gRPC system, the function replies with the status code mapped by HTTPStatusFromCode.

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -111,11 +111,11 @@ func WithMetadata(annotator func(context.Context, *http.Request) metadata.MD) Se
 	}
 }
 
-// WithProtoErrorHandler returns a ServeMuxOption for passing metadata to a gRPC context.
+// WithProtoErrorHandler returns a ServeMuxOption for configuring a custom error handler.
 //
 // This can be used to handle an error as general proto message defined by gRPC.
-// The response including body and status is not backward compatible with the default error handler.
-// When this option is used, HTTPError and OtherErrorHandler are overwritten on initialization.
+// When this option is used, the mux uses the configured error handler instead of HTTPError and
+// OtherErrorHandler.
 func WithProtoErrorHandler(fn ProtoErrorHandlerFunc) ServeMuxOption {
 	return func(serveMux *ServeMux) {
 		serveMux.protoErrorHandler = fn

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -165,18 +165,6 @@ func NewServeMux(opts ...ServeMuxOption) *ServeMux {
 		opt(serveMux)
 	}
 
-	if serveMux.protoErrorHandler != nil {
-		HTTPError = serveMux.protoErrorHandler
-		// OtherErrorHandler is no longer used when protoErrorHandler is set.
-		// Overwritten by a special error handler to return Unknown.
-		OtherErrorHandler = func(w http.ResponseWriter, r *http.Request, _ string, _ int) {
-			ctx := context.Background()
-			_, outboundMarshaler := MarshalerForRequest(serveMux, r)
-			sterr := status.Error(codes.Unknown, "unexpected use of OtherErrorHandler")
-			serveMux.protoErrorHandler(ctx, serveMux, outboundMarshaler, w, r, sterr)
-		}
-	}
-
 	if serveMux.incomingHeaderMatcher == nil {
 		serveMux.incomingHeaderMatcher = DefaultHeaderMatcher
 	}


### PR DESCRIPTION
Support specifying different custom error handlers on different muxes,
or specifying custom error handlers on some muxes and using the default
handlers on others.

Make the runtime.HTTPError use the mux-configured error handler if
present, and allow overriding the global default behavior by setting
GlobalHTTPErrorHandler.

Add commentary explaining the use of the different options for
controlling error handling.