### PR TITLE
Add Routes method to return registered routes

### DIFF
--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -187,6 +187,35 @@ func (s *ServeMux) Handle(meth string, pat Pattern, h HandlerFunc) {
 	}
 }
 
+// Routes returns all defined routes defined on the ServeMux. The returned map
+// maps HTTP verbs to route paths, ie, the returned map will look something
+// like,
+//
+//  map[string][]string{
+//      "GET", []string{
+//          "/users",
+//          "/users{id=*}",
+//      },
+//      "POST": []string{
+//          "/users",
+//      }
+//  }
+func (s *ServeMux) Routes() map[string][]string {
+	routes := make(map[string][]string)
+
+	for method, handlers := range s.handlers {
+		for _, handler := range handlers {
+			if path, ok := routes[method]; !ok {
+				routes[method] = []string{handler.pat.String()}
+			} else {
+				path = append(path, handler.pat.String())
+			}
+		}
+	}
+
+	return routes
+}
+
 // ServeHTTP dispatches the request to the first handler whose pattern matches to r.Method and r.Path.
 func (s *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()


### PR DESCRIPTION
### Overview

Adds a new `Routes` method to the `ServeMux` that allows a user to get all registered routes, that is, a map of HTTP verbs to URL paths.

### Motivation

I want to push my routes up to a proxy, in order to make that proxy aware of which routes go to my grpc-gateway powered service. Previously, there was no way to do that other than to manually write out each route. With this change, users can now call `Routes` on a `ServeMux` to get a `map[string][]string` of HTTP verbs to URL paths.

---

I know this PR may be lacking tests, and might not even be the right way to approach this, but I wanted to create this PR to open this up for discussion.