### PR TITLE
Use an interface for ContentTypeFromMessage

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -123,9 +123,9 @@ func DefaultHTTPError(ctx context.Context, mux *ServeMux, marshaler Marshaler, w
 	// Check marshaler on run time in order to keep backwards compatability
 	// An interface param needs to be added to the ContentType() function on
 	// the Marshal interface to be able to remove this check
-	if httpBodyMarshaler, ok := marshaler.(*HTTPBodyMarshaler); ok {
+	if typeMarshaler, ok := marshaler.(contentTypeMarshaler); ok {
 		pb := s.Proto()
-		contentType = httpBodyMarshaler.ContentTypeFromMessage(pb)
+		contentType = typeMarshaler.ContentTypeFromMessage(pb)
 	}
 	w.Header().Set("Content-Type", contentType)
 

--- a/runtime/errors_test.go
+++ b/runtime/errors_test.go
@@ -23,26 +23,41 @@ func TestDefaultHTTPError(t *testing.T) {
 	)
 
 	for _, spec := range []struct {
-		err     error
-		status  int
-		msg     string
-		details string
+		err         error
+		status      int
+		msg         string
+		marshaler   runtime.Marshaler
+		contentType string
+		details     string
 	}{
 		{
-			err:    fmt.Errorf("example error"),
-			status: http.StatusInternalServerError,
-			msg:    "example error",
+			err:         fmt.Errorf("example error"),
+			status:      http.StatusInternalServerError,
+			marshaler:   &runtime.JSONPb{},
+			contentType: "application/json",
+			msg:         "example error",
 		},
 		{
-			err:    status.Error(codes.NotFound, "no such resource"),
-			status: http.StatusNotFound,
-			msg:    "no such resource",
+			err:         status.Error(codes.NotFound, "no such resource"),
+			status:      http.StatusNotFound,
+			marshaler:   &runtime.JSONPb{},
+			contentType: "application/json",
+			msg:         "no such resource",
 		},
 		{
-			err:     statusWithDetails.Err(),
-			status:  http.StatusBadRequest,
-			msg:     "failed precondition",
-			details: "type.googleapis.com/google.rpc.PreconditionFailure",
+			err:         statusWithDetails.Err(),
+			status:      http.StatusBadRequest,
+			marshaler:   &runtime.JSONPb{},
+			contentType: "application/json",
+			msg:         "failed precondition",
+			details:     "type.googleapis.com/google.rpc.PreconditionFailure",
+		},
+		{
+			err:         fmt.Errorf("example error"),
+			status:      http.StatusInternalServerError,
+			marshaler:   &CustomMarshaler{&runtime.JSONPb{}},
+			contentType: "Custom-Content-Type",
+			msg:         "example error",
 		},
 	} {
 		w := httptest.NewRecorder()

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -1,13 +1,13 @@
 package runtime
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/textproto"
 
-	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/internal"
 	"google.golang.org/grpc/grpclog"
@@ -126,8 +126,8 @@ func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marsha
 	// Check marshaler on run time in order to keep backwards compatability
 	// An interface param needs to be added to the ContentType() function on
 	// the Marshal interface to be able to remove this check
-	if httpBodyMarshaler, ok := marshaler.(*HTTPBodyMarshaler); ok {
-		contentType = httpBodyMarshaler.ContentTypeFromMessage(resp)
+	if typeMarshaler, ok := marshaler.(contentTypeMarshaler); ok {
+		contentType = typeMarshaler.ContentTypeFromMessage(resp)
 	}
 	w.Header().Set("Content-Type", contentType)
 

--- a/runtime/marshaler.go
+++ b/runtime/marshaler.go
@@ -19,6 +19,13 @@ type Marshaler interface {
 	ContentType() string
 }
 
+// Marshalers that implement contentTypeMarshaler will have their ContentTypeFromMessage method called
+// to set the Content-Type header on the response
+type contentTypeMarshaler interface {
+	// ContentTypeFromMessage returns the Content-Type this marshaler produces from the provided message
+	ContentTypeFromMessage(v interface{}) string
+}
+
 // Decoder decodes a byte sequence
 type Decoder interface {
 	Decode(v interface{}) error

--- a/runtime/proto_errors.go
+++ b/runtime/proto_errors.go
@@ -47,9 +47,9 @@ func DefaultHTTPProtoErrorHandler(ctx context.Context, mux *ServeMux, marshaler 
 	// Check marshaler on run time in order to keep backwards compatability
 	// An interface param needs to be added to the ContentType() function on
 	// the Marshal interface to be able to remove this check
-	if httpBodyMarshaler, ok := marshaler.(*HTTPBodyMarshaler); ok {
+	if typeMarshaler, ok := marshaler.(contentTypeMarshaler); ok {
 		pb := s.Proto()
-		contentType = httpBodyMarshaler.ContentTypeFromMessage(pb)
+		contentType = typeMarshaler.ContentTypeFromMessage(pb)
 	}
 	w.Header().Set("Content-Type", contentType)
 


### PR DESCRIPTION
This allows custom `Marshaler` implementations to vary the HTTP response's Content-Type based on the returned proto.

Because of the comments around adding the interface param to the existing `ContentType()` function, I left the interface unexported, so that it doesn't become part of the public API of the package.

Alternatively, it could be exported and used to eventually deprecate the old `Marshaler` interface in favor of a more flexible `ContentTypeFromMessage`.
```go
// A ContentTypeMarshaler is a Marshaler that can vary its Content-Type based on the response value
type ContentTypeMarshaler interface {
   Marshaler
   ContentTypeFromMessage(v interface{}) string
}
```

Is there a preference between the two approaches?