### PR TITLE
Use 8088 instead of 8080 in integration test.

### DIFF
--- a/examples/internal/integration/client_test.go
+++ b/examples/internal/integration/client_test.go
@@ -16,7 +16,7 @@ func TestEchoClient(t *testing.T) {
 	}
 
 	cfg := echo.NewConfiguration()
-	cfg.BasePath = "http://localhost:8080"
+	cfg.BasePath = "http://localhost:8088"
 
 	cl := echo.NewAPIClient(cfg)
 	resp, _, err := cl.EchoServiceApi.Echo(context.Background(), "foo")
@@ -35,7 +35,7 @@ func TestEchoBodyClient(t *testing.T) {
 	}
 
 	cfg := echo.NewConfiguration()
-	cfg.BasePath = "http://localhost:8080"
+	cfg.BasePath = "http://localhost:8088"
 
 	cl := echo.NewAPIClient(cfg)
 	req := echo.ExamplepbSimpleMessage{Id: "foo"}
@@ -55,7 +55,7 @@ func TestAbitOfEverythingClient(t *testing.T) {
 	}
 
 	cfg := abe.NewConfiguration()
-	cfg.BasePath = "http://localhost:8080"
+	cfg.BasePath = "http://localhost:8088"
 
 	cl := abe.NewAPIClient(cfg)
 
@@ -184,7 +184,7 @@ func TestUnannotatedEchoClient(t *testing.T) {
 	}
 
 	cfg := unannotatedecho.NewConfiguration()
-	cfg.BasePath = "http://localhost:8080"
+	cfg.BasePath = "http://localhost:8088"
 
 	cl := unannotatedecho.NewAPIClient(cfg)
 
@@ -204,7 +204,7 @@ func TestUnannotatedEchoBodyClient(t *testing.T) {
 	}
 
 	cfg := unannotatedecho.NewConfiguration()
-	cfg.BasePath = "http://localhost:8080"
+	cfg.BasePath = "http://localhost:8088"
 
 	cl := unannotatedecho.NewAPIClient(cfg)
 

--- a/examples/internal/integration/integration_test.go
+++ b/examples/internal/integration/integration_test.go
@@ -40,11 +40,11 @@ func TestEcho(t *testing.T) {
 		return
 	}
 
-	testEcho(t, 8080, "application/json")
-	testEchoOneof(t, 8080, "application/json")
-	testEchoOneof1(t, 8080, "application/json")
-	testEchoOneof2(t, 8080, "application/json")
-	testEchoBody(t, 8080)
+	testEcho(t, 8088, "application/json")
+	testEchoOneof(t, 8088, "application/json")
+	testEchoOneof1(t, 8088, "application/json")
+	testEchoOneof2(t, 8088, "application/json")
+	testEchoBody(t, 8088)
 }
 
 func TestForwardResponseOption(t *testing.T) {
@@ -266,17 +266,17 @@ func TestABE(t *testing.T) {
 		return
 	}
 
-	testABECreate(t, 8080)
-	testABECreateBody(t, 8080)
-	testABEBulkCreate(t, 8080)
-	testABEBulkCreateWithError(t, 8080)
-	testABELookup(t, 8080)
-	testABELookupNotFound(t, 8080)
-	testABEList(t, 8080)
-	testABEBulkEcho(t, 8080)
-	testABEBulkEchoZeroLength(t, 8080)
-	testAdditionalBindings(t, 8080)
-	testABERepeated(t, 8080)
+	testABECreate(t, 8088)
+	testABECreateBody(t, 8088)
+	testABEBulkCreate(t, 8088)
+	testABEBulkCreateWithError(t, 8088)
+	testABELookup(t, 8088)
+	testABELookupNotFound(t, 8088)
+	testABEList(t, 8088)
+	testABEBulkEcho(t, 8088)
+	testABEBulkEchoZeroLength(t, 8088)
+	testAdditionalBindings(t, 8088)
+	testABERepeated(t, 8088)
 }
 
 func testABECreate(t *testing.T, port int) {
@@ -680,7 +680,7 @@ func TestABEPatch(t *testing.T) {
 		return
 	}
 
-	port := 8080
+	port := 8088
 
 	// create a record with a known string_value and int32_value
 	uuid := postABE(t, port, gw.ABitOfEverything{StringValue: "strprefix/bar", Int32Value: 32})
@@ -724,7 +724,7 @@ func TestABEPatchBody(t *testing.T) {
 		return
 	}
 
-	port := 8080
+	port := 8088
 
 	for _, tc := range []struct {
 		name          string
@@ -1284,7 +1284,7 @@ func TestTimeout(t *testing.T) {
 		return
 	}
 
-	apiURL := "http://localhost:8080/v2/example/timeout"
+	apiURL := "http://localhost:8088/v2/example/timeout"
 	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
 		t.Errorf(`http.NewRequest("GET", %q, nil) failed with %v; want success`, apiURL, err)
@@ -1309,7 +1309,7 @@ func TestErrorWithDetails(t *testing.T) {
 		return
 	}
 
-	apiURL := "http://localhost:8080/v2/example/errorwithdetails"
+	apiURL := "http://localhost:8088/v2/example/errorwithdetails"
 	resp, err := http.Get(apiURL)
 	if err != nil {
 		t.Errorf("http.Get(%q) failed with %v; want success", apiURL, err)
@@ -1374,7 +1374,7 @@ func TestPostWithEmptyBody(t *testing.T) {
 		return
 	}
 
-	apiURL := "http://localhost:8080/v2/example/postwithemptybody/name"
+	apiURL := "http://localhost:8088/v2/example/postwithemptybody/name"
 	rep, err := http.Post(apiURL, "application/json", nil)
 
 	if err != nil {
@@ -1395,7 +1395,7 @@ func TestUnknownPath(t *testing.T) {
 		return
 	}
 
-	apiURL := "http://localhost:8080"
+	apiURL := "http://localhost:8088"
 	resp, err := http.Post(apiURL, "application/json", strings.NewReader("{}"))
 	if err != nil {
 		t.Errorf("http.Post(%q) failed with %v; want success", apiURL, err)
@@ -1420,7 +1420,7 @@ func TestMethodNotAllowed(t *testing.T) {
 		return
 	}
 
-	apiURL := "http://localhost:8080/v1/example/echo/myid"
+	apiURL := "http://localhost:8088/v1/example/echo/myid"
 	resp, err := http.Get(apiURL)
 	if err != nil {
 		t.Errorf("http.Post(%q) failed with %v; want success", apiURL, err)
@@ -1445,7 +1445,7 @@ func TestInvalidArgument(t *testing.T) {
 		return
 	}
 
-	apiURL := "http://localhost:8080/v1/example/echo/myid/not_int64"
+	apiURL := "http://localhost:8088/v1/example/echo/myid/not_int64"
 	resp, err := http.Get(apiURL)
 	if err != nil {
 		t.Errorf("http.Get(%q) failed with %v; want success", apiURL, err)
@@ -1470,9 +1470,9 @@ func TestResponseBody(t *testing.T) {
 		return
 	}
 
-	testResponseBody(t, 8080)
-	testResponseBodies(t, 8080)
-	testResponseStrings(t, 8080)
+	testResponseBody(t, 8088)
+	testResponseBodies(t, 8088)
+	testResponseStrings(t, 8088)
 }
 
 func testResponseBody(t *testing.T, port int) {
@@ -1594,7 +1594,7 @@ func TestRequestQueryParams(t *testing.T) {
 		return
 	}
 
-	port := 8080
+	port := 8088
 
 	formValues := url.Values{}
 	formValues.Set("string_value", "hello-world")

--- a/examples/internal/integration/main_test.go
+++ b/examples/internal/integration/main_test.go
@@ -64,7 +64,7 @@ func runServers(ctx context.Context) <-chan error {
 		}
 	}()
 	go func() {
-		if err := runGateway(ctx, ":8080"); err != nil {
+		if err := runGateway(ctx, ":8088"); err != nil {
 			ch <- fmt.Errorf("cannot run gateway service: %v", err)
 		}
 	}()
@@ -81,8 +81,8 @@ func TestMain(m *testing.M) {
 
 	ch := make(chan int, 1)
 	go func() {
-		if err := waitForGateway(ctx, 8080); err != nil {
-			glog.Errorf("waitForGateway(ctx, 8080) failed with %v; want success", err)
+		if err := waitForGateway(ctx, 8088); err != nil {
+			glog.Errorf("waitForGateway(ctx, 8088) failed with %v; want success", err)
 		}
 		ch <- m.Run()
 	}()


### PR DESCRIPTION
This should avoid a failure on Bazel's Buildkite CI, where 8080 cannot be used.