### PR TITLE
Emit error on HTTP rules without a matching selector and log warning on unbound methods

### DIFF
--- a/protoc-gen-grpc-gateway/descriptor/registry_test.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry_test.go
@@ -586,3 +586,43 @@ func TestLoadGoPackageInputPath(t *testing.T) {
 		t.Errorf("file.GoPkg = %#v; want %#v", got, want)
 	}
 }
+
+func TestUnboundExternalHTTPRules(t *testing.T) {
+	reg := NewRegistry()
+	methodName := ".example.ExampleService.Echo"
+	reg.AddExternalHTTPRule(methodName, nil)
+	assertStringSlice(t, "unbound external HTTP rules", reg.UnboundExternalHTTPRules(), []string{methodName})
+	loadFile(t, reg, `
+		name: "path/to/example.proto",
+		package: "example"
+		message_type <
+			name: "StringMessage"
+			field <
+				name: "string"
+				number: 1
+				label: LABEL_OPTIONAL
+				type: TYPE_STRING
+			>
+		>
+		service <
+			name: "ExampleService"
+			method <
+				name: "Echo"
+				input_type: "StringMessage"
+				output_type: "StringMessage"
+			>
+		>
+	`)
+	assertStringSlice(t, "unbound external HTTP rules", reg.UnboundExternalHTTPRules(), []string{})
+}
+
+func assertStringSlice(t *testing.T, message string, got, want []string) {
+	if len(got) != len(want) {
+		t.Errorf("%s = %#v len(%d); want %#v len(%d)", message, got, len(got), want, len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("%s[%d] = %#v; want %#v", message, i, got[i], want[i])
+		}
+	}
+}

--- a/protoc-gen-grpc-gateway/descriptor/services.go
+++ b/protoc-gen-grpc-gateway/descriptor/services.go
@@ -35,7 +35,7 @@ func (r *Registry) loadServices(file *File) error {
 				optsList = append(optsList, opts)
 			}
 			if len(optsList) == 0 {
-				glog.V(1).Infof("Found non-target method: %s.%s", svc.GetName(), md.GetName())
+				glog.Warningf("No HttpRule found for method: %s.%s", svc.GetName(), md.GetName())
 			}
 			meth, err := r.newMethod(svc, md, optsList)
 			if err != nil {

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -103,6 +103,11 @@ func main() {
 		emitError(err)
 		return
 	}
+	unboundHTTPRules := reg.UnboundExternalHTTPRules()
+	if len(unboundHTTPRules) != 0 {
+		emitError(fmt.Errorf("HTTP rules without a matching selector: %s", strings.Join(unboundHTTPRules, ", ")))
+		return
+	}
 
 	var targets []*descriptor.File
 	for _, target := range req.FileToGenerate {


### PR DESCRIPTION
Fixing: https://github.com/grpc-ecosystem/grpc-gateway/issues/1175

I could not emit error in case of unbound methods as that would have break all the examples.