### PR TITLE
Generate Swagger with Unique Operation IDs

### DIFF
--- a/examples/internal/clients/abe/api/swagger.yaml
+++ b/examples/internal/clients/abe/api/swagger.yaml
@@ -33,7 +33,7 @@ paths:
     post:
       tags:
       - "ABitOfEverythingService"
-      operationId: "CreateBody"
+      operationId: "ABitOfEverythingService_CreateBody"
       parameters:
       - in: "body"
         name: "body"
@@ -69,7 +69,7 @@ paths:
       - "echo rpc"
       summary: "Summary: Echo rpc"
       description: "Description Echo"
-      operationId: "Echo"
+      operationId: "ABitOfEverythingService_Echo"
       parameters:
       - name: "value"
         in: "path"
@@ -112,7 +112,7 @@ paths:
     get:
       tags:
       - "ABitOfEverythingService"
-      operationId: "CheckNestedEnumGetQueryParams"
+      operationId: "ABitOfEverythingService_CheckNestedEnumGetQueryParams"
       parameters:
       - name: "single_nested.ok"
         in: "path"
@@ -400,7 +400,7 @@ paths:
     get:
       tags:
       - "ABitOfEverythingService"
-      operationId: "CheckGetQueryParams"
+      operationId: "ABitOfEverythingService_CheckGetQueryParams"
       parameters:
       - name: "single_nested.name"
         in: "path"
@@ -695,7 +695,7 @@ paths:
     post:
       tags:
       - "ABitOfEverythingService"
-      operationId: "CheckPostQueryParams"
+      operationId: "ABitOfEverythingService_CheckPostQueryParams"
       parameters:
       - name: "string_value"
         in: "path"
@@ -734,7 +734,7 @@ paths:
     get:
       tags:
       - "ABitOfEverythingService"
-      operationId: "GetQuery"
+      operationId: "ABitOfEverythingService_GetQuery"
       parameters:
       - name: "uuid"
         in: "path"
@@ -1042,7 +1042,7 @@ paths:
       - "ABitOfEverythingService"
       summary: "Create a new ABitOfEverything"
       description: "This API creates a new ABitOfEverything"
-      operationId: "Create"
+      operationId: "ABitOfEverythingService_Create"
       parameters:
       - name: "float_value"
         in: "path"
@@ -1193,7 +1193,7 @@ paths:
     post:
       tags:
       - "ABitOfEverythingService"
-      operationId: "DeepPathEcho"
+      operationId: "ABitOfEverythingService_DeepPathEcho"
       parameters:
       - name: "single_nested.name"
         in: "path"
@@ -1233,7 +1233,7 @@ paths:
     get:
       tags:
       - "ABitOfEverythingService"
-      operationId: "Lookup"
+      operationId: "ABitOfEverythingService_Lookup"
       parameters:
       - name: "uuid"
         in: "path"
@@ -1265,7 +1265,7 @@ paths:
     put:
       tags:
       - "ABitOfEverythingService"
-      operationId: "Update"
+      operationId: "ABitOfEverythingService_Update"
       parameters:
       - name: "uuid"
         in: "path"
@@ -1302,7 +1302,7 @@ paths:
     delete:
       tags:
       - "ABitOfEverythingService"
-      operationId: "Delete"
+      operationId: "ABitOfEverythingService_Delete"
       parameters:
       - name: "uuid"
         in: "path"
@@ -1340,7 +1340,7 @@ paths:
   : get:
       tags:
       - "ABitOfEverythingService"
-      operationId: "GetRepeatedQuery"
+      operationId: "ABitOfEverythingService_GetRepeatedQuery"
       parameters:
       - name: "path_repeated_float_value"
         in: "path"
@@ -1531,7 +1531,7 @@ paths:
     put:
       tags:
       - "ABitOfEverythingService"
-      operationId: "UpdateV2"
+      operationId: "ABitOfEverythingService_UpdateV2"
       parameters:
       - name: "abe.uuid"
         in: "path"
@@ -1568,7 +1568,7 @@ paths:
     patch:
       tags:
       - "ABitOfEverythingService"
-      operationId: "UpdateV22"
+      operationId: "ABitOfEverythingService_UpdateV22"
       parameters:
       - name: "abe.uuid"
         in: "path"
@@ -1608,7 +1608,7 @@ paths:
       - "echo rpc"
       summary: "Summary: Echo rpc"
       description: "Description Echo"
-      operationId: "Echo3"
+      operationId: "ABitOfEverythingService_Echo3"
       parameters:
       - name: "value"
         in: "query"
@@ -1653,7 +1653,7 @@ paths:
       - "echo rpc"
       summary: "Summary: Echo rpc"
       description: "Description Echo"
-      operationId: "Echo2"
+      operationId: "ABitOfEverythingService_Echo2"
       parameters:
       - in: "body"
         name: "body"
@@ -1697,7 +1697,7 @@ paths:
     get:
       tags:
       - "camelCaseServiceName"
-      operationId: "Empty"
+      operationId: "camelCaseServiceName_Empty"
       parameters: []
       responses:
         200:
@@ -1724,7 +1724,7 @@ paths:
     get:
       tags:
       - "ABitOfEverythingService"
-      operationId: "ErrorWithDetails"
+      operationId: "ABitOfEverythingService_ErrorWithDetails"
       parameters: []
       responses:
         200:
@@ -1751,7 +1751,7 @@ paths:
     get:
       tags:
       - "ABitOfEverythingService"
-      operationId: "OverwriteResponseContentType"
+      operationId: "ABitOfEverythingService_OverwriteResponseContentType"
       produces:
       - "application/text"
       parameters: []
@@ -1781,7 +1781,7 @@ paths:
     post:
       tags:
       - "ABitOfEverythingService"
-      operationId: "PostWithEmptyBody"
+      operationId: "ABitOfEverythingService_PostWithEmptyBody"
       parameters:
       - name: "name"
         in: "path"
@@ -1819,7 +1819,7 @@ paths:
     get:
       tags:
       - "ABitOfEverythingService"
-      operationId: "Timeout"
+      operationId: "ABitOfEverythingService_Timeout"
       parameters: []
       responses:
         200:
@@ -1846,7 +1846,7 @@ paths:
     post:
       tags:
       - "ABitOfEverythingService"
-      operationId: "GetMessageWithBody"
+      operationId: "ABitOfEverythingService_GetMessageWithBody"
       parameters:
       - name: "id"
         in: "path"
@@ -1884,7 +1884,7 @@ paths:
     patch:
       tags:
       - "ABitOfEverythingService"
-      operationId: "UpdateV23"
+      operationId: "ABitOfEverythingService_UpdateV23"
       parameters:
       - name: "abe.uuid"
         in: "path"

--- a/examples/internal/clients/abe/api_a_bit_of_everything_service.go
+++ b/examples/internal/clients/abe/api_a_bit_of_everything_service.go
@@ -32,7 +32,7 @@ ABitOfEverythingServiceApiService
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param singleNestedName name is nested field.
  * @param floatValue Float value field
- * @param optional nil or *CheckGetQueryParamsOpts - Optional Parameters:
+ * @param optional nil or *ABitOfEverythingServiceCheckGetQueryParamsOpts - Optional Parameters:
      * @param "SingleNestedAmount" (optional.Int64) - 
      * @param "SingleNestedOk" (optional.String) -  DeepEnum description.   - FALSE: FALSE is false.  - TRUE: TRUE is true.
      * @param "Uuid" (optional.String) - 
@@ -68,7 +68,7 @@ ABitOfEverythingServiceApiService
 @return ExamplepbABitOfEverything
 */
 
-type CheckGetQueryParamsOpts struct { 
+type ABitOfEverythingServiceCheckGetQueryParamsOpts struct { 
 	SingleNestedAmount optional.Int64
 	SingleNestedOk optional.String
 	Uuid optional.String
@@ -102,7 +102,7 @@ type CheckGetQueryParamsOpts struct {
 	Int64OverrideType optional.Int64
 }
 
-func (a *ABitOfEverythingServiceApiService) CheckGetQueryParams(ctx context.Context, singleNestedName string, floatValue float32, localVarOptionals *CheckGetQueryParamsOpts) (ExamplepbABitOfEverything, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCheckGetQueryParams(ctx context.Context, singleNestedName string, floatValue float32, localVarOptionals *ABitOfEverythingServiceCheckGetQueryParamsOpts) (ExamplepbABitOfEverything, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -339,7 +339,7 @@ ABitOfEverythingServiceApiService
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param singleNestedOk DeepEnum description.
  * @param floatValue Float value field
- * @param optional nil or *CheckNestedEnumGetQueryParamsOpts - Optional Parameters:
+ * @param optional nil or *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsOpts - Optional Parameters:
      * @param "SingleNestedName" (optional.String) -  name is nested field.
      * @param "SingleNestedAmount" (optional.Int64) - 
      * @param "Uuid" (optional.String) - 
@@ -375,7 +375,7 @@ ABitOfEverythingServiceApiService
 @return ExamplepbABitOfEverything
 */
 
-type CheckNestedEnumGetQueryParamsOpts struct { 
+type ABitOfEverythingServiceCheckNestedEnumGetQueryParamsOpts struct { 
 	SingleNestedName optional.String
 	SingleNestedAmount optional.Int64
 	Uuid optional.String
@@ -409,7 +409,7 @@ type CheckNestedEnumGetQueryParamsOpts struct {
 	Int64OverrideType optional.Int64
 }
 
-func (a *ABitOfEverythingServiceApiService) CheckNestedEnumGetQueryParams(ctx context.Context, singleNestedOk string, floatValue float32, localVarOptionals *CheckNestedEnumGetQueryParamsOpts) (ExamplepbABitOfEverything, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCheckNestedEnumGetQueryParams(ctx context.Context, singleNestedOk string, floatValue float32, localVarOptionals *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsOpts) (ExamplepbABitOfEverything, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -649,7 +649,7 @@ ABitOfEverythingServiceApiService
 
 @return ExamplepbABitOfEverything
 */
-func (a *ABitOfEverythingServiceApiService) CheckPostQueryParams(ctx context.Context, stringValue string, body ABitOfEverythingNested) (ExamplepbABitOfEverything, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCheckPostQueryParams(ctx context.Context, stringValue string, body ABitOfEverythingNested) (ExamplepbABitOfEverything, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -815,7 +815,7 @@ This API creates a new ABitOfEverything
 
 @return ExamplepbABitOfEverything
 */
-func (a *ABitOfEverythingServiceApiService) Create(ctx context.Context, floatValue float32, doubleValue float64, int64Value string, uint64Value string, int32Value int32, fixed64Value string, fixed32Value int64, boolValue bool, stringValue string, uint32Value int64, sfixed32Value int32, sfixed64Value string, sint32Value int32, sint64Value string, nonConventionalNameValue string, enumValue string, pathEnumValue string, nestedPathEnumValue string, enumValueAnnotation string) (ExamplepbABitOfEverything, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCreate(ctx context.Context, floatValue float32, doubleValue float64, int64Value string, uint64Value string, int32Value int32, fixed64Value string, fixed32Value int64, boolValue bool, stringValue string, uint32Value int64, sfixed32Value int32, sfixed64Value string, sint32Value int32, sint64Value string, nonConventionalNameValue string, enumValue string, pathEnumValue string, nestedPathEnumValue string, enumValueAnnotation string) (ExamplepbABitOfEverything, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -978,7 +978,7 @@ ABitOfEverythingServiceApiService
 
 @return ExamplepbABitOfEverything
 */
-func (a *ABitOfEverythingServiceApiService) CreateBody(ctx context.Context, body ExamplepbABitOfEverything) (ExamplepbABitOfEverything, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCreateBody(ctx context.Context, body ExamplepbABitOfEverything) (ExamplepbABitOfEverything, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -1125,7 +1125,7 @@ ABitOfEverythingServiceApiService
 
 @return ExamplepbABitOfEverything
 */
-func (a *ABitOfEverythingServiceApiService) DeepPathEcho(ctx context.Context, singleNestedName string, body ExamplepbABitOfEverything) (ExamplepbABitOfEverything, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceDeepPathEcho(ctx context.Context, singleNestedName string, body ExamplepbABitOfEverything) (ExamplepbABitOfEverything, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -1272,7 +1272,7 @@ ABitOfEverythingServiceApiService
 
 @return interface{}
 */
-func (a *ABitOfEverythingServiceApiService) Delete(ctx context.Context, uuid string) (interface{}, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceDelete(ctx context.Context, uuid string) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
 		localVarPostBody   interface{}
@@ -1416,7 +1416,7 @@ ABitOfEverythingServiceApiService
 
 @return interface{}
 */
-func (a *ABitOfEverythingServiceApiService) ErrorWithDetails(ctx context.Context) (interface{}, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceErrorWithDetails(ctx context.Context) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -1561,7 +1561,7 @@ ABitOfEverythingServiceApiService
 
 @return interface{}
 */
-func (a *ABitOfEverythingServiceApiService) GetMessageWithBody(ctx context.Context, id string, body ExamplepbBody) (interface{}, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceGetMessageWithBody(ctx context.Context, id string, body ExamplepbBody) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -1706,7 +1706,7 @@ ABitOfEverythingServiceApiService
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param uuid
  * @param floatValue Float value field
- * @param optional nil or *GetQueryOpts - Optional Parameters:
+ * @param optional nil or *ABitOfEverythingServiceGetQueryOpts - Optional Parameters:
      * @param "SingleNestedName" (optional.String) -  name is nested field.
      * @param "SingleNestedAmount" (optional.Int64) - 
      * @param "SingleNestedOk" (optional.String) -  DeepEnum description.   - FALSE: FALSE is false.  - TRUE: TRUE is true.
@@ -1743,7 +1743,7 @@ ABitOfEverythingServiceApiService
 @return interface{}
 */
 
-type GetQueryOpts struct { 
+type ABitOfEverythingServiceGetQueryOpts struct { 
 	SingleNestedName optional.String
 	SingleNestedAmount optional.Int64
 	SingleNestedOk optional.String
@@ -1778,7 +1778,7 @@ type GetQueryOpts struct {
 	Int64OverrideType optional.Int64
 }
 
-func (a *ABitOfEverythingServiceApiService) GetQuery(ctx context.Context, uuid string, floatValue float32, localVarOptionals *GetQueryOpts) (interface{}, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceGetQuery(ctx context.Context, uuid string, floatValue float32, localVarOptionals *ABitOfEverythingServiceGetQueryOpts) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -2022,7 +2022,7 @@ ABitOfEverythingServiceApiService
 
 @return ExamplepbABitOfEverythingRepeated
 */
-func (a *ABitOfEverythingServiceApiService) GetRepeatedQuery(ctx context.Context, pathRepeatedFloatValue []float32, pathRepeatedDoubleValue []float64, pathRepeatedInt64Value []string, pathRepeatedUint64Value []string, pathRepeatedInt32Value []int32, pathRepeatedFixed64Value []string, pathRepeatedFixed32Value []int64, pathRepeatedBoolValue []bool, pathRepeatedStringValue []string, pathRepeatedBytesValue []string, pathRepeatedUint32Value []int64, pathRepeatedEnumValue []string, pathRepeatedSfixed32Value []int32, pathRepeatedSfixed64Value []string, pathRepeatedSint32Value []int32, pathRepeatedSint64Value []string) (ExamplepbABitOfEverythingRepeated, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceGetRepeatedQuery(ctx context.Context, pathRepeatedFloatValue []float32, pathRepeatedDoubleValue []float64, pathRepeatedInt64Value []string, pathRepeatedUint64Value []string, pathRepeatedInt32Value []int32, pathRepeatedFixed64Value []string, pathRepeatedFixed32Value []int64, pathRepeatedBoolValue []bool, pathRepeatedStringValue []string, pathRepeatedBytesValue []string, pathRepeatedUint32Value []int64, pathRepeatedEnumValue []string, pathRepeatedSfixed32Value []int32, pathRepeatedSfixed64Value []string, pathRepeatedSint32Value []int32, pathRepeatedSint64Value []string) (ExamplepbABitOfEverythingRepeated, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -2230,7 +2230,7 @@ ABitOfEverythingServiceApiService
 
 @return ExamplepbABitOfEverything
 */
-func (a *ABitOfEverythingServiceApiService) Lookup(ctx context.Context, uuid string) (ExamplepbABitOfEverything, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceLookup(ctx context.Context, uuid string) (ExamplepbABitOfEverything, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -2374,7 +2374,7 @@ ABitOfEverythingServiceApiService
 
 @return string
 */
-func (a *ABitOfEverythingServiceApiService) OverwriteResponseContentType(ctx context.Context) (string, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceOverwriteResponseContentType(ctx context.Context) (string, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -2519,7 +2519,7 @@ ABitOfEverythingServiceApiService
 
 @return interface{}
 */
-func (a *ABitOfEverythingServiceApiService) PostWithEmptyBody(ctx context.Context, name string, body ExamplepbBody) (interface{}, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServicePostWithEmptyBody(ctx context.Context, name string, body ExamplepbBody) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -2665,7 +2665,7 @@ ABitOfEverythingServiceApiService
 
 @return interface{}
 */
-func (a *ABitOfEverythingServiceApiService) Timeout(ctx context.Context) (interface{}, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceTimeout(ctx context.Context) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -2810,7 +2810,7 @@ ABitOfEverythingServiceApiService
 
 @return interface{}
 */
-func (a *ABitOfEverythingServiceApiService) Update(ctx context.Context, uuid string, body ExamplepbABitOfEverything) (interface{}, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdate(ctx context.Context, uuid string, body ExamplepbABitOfEverything) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
 		localVarPostBody   interface{}
@@ -2958,7 +2958,7 @@ ABitOfEverythingServiceApiService
 
 @return interface{}
 */
-func (a *ABitOfEverythingServiceApiService) UpdateV2(ctx context.Context, abeUuid string, body ExamplepbABitOfEverything) (interface{}, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV2(ctx context.Context, abeUuid string, body ExamplepbABitOfEverything) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
 		localVarPostBody   interface{}
@@ -3106,7 +3106,7 @@ ABitOfEverythingServiceApiService
 
 @return interface{}
 */
-func (a *ABitOfEverythingServiceApiService) UpdateV22(ctx context.Context, abeUuid string, body ExamplepbABitOfEverything) (interface{}, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV22(ctx context.Context, abeUuid string, body ExamplepbABitOfEverything) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Patch")
 		localVarPostBody   interface{}
@@ -3254,7 +3254,7 @@ ABitOfEverythingServiceApiService
 
 @return interface{}
 */
-func (a *ABitOfEverythingServiceApiService) UpdateV23(ctx context.Context, abeUuid string, body ExamplepbUpdateV2Request) (interface{}, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV23(ctx context.Context, abeUuid string, body ExamplepbUpdateV2Request) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Patch")
 		localVarPostBody   interface{}

--- a/examples/internal/clients/abe/api_camel_case_service_name.go
+++ b/examples/internal/clients/abe/api_camel_case_service_name.go
@@ -31,7 +31,7 @@ CamelCaseServiceNameApiService
 
 @return interface{}
 */
-func (a *CamelCaseServiceNameApiService) Empty(ctx context.Context) (interface{}, *http.Response, error) {
+func (a *CamelCaseServiceNameApiService) CamelCaseServiceNameEmpty(ctx context.Context) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}

--- a/examples/internal/clients/abe/api_echo_rpc.go
+++ b/examples/internal/clients/abe/api_echo_rpc.go
@@ -35,7 +35,7 @@ Description Echo
 
 @return SubStringMessage
 */
-func (a *EchoRpcApiService) Echo(ctx context.Context, value string) (SubStringMessage, *http.Response, error) {
+func (a *EchoRpcApiService) ABitOfEverythingServiceEcho(ctx context.Context, value string) (SubStringMessage, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -192,7 +192,7 @@ Description Echo
 
 @return SubStringMessage
 */
-func (a *EchoRpcApiService) Echo2(ctx context.Context, body string) (SubStringMessage, *http.Response, error) {
+func (a *EchoRpcApiService) ABitOfEverythingServiceEcho2(ctx context.Context, body string) (SubStringMessage, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -346,17 +346,17 @@ func (a *EchoRpcApiService) Echo2(ctx context.Context, body string) (SubStringMe
 EchoRpcApiService Summary: Echo rpc
 Description Echo
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param optional nil or *Echo3Opts - Optional Parameters:
+ * @param optional nil or *ABitOfEverythingServiceEcho3Opts - Optional Parameters:
      * @param "Value" (optional.String) - 
 
 @return SubStringMessage
 */
 
-type Echo3Opts struct { 
+type ABitOfEverythingServiceEcho3Opts struct { 
 	Value optional.String
 }
 
-func (a *EchoRpcApiService) Echo3(ctx context.Context, localVarOptionals *Echo3Opts) (SubStringMessage, *http.Response, error) {
+func (a *EchoRpcApiService) ABitOfEverythingServiceEcho3(ctx context.Context, localVarOptionals *ABitOfEverythingServiceEcho3Opts) (SubStringMessage, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}

--- a/examples/internal/clients/echo/api/swagger.yaml
+++ b/examples/internal/clients/echo/api/swagger.yaml
@@ -15,7 +15,7 @@ paths:
       - "EchoService"
       summary: "Echo method receives a simple message and returns it."
       description: "The message posted as the id parameter will also be\nreturned."
-      operationId: "Echo"
+      operationId: "EchoService_Echo"
       parameters:
       - name: "id"
         in: "path"
@@ -38,7 +38,7 @@ paths:
       - "EchoService"
       summary: "Echo method receives a simple message and returns it."
       description: "The message posted as the id parameter will also be\nreturned."
-      operationId: "Echo2"
+      operationId: "EchoService_Echo2"
       parameters:
       - name: "id"
         in: "path"
@@ -113,7 +113,7 @@ paths:
       - "EchoService"
       summary: "Echo method receives a simple message and returns it."
       description: "The message posted as the id parameter will also be\nreturned."
-      operationId: "Echo3"
+      operationId: "EchoService_Echo3"
       parameters:
       - name: "id"
         in: "path"
@@ -187,7 +187,7 @@ paths:
       - "EchoService"
       summary: "Echo method receives a simple message and returns it."
       description: "The message posted as the id parameter will also be\nreturned."
-      operationId: "Echo4"
+      operationId: "EchoService_Echo4"
       parameters:
       - name: "id"
         in: "path"
@@ -255,7 +255,7 @@ paths:
       - "EchoService"
       summary: "Echo method receives a simple message and returns it."
       description: "The message posted as the id parameter will also be\nreturned."
-      operationId: "Echo5"
+      operationId: "EchoService_Echo5"
       parameters:
       - name: "no.note"
         in: "path"
@@ -324,7 +324,7 @@ paths:
       tags:
       - "EchoService"
       summary: "EchoBody method receives a simple message and returns it."
-      operationId: "EchoBody"
+      operationId: "EchoService_EchoBody"
       parameters:
       - in: "body"
         name: "body"
@@ -346,7 +346,7 @@ paths:
       tags:
       - "EchoService"
       summary: "EchoDelete method receives a simple message and returns it."
-      operationId: "EchoDelete"
+      operationId: "EchoService_EchoDelete"
       parameters:
       - name: "id"
         in: "query"

--- a/examples/internal/clients/echo/api_echo_service.go
+++ b/examples/internal/clients/echo/api_echo_service.go
@@ -34,7 +34,7 @@ The message posted as the id parameter will also be returned.
 
 @return ExamplepbSimpleMessage
 */
-func (a *EchoServiceApiService) Echo(ctx context.Context, id string) (ExamplepbSimpleMessage, *http.Response, error) {
+func (a *EchoServiceApiService) EchoServiceEcho(ctx context.Context, id string) (ExamplepbSimpleMessage, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -132,7 +132,7 @@ The message posted as the id parameter will also be returned.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param id Id represents the message identifier.
  * @param num
- * @param optional nil or *Echo2Opts - Optional Parameters:
+ * @param optional nil or *EchoServiceEcho2Opts - Optional Parameters:
      * @param "LineNum" (optional.String) - 
      * @param "Lang" (optional.String) - 
      * @param "StatusProgress" (optional.String) - 
@@ -144,7 +144,7 @@ The message posted as the id parameter will also be returned.
 @return ExamplepbSimpleMessage
 */
 
-type Echo2Opts struct { 
+type EchoServiceEcho2Opts struct { 
 	LineNum optional.String
 	Lang optional.String
 	StatusProgress optional.String
@@ -154,7 +154,7 @@ type Echo2Opts struct {
 	NoNote optional.String
 }
 
-func (a *EchoServiceApiService) Echo2(ctx context.Context, id string, num string, localVarOptionals *Echo2Opts) (ExamplepbSimpleMessage, *http.Response, error) {
+func (a *EchoServiceApiService) EchoServiceEcho2(ctx context.Context, id string, num string, localVarOptionals *EchoServiceEcho2Opts) (ExamplepbSimpleMessage, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -275,7 +275,7 @@ The message posted as the id parameter will also be returned.
  * @param id Id represents the message identifier.
  * @param num
  * @param lang
- * @param optional nil or *Echo3Opts - Optional Parameters:
+ * @param optional nil or *EchoServiceEcho3Opts - Optional Parameters:
      * @param "LineNum" (optional.String) - 
      * @param "StatusProgress" (optional.String) - 
      * @param "StatusNote" (optional.String) - 
@@ -286,7 +286,7 @@ The message posted as the id parameter will also be returned.
 @return ExamplepbSimpleMessage
 */
 
-type Echo3Opts struct { 
+type EchoServiceEcho3Opts struct { 
 	LineNum optional.String
 	StatusProgress optional.String
 	StatusNote optional.String
@@ -295,7 +295,7 @@ type Echo3Opts struct {
 	NoNote optional.String
 }
 
-func (a *EchoServiceApiService) Echo3(ctx context.Context, id string, num string, lang string, localVarOptionals *Echo3Opts) (ExamplepbSimpleMessage, *http.Response, error) {
+func (a *EchoServiceApiService) EchoServiceEcho3(ctx context.Context, id string, num string, lang string, localVarOptionals *EchoServiceEcho3Opts) (ExamplepbSimpleMessage, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -414,7 +414,7 @@ The message posted as the id parameter will also be returned.
  * @param id Id represents the message identifier.
  * @param lineNum
  * @param statusNote
- * @param optional nil or *Echo4Opts - Optional Parameters:
+ * @param optional nil or *EchoServiceEcho4Opts - Optional Parameters:
      * @param "Num" (optional.String) - 
      * @param "Lang" (optional.String) - 
      * @param "StatusProgress" (optional.String) - 
@@ -424,7 +424,7 @@ The message posted as the id parameter will also be returned.
 @return ExamplepbSimpleMessage
 */
 
-type Echo4Opts struct { 
+type EchoServiceEcho4Opts struct { 
 	Num optional.String
 	Lang optional.String
 	StatusProgress optional.String
@@ -432,7 +432,7 @@ type Echo4Opts struct {
 	NoProgress optional.String
 }
 
-func (a *EchoServiceApiService) Echo4(ctx context.Context, id string, lineNum string, statusNote string, localVarOptionals *Echo4Opts) (ExamplepbSimpleMessage, *http.Response, error) {
+func (a *EchoServiceApiService) EchoServiceEcho4(ctx context.Context, id string, lineNum string, statusNote string, localVarOptionals *EchoServiceEcho4Opts) (ExamplepbSimpleMessage, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -546,7 +546,7 @@ EchoServiceApiService Echo method receives a simple message and returns it.
 The message posted as the id parameter will also be returned.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param noNote
- * @param optional nil or *Echo5Opts - Optional Parameters:
+ * @param optional nil or *EchoServiceEcho5Opts - Optional Parameters:
      * @param "Id" (optional.String) -  Id represents the message identifier.
      * @param "Num" (optional.String) - 
      * @param "LineNum" (optional.String) - 
@@ -558,7 +558,7 @@ The message posted as the id parameter will also be returned.
 @return ExamplepbSimpleMessage
 */
 
-type Echo5Opts struct { 
+type EchoServiceEcho5Opts struct { 
 	Id optional.String
 	Num optional.String
 	LineNum optional.String
@@ -568,7 +568,7 @@ type Echo5Opts struct {
 	NoProgress optional.String
 }
 
-func (a *EchoServiceApiService) Echo5(ctx context.Context, noNote string, localVarOptionals *Echo5Opts) (ExamplepbSimpleMessage, *http.Response, error) {
+func (a *EchoServiceApiService) EchoServiceEcho5(ctx context.Context, noNote string, localVarOptionals *EchoServiceEcho5Opts) (ExamplepbSimpleMessage, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -688,7 +688,7 @@ EchoServiceApiService EchoBody method receives a simple message and returns it.
 
 @return ExamplepbSimpleMessage
 */
-func (a *EchoServiceApiService) EchoBody(ctx context.Context, body ExamplepbSimpleMessage) (ExamplepbSimpleMessage, *http.Response, error) {
+func (a *EchoServiceApiService) EchoServiceEchoBody(ctx context.Context, body ExamplepbSimpleMessage) (ExamplepbSimpleMessage, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -784,7 +784,7 @@ func (a *EchoServiceApiService) EchoBody(ctx context.Context, body ExamplepbSimp
 /* 
 EchoServiceApiService EchoDelete method receives a simple message and returns it.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param optional nil or *EchoDeleteOpts - Optional Parameters:
+ * @param optional nil or *EchoServiceEchoDeleteOpts - Optional Parameters:
      * @param "Id" (optional.String) -  Id represents the message identifier.
      * @param "Num" (optional.String) - 
      * @param "LineNum" (optional.String) - 
@@ -798,7 +798,7 @@ EchoServiceApiService EchoDelete method receives a simple message and returns it
 @return ExamplepbSimpleMessage
 */
 
-type EchoDeleteOpts struct { 
+type EchoServiceEchoDeleteOpts struct { 
 	Id optional.String
 	Num optional.String
 	LineNum optional.String
@@ -810,7 +810,7 @@ type EchoDeleteOpts struct {
 	NoNote optional.String
 }
 
-func (a *EchoServiceApiService) EchoDelete(ctx context.Context, localVarOptionals *EchoDeleteOpts) (ExamplepbSimpleMessage, *http.Response, error) {
+func (a *EchoServiceApiService) EchoServiceEchoDelete(ctx context.Context, localVarOptionals *EchoServiceEchoDeleteOpts) (ExamplepbSimpleMessage, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
 		localVarPostBody   interface{}

--- a/examples/internal/clients/responsebody/api/swagger.yaml
+++ b/examples/internal/clients/responsebody/api/swagger.yaml
@@ -12,7 +12,7 @@ paths:
     get:
       tags:
       - "ResponseBodyService"
-      operationId: "ListResponseBodies"
+      operationId: "ResponseBodyService_ListResponseBodies"
       parameters:
       - name: "data"
         in: "path"
@@ -34,7 +34,7 @@ paths:
     get:
       tags:
       - "ResponseBodyService"
-      operationId: "GetResponseBody"
+      operationId: "ResponseBodyService_GetResponseBody"
       parameters:
       - name: "data"
         in: "path"
@@ -54,7 +54,7 @@ paths:
     get:
       tags:
       - "ResponseBodyService"
-      operationId: "ListResponseStrings"
+      operationId: "ResponseBodyService_ListResponseStrings"
       parameters:
       - name: "data"
         in: "path"

--- a/examples/internal/clients/responsebody/api_response_body_service.go
+++ b/examples/internal/clients/responsebody/api_response_body_service.go
@@ -32,7 +32,7 @@ ResponseBodyServiceApiService
 
 @return ExamplepbResponseBodyOutResponse
 */
-func (a *ResponseBodyServiceApiService) GetResponseBody(ctx context.Context, data string) (ExamplepbResponseBodyOutResponse, *http.Response, error) {
+func (a *ResponseBodyServiceApiService) ResponseBodyServiceGetResponseBody(ctx context.Context, data string) (ExamplepbResponseBodyOutResponse, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -131,7 +131,7 @@ ResponseBodyServiceApiService
 
 @return []ExamplepbRepeatedResponseBodyOutResponse
 */
-func (a *ResponseBodyServiceApiService) ListResponseBodies(ctx context.Context, data string) ([]ExamplepbRepeatedResponseBodyOutResponse, *http.Response, error) {
+func (a *ResponseBodyServiceApiService) ResponseBodyServiceListResponseBodies(ctx context.Context, data string) ([]ExamplepbRepeatedResponseBodyOutResponse, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -230,7 +230,7 @@ ResponseBodyServiceApiService
 
 @return []string
 */
-func (a *ResponseBodyServiceApiService) ListResponseStrings(ctx context.Context, data string) ([]string, *http.Response, error) {
+func (a *ResponseBodyServiceApiService) ResponseBodyServiceListResponseStrings(ctx context.Context, data string) ([]string, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}

--- a/examples/internal/clients/responsebody/docs/ResponseBodyServiceApi.md
+++ b/examples/internal/clients/responsebody/docs/ResponseBodyServiceApi.md
@@ -4,13 +4,13 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**GetResponseBody**](ResponseBodyServiceApi.md#GetResponseBody) | **Get** /responsebody/{data} | 
-[**ListResponseBodies**](ResponseBodyServiceApi.md#ListResponseBodies) | **Get** /responsebodies/{data} | 
-[**ListResponseStrings**](ResponseBodyServiceApi.md#ListResponseStrings) | **Get** /responsestrings/{data} | 
+[**ResponseBodyServiceGetResponseBody**](ResponseBodyServiceApi.md#ResponseBodyServiceGetResponseBody) | **Get** /responsebody/{data} | 
+[**ResponseBodyServiceListResponseBodies**](ResponseBodyServiceApi.md#ResponseBodyServiceListResponseBodies) | **Get** /responsebodies/{data} | 
+[**ResponseBodyServiceListResponseStrings**](ResponseBodyServiceApi.md#ResponseBodyServiceListResponseStrings) | **Get** /responsestrings/{data} | 
 
 
-# **GetResponseBody**
-> ExamplepbResponseBodyOutResponse GetResponseBody(ctx, data)
+# **ResponseBodyServiceGetResponseBody**
+> ExamplepbResponseBodyOutResponse ResponseBodyServiceGetResponseBody(ctx, data)
 
 
 ### Required Parameters
@@ -35,8 +35,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **ListResponseBodies**
-> []ExamplepbRepeatedResponseBodyOutResponse ListResponseBodies(ctx, data)
+# **ResponseBodyServiceListResponseBodies**
+> []ExamplepbRepeatedResponseBodyOutResponse ResponseBodyServiceListResponseBodies(ctx, data)
 
 
 ### Required Parameters
@@ -61,8 +61,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **ListResponseStrings**
-> []string ListResponseStrings(ctx, data)
+# **ResponseBodyServiceListResponseStrings**
+> []string ResponseBodyServiceListResponseStrings(ctx, data)
 
 
 ### Required Parameters

--- a/examples/internal/clients/unannotatedecho/api/swagger.yaml
+++ b/examples/internal/clients/unannotatedecho/api/swagger.yaml
@@ -18,7 +18,7 @@ paths:
       - "UnannotatedEchoService"
       summary: "Echo method receives a simple message and returns it."
       description: "The message posted as the id parameter will also be\nreturned."
-      operationId: "Echo"
+      operationId: "UnannotatedEchoService_Echo"
       parameters:
       - name: "id"
         in: "path"
@@ -41,7 +41,7 @@ paths:
       - "UnannotatedEchoService"
       summary: "Echo method receives a simple message and returns it."
       description: "The message posted as the id parameter will also be\nreturned."
-      operationId: "Echo2"
+      operationId: "UnannotatedEchoService_Echo2"
       parameters:
       - name: "id"
         in: "path"
@@ -75,7 +75,7 @@ paths:
       tags:
       - "UnannotatedEchoService"
       summary: "EchoBody method receives a simple message and returns it."
-      operationId: "EchoBody"
+      operationId: "UnannotatedEchoService_EchoBody"
       parameters:
       - in: "body"
         name: "body"
@@ -97,7 +97,7 @@ paths:
       tags:
       - "UnannotatedEchoService"
       summary: "EchoDelete method receives a simple message and returns it."
-      operationId: "EchoDelete"
+      operationId: "UnannotatedEchoService_EchoDelete"
       parameters:
       - name: "id"
         in: "query"

--- a/examples/internal/clients/unannotatedecho/api_unannotated_echo_service.go
+++ b/examples/internal/clients/unannotatedecho/api_unannotated_echo_service.go
@@ -34,7 +34,7 @@ The message posted as the id parameter will also be returned.
 
 @return ExamplepbUnannotatedSimpleMessage
 */
-func (a *UnannotatedEchoServiceApiService) Echo(ctx context.Context, id string) (ExamplepbUnannotatedSimpleMessage, *http.Response, error) {
+func (a *UnannotatedEchoServiceApiService) UnannotatedEchoServiceEcho(ctx context.Context, id string) (ExamplepbUnannotatedSimpleMessage, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -132,17 +132,17 @@ The message posted as the id parameter will also be returned.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param id Id represents the message identifier.
  * @param num
- * @param optional nil or *Echo2Opts - Optional Parameters:
+ * @param optional nil or *UnannotatedEchoServiceEcho2Opts - Optional Parameters:
      * @param "Duration" (optional.String) - 
 
 @return ExamplepbUnannotatedSimpleMessage
 */
 
-type Echo2Opts struct { 
+type UnannotatedEchoServiceEcho2Opts struct { 
 	Duration optional.String
 }
 
-func (a *UnannotatedEchoServiceApiService) Echo2(ctx context.Context, id string, num string, localVarOptionals *Echo2Opts) (ExamplepbUnannotatedSimpleMessage, *http.Response, error) {
+func (a *UnannotatedEchoServiceApiService) UnannotatedEchoServiceEcho2(ctx context.Context, id string, num string, localVarOptionals *UnannotatedEchoServiceEcho2Opts) (ExamplepbUnannotatedSimpleMessage, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
@@ -245,7 +245,7 @@ UnannotatedEchoServiceApiService EchoBody method receives a simple message and r
 
 @return ExamplepbUnannotatedSimpleMessage
 */
-func (a *UnannotatedEchoServiceApiService) EchoBody(ctx context.Context, body ExamplepbUnannotatedSimpleMessage) (ExamplepbUnannotatedSimpleMessage, *http.Response, error) {
+func (a *UnannotatedEchoServiceApiService) UnannotatedEchoServiceEchoBody(ctx context.Context, body ExamplepbUnannotatedSimpleMessage) (ExamplepbUnannotatedSimpleMessage, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -341,7 +341,7 @@ func (a *UnannotatedEchoServiceApiService) EchoBody(ctx context.Context, body Ex
 /* 
 UnannotatedEchoServiceApiService EchoDelete method receives a simple message and returns it.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param optional nil or *EchoDeleteOpts - Optional Parameters:
+ * @param optional nil or *UnannotatedEchoServiceEchoDeleteOpts - Optional Parameters:
      * @param "Id" (optional.String) -  Id represents the message identifier.
      * @param "Num" (optional.String) - 
      * @param "Duration" (optional.String) - 
@@ -349,13 +349,13 @@ UnannotatedEchoServiceApiService EchoDelete method receives a simple message and
 @return ExamplepbUnannotatedSimpleMessage
 */
 
-type EchoDeleteOpts struct { 
+type UnannotatedEchoServiceEchoDeleteOpts struct { 
 	Id optional.String
 	Num optional.String
 	Duration optional.String
 }
 
-func (a *UnannotatedEchoServiceApiService) EchoDelete(ctx context.Context, localVarOptionals *EchoDeleteOpts) (ExamplepbUnannotatedSimpleMessage, *http.Response, error) {
+func (a *UnannotatedEchoServiceApiService) UnannotatedEchoServiceEchoDelete(ctx context.Context, localVarOptionals *UnannotatedEchoServiceEchoDeleteOpts) (ExamplepbUnannotatedSimpleMessage, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
 		localVarPostBody   interface{}

--- a/examples/internal/integration/client_test.go
+++ b/examples/internal/integration/client_test.go
@@ -19,7 +19,7 @@ func TestEchoClient(t *testing.T) {
 	cfg.BasePath = "http://localhost:8088"
 
 	cl := echo.NewAPIClient(cfg)
-	resp, _, err := cl.EchoServiceApi.Echo(context.Background(), "foo")
+	resp, _, err := cl.EchoServiceApi.EchoServiceEcho(context.Background(), "foo")
 	if err != nil {
 		t.Errorf(`cl.EchoServiceApi.Echo("foo") failed with %v; want success`, err)
 	}
@@ -39,7 +39,7 @@ func TestEchoBodyClient(t *testing.T) {
 
 	cl := echo.NewAPIClient(cfg)
 	req := echo.ExamplepbSimpleMessage{Id: "foo"}
-	resp, _, err := cl.EchoServiceApi.EchoBody(context.Background(), req)
+	resp, _, err := cl.EchoServiceApi.EchoServiceEchoBody(context.Background(), req)
 	if err != nil {
 		t.Errorf("cl.EchoBody(%#v) failed with %v; want success", req, err)
 	}
@@ -88,7 +88,7 @@ func testABEClientCreate(t *testing.T, cl *abe.APIClient) {
 		NestedPathEnumValue:      &messagePath,
 		EnumValueAnnotation:      &enumZero,
 	}
-	resp, _, err := cl.ABitOfEverythingServiceApi.Create(
+	resp, _, err := cl.ABitOfEverythingServiceApi.ABitOfEverythingServiceCreate(
 		context.Background(),
 		want.FloatValue,
 		want.DoubleValue,
@@ -188,7 +188,7 @@ func TestUnannotatedEchoClient(t *testing.T) {
 
 	cl := unannotatedecho.NewAPIClient(cfg)
 
-	resp, _, err := cl.UnannotatedEchoServiceApi.Echo(context.Background(), "foo")
+	resp, _, err := cl.UnannotatedEchoServiceApi.UnannotatedEchoServiceEcho(context.Background(), "foo")
 	if err != nil {
 		t.Errorf(`cl.Echo("foo") failed with %v; want success`, err)
 	}
@@ -209,7 +209,7 @@ func TestUnannotatedEchoBodyClient(t *testing.T) {
 	cl := unannotatedecho.NewAPIClient(cfg)
 
 	req := unannotatedecho.ExamplepbUnannotatedSimpleMessage{Id: "foo"}
-	resp, _, err := cl.UnannotatedEchoServiceApi.EchoBody(context.Background(), req)
+	resp, _, err := cl.UnannotatedEchoServiceApi.UnannotatedEchoServiceEchoBody(context.Background(), req)
 	if err != nil {
 		t.Errorf("cl.EchoBody(%#v) failed with %v; want success", req, err)
 	}

--- a/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
+++ b/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
@@ -30,7 +30,7 @@
   "paths": {
     "/v1/example/a_bit_of_everything": {
       "post": {
-        "operationId": "CreateBody",
+        "operationId": "ABitOfEverythingService_CreateBody",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -81,7 +81,7 @@
       "get": {
         "summary": "Summary: Echo rpc",
         "description": "Description Echo",
-        "operationId": "Echo",
+        "operationId": "ABitOfEverythingService_Echo",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -142,7 +142,7 @@
     },
     "/v1/example/a_bit_of_everything/params/get/nested_enum/{single_nested.ok}": {
       "get": {
-        "operationId": "CheckNestedEnumGetQueryParams",
+        "operationId": "ABitOfEverythingService_CheckNestedEnumGetQueryParams",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -457,7 +457,7 @@
     },
     "/v1/example/a_bit_of_everything/params/get/{single_nested.name}": {
       "get": {
-        "operationId": "CheckGetQueryParams",
+        "operationId": "ABitOfEverythingService_CheckGetQueryParams",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -778,7 +778,7 @@
     },
     "/v1/example/a_bit_of_everything/params/post/{string_value}": {
       "post": {
-        "operationId": "CheckPostQueryParams",
+        "operationId": "ABitOfEverythingService_CheckPostQueryParams",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -833,7 +833,7 @@
     },
     "/v1/example/a_bit_of_everything/query/{uuid}": {
       "get": {
-        "operationId": "GetQuery",
+        "operationId": "ABitOfEverythingService_GetQuery",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1169,7 +1169,7 @@
       "post": {
         "summary": "Create a new ABitOfEverything",
         "description": "This API creates a new ABitOfEverything",
-        "operationId": "Create",
+        "operationId": "ABitOfEverythingService_Create",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1356,7 +1356,7 @@
     },
     "/v1/example/a_bit_of_everything/{single_nested.name}": {
       "post": {
-        "operationId": "DeepPathEcho",
+        "operationId": "ABitOfEverythingService_DeepPathEcho",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1412,7 +1412,7 @@
     },
     "/v1/example/a_bit_of_everything/{uuid}": {
       "get": {
-        "operationId": "Lookup",
+        "operationId": "ABitOfEverythingService_Lookup",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1457,7 +1457,7 @@
         ]
       },
       "delete": {
-        "operationId": "Delete",
+        "operationId": "ABitOfEverythingService_Delete",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1512,7 +1512,7 @@
         "x-irreversible": true
       },
       "put": {
-        "operationId": "Update",
+        "operationId": "ABitOfEverythingService_Update",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1567,7 +1567,7 @@
     },
     "/v1/example/a_bit_of_everything_repeated/{path_repeated_float_value}/{path_repeated_double_value}/{path_repeated_int64_value}/{path_repeated_uint64_value}/{path_repeated_int32_value}/{path_repeated_fixed64_value}/{path_repeated_fixed32_value}/{path_repeated_bool_value}/{path_repeated_string_value}/{path_repeated_bytes_value}/{path_repeated_uint32_value}/{path_repeated_enum_value}/{path_repeated_sfixed32_value}/{path_repeated_sfixed64_value}/{path_repeated_sint32_value}/{path_repeated_sint64_value}": {
       "get": {
-        "operationId": "GetRepeatedQuery",
+        "operationId": "ABitOfEverythingService_GetRepeatedQuery",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1803,7 +1803,7 @@
     },
     "/v2/example/a_bit_of_everything/{abe.uuid}": {
       "put": {
-        "operationId": "UpdateV2",
+        "operationId": "ABitOfEverythingService_UpdateV2",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1856,7 +1856,7 @@
         ]
       },
       "patch": {
-        "operationId": "UpdateV22",
+        "operationId": "ABitOfEverythingService_UpdateV22",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1913,7 +1913,7 @@
       "get": {
         "summary": "Summary: Echo rpc",
         "description": "Description Echo",
-        "operationId": "Echo3",
+        "operationId": "ABitOfEverythingService_Echo3",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1974,7 +1974,7 @@
       "post": {
         "summary": "Summary: Echo rpc",
         "description": "Description Echo",
-        "operationId": "Echo2",
+        "operationId": "ABitOfEverythingService_Echo2",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -2037,7 +2037,7 @@
     },
     "/v2/example/empty": {
       "get": {
-        "operationId": "Empty",
+        "operationId": "camelCaseServiceName_Empty",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -2076,7 +2076,7 @@
     },
     "/v2/example/errorwithdetails": {
       "get": {
-        "operationId": "ErrorWithDetails",
+        "operationId": "ABitOfEverythingService_ErrorWithDetails",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -2115,7 +2115,7 @@
     },
     "/v2/example/overwriteresponsecontenttype": {
       "get": {
-        "operationId": "OverwriteResponseContentType",
+        "operationId": "ABitOfEverythingService_OverwriteResponseContentType",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -2157,7 +2157,7 @@
     },
     "/v2/example/postwithemptybody/{name}": {
       "post": {
-        "operationId": "PostWithEmptyBody",
+        "operationId": "ABitOfEverythingService_PostWithEmptyBody",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -2212,7 +2212,7 @@
     },
     "/v2/example/timeout": {
       "get": {
-        "operationId": "Timeout",
+        "operationId": "ABitOfEverythingService_Timeout",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -2251,7 +2251,7 @@
     },
     "/v2/example/withbody/{id}": {
       "post": {
-        "operationId": "GetMessageWithBody",
+        "operationId": "ABitOfEverythingService_GetMessageWithBody",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -2306,7 +2306,7 @@
     },
     "/v2a/example/a_bit_of_everything/{abe.uuid}": {
       "patch": {
-        "operationId": "UpdateV23",
+        "operationId": "ABitOfEverythingService_UpdateV23",
         "responses": {
           "200": {
             "description": "A successful response.",

--- a/examples/internal/proto/examplepb/echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/echo_service.swagger.json
@@ -16,7 +16,7 @@
       "post": {
         "summary": "Echo method receives a simple message and returns it.",
         "description": "The message posted as the id parameter will also be\nreturned.",
-        "operationId": "Echo",
+        "operationId": "EchoService_Echo",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -49,7 +49,7 @@
       "get": {
         "summary": "Echo method receives a simple message and returns it.",
         "description": "The message posted as the id parameter will also be\nreturned.",
-        "operationId": "Echo2",
+        "operationId": "EchoService_Echo2",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -135,7 +135,7 @@
       "get": {
         "summary": "Echo method receives a simple message and returns it.",
         "description": "The message posted as the id parameter will also be\nreturned.",
-        "operationId": "Echo3",
+        "operationId": "EchoService_Echo3",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -221,7 +221,7 @@
       "get": {
         "summary": "Echo method receives a simple message and returns it.",
         "description": "The message posted as the id parameter will also be\nreturned.",
-        "operationId": "Echo4",
+        "operationId": "EchoService_Echo4",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -301,7 +301,7 @@
       "get": {
         "summary": "Echo method receives a simple message and returns it.",
         "description": "The message posted as the id parameter will also be\nreturned.",
-        "operationId": "Echo5",
+        "operationId": "EchoService_Echo5",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -380,7 +380,7 @@
     "/v1/example/echo_body": {
       "post": {
         "summary": "EchoBody method receives a simple message and returns it.",
-        "operationId": "EchoBody",
+        "operationId": "EchoService_EchoBody",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -413,7 +413,7 @@
     "/v1/example/echo_delete": {
       "delete": {
         "summary": "EchoDelete method receives a simple message and returns it.",
-        "operationId": "EchoDelete",
+        "operationId": "EchoService_EchoDelete",
         "responses": {
           "200": {
             "description": "A successful response.",

--- a/examples/internal/proto/examplepb/response_body_service.swagger.json
+++ b/examples/internal/proto/examplepb/response_body_service.swagger.json
@@ -13,7 +13,7 @@
   "paths": {
     "/responsebodies/{data}": {
       "get": {
-        "operationId": "ListResponseBodies",
+        "operationId": "ResponseBodyService_ListResponseBodies",
         "responses": {
           "200": {
             "description": "",
@@ -46,7 +46,7 @@
     },
     "/responsebody/{data}": {
       "get": {
-        "operationId": "GetResponseBody",
+        "operationId": "ResponseBodyService_GetResponseBody",
         "responses": {
           "200": {
             "description": "",
@@ -76,7 +76,7 @@
     },
     "/responsestrings/{data}": {
       "get": {
-        "operationId": "ListResponseStrings",
+        "operationId": "ResponseBodyService_ListResponseStrings",
         "responses": {
           "200": {
             "description": "",

--- a/examples/internal/proto/examplepb/stream.swagger.json
+++ b/examples/internal/proto/examplepb/stream.swagger.json
@@ -13,7 +13,7 @@
   "paths": {
     "/v1/example/a_bit_of_everything": {
       "get": {
-        "operationId": "List",
+        "operationId": "StreamService_List",
         "responses": {
           "200": {
             "description": "A successful response.(streaming responses)",
@@ -44,7 +44,7 @@
     },
     "/v1/example/a_bit_of_everything/bulk": {
       "post": {
-        "operationId": "BulkCreate",
+        "operationId": "StreamService_BulkCreate",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -77,7 +77,7 @@
     },
     "/v1/example/a_bit_of_everything/echo": {
       "post": {
-        "operationId": "BulkEcho",
+        "operationId": "StreamService_BulkEcho",
         "responses": {
           "200": {
             "description": "A successful response.(streaming responses)",

--- a/examples/internal/proto/examplepb/unannotated_echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/unannotated_echo_service.swagger.json
@@ -16,7 +16,7 @@
       "post": {
         "summary": "Echo method receives a simple message and returns it.",
         "description": "The message posted as the id parameter will also be\nreturned.",
-        "operationId": "Echo",
+        "operationId": "UnannotatedEchoService_Echo",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -49,7 +49,7 @@
       "get": {
         "summary": "Echo method receives a simple message and returns it.",
         "description": "The message posted as the id parameter will also be\nreturned.",
-        "operationId": "Echo2",
+        "operationId": "UnannotatedEchoService_Echo2",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -94,7 +94,7 @@
     "/v1/example/echo_body": {
       "post": {
         "summary": "EchoBody method receives a simple message and returns it.",
-        "operationId": "EchoBody",
+        "operationId": "UnannotatedEchoService_EchoBody",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -127,7 +127,7 @@
     "/v1/example/echo_delete": {
       "delete": {
         "summary": "EchoDelete method receives a simple message and returns it.",
-        "operationId": "EchoDelete",
+        "operationId": "UnannotatedEchoService_EchoDelete",
         "responses": {
           "200": {
             "description": "A successful response.",

--- a/examples/internal/proto/examplepb/use_go_template.swagger.json
+++ b/examples/internal/proto/examplepb/use_go_template.swagger.json
@@ -15,7 +15,7 @@
       "post": {
         "summary": "Login",
         "description": "Login is a call with the method(s) POST within the \"LoginService\" service.\nIt takes in \"LoginRequest\" and returns a \"LoginReply\".\n\n## LoginRequest\n| Field ID    | Name      | Type                                                       | Description                  |\n| ----------- | --------- | ---------------------------------------------------------  | ---------------------------- | \n| 1 | username | TYPE_STRING | The entered username | \n| 2 | password | TYPE_STRING | The entered password |   \n\n## LoginReply\n| Field ID    | Name      | Type                                                       | Description                  |\n| ----------- | --------- | ---------------------------------------------------------- | ---------------------------- | \n| 1 | message | TYPE_STRING |  | \n| 2 | access | TYPE_BOOL | Whether you have access or not |",
-        "operationId": "Login",
+        "operationId": "LoginService_Login",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -49,7 +49,7 @@
       "post": {
         "summary": "Logout",
         "description": "Logout is a call with the method(s) POST within the \"LoginService\" service.\nIt takes in \"LogoutRequest\" and returns a \"LogoutReply\".\n\n## LogoutRequest\n| Field ID    | Name      | Type                                                       | Description                  |\n| ----------- | --------- | ---------------------------------------------------------  | ---------------------------- | \n| 1 | timeoflogout | TYPE_STRING | The time the logout was registered | \n| 2 | test | TYPE_INT32 | This is the title\u003cbr\u003e\u003cbr\u003eThis is the \"Description\" of field test\u003cbr\u003eyou can use as many newlines as you want\u003cbr\u003e\u003cbr\u003e\u003cbr\u003eit will still format the same in the table | \n| 3 | stringarray | []TYPE_STRING | This is an array\u003cbr\u003e\u003cbr\u003eIt displays that using [] infront of the type |   \n\n## LogoutReply\n| Field ID    | Name      | Type                                                       | Description                  |\n| ----------- | --------- | ---------------------------------------------------------- | ---------------------------- | \n| 1 | message | TYPE_STRING | Message that tells you whether your\u003cbr\u003elogout was succesful or not |",
-        "operationId": "Logout",
+        "operationId": "LoginService_Logout",
         "responses": {
           "200": {
             "description": "A successful response.",

--- a/examples/internal/proto/examplepb/wrappers.swagger.json
+++ b/examples/internal/proto/examplepb/wrappers.swagger.json
@@ -13,7 +13,7 @@
   "paths": {
     "/v1/example/wrappers": {
       "post": {
-        "operationId": "Create",
+        "operationId": "WrappersService_Create",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -45,7 +45,7 @@
     },
     "/v1/testBool": {
       "post": {
-        "operationId": "CreateBoolValue",
+        "operationId": "WrappersService_CreateBoolValue",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -79,7 +79,7 @@
     },
     "/v1/testBytes": {
       "post": {
-        "operationId": "CreateBytesValue",
+        "operationId": "WrappersService_CreateBytesValue",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -113,7 +113,7 @@
     },
     "/v1/testDouble": {
       "post": {
-        "operationId": "CreateDoubleValue",
+        "operationId": "WrappersService_CreateDoubleValue",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -147,7 +147,7 @@
     },
     "/v1/testEmpty": {
       "post": {
-        "operationId": "CreateEmpty",
+        "operationId": "WrappersService_CreateEmpty",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -179,7 +179,7 @@
     },
     "/v1/testFloat": {
       "post": {
-        "operationId": "CreateFloatValue",
+        "operationId": "WrappersService_CreateFloatValue",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -213,7 +213,7 @@
     },
     "/v1/testInt32": {
       "post": {
-        "operationId": "CreateInt32Value",
+        "operationId": "WrappersService_CreateInt32Value",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -247,7 +247,7 @@
     },
     "/v1/testInt64": {
       "post": {
-        "operationId": "CreateInt64Value",
+        "operationId": "WrappersService_CreateInt64Value",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -281,7 +281,7 @@
     },
     "/v1/testString": {
       "post": {
-        "operationId": "CreateStringValue",
+        "operationId": "WrappersService_CreateStringValue",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -313,7 +313,7 @@
     },
     "/v1/testUint32": {
       "post": {
-        "operationId": "CreateUInt32Value",
+        "operationId": "WrappersService_CreateUInt32Value",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -347,7 +347,7 @@
     },
     "/v1/testUint64": {
       "post": {
-        "operationId": "CreateUInt64Value",
+        "operationId": "WrappersService_CreateUInt64Value",
         "responses": {
           "200": {
             "description": "A successful response.",

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -978,10 +978,10 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
 					}
 				}
 				if bIdx == 0 {
-					operationObject.OperationID = fmt.Sprintf("%s", meth.GetName())
+					operationObject.OperationID = fmt.Sprintf("%s_%s", svc.GetName(), meth.GetName())
 				} else {
 					// OperationID must be unique in an OpenAPI v2 definition.
-					operationObject.OperationID = fmt.Sprintf("%s%d", meth.GetName(), bIdx+1)
+					operationObject.OperationID = fmt.Sprintf("%s_%s%d", svc.GetName(), meth.GetName(), bIdx+1)
 				}
 
 				// Fill reference map with referenced request messages
@@ -1945,7 +1945,7 @@ func lowerCamelCase(fieldName string, fields []*descriptor.Field, msgs []*descri
 	fieldNameToType := make(map[string]string, 0)
 	for _, msg := range msgs {
 		fieldNameToJSONName := make(map[string]string, 0)
-		for _, oneField := range msg.GetField()  {
+		for _, oneField := range msg.GetField() {
 			fieldNameToJSONName[oneField.GetName()] = oneField.GetJsonName()
 			fieldNameToType[oneField.GetName()] = oneField.GetTypeName()
 		}
@@ -1954,11 +1954,11 @@ func lowerCamelCase(fieldName string, fields []*descriptor.Field, msgs []*descri
 	if strings.Contains(fieldName, ".") {
 		fieldNames := strings.Split(fieldName, ".")
 		fieldNamesWithCamelCase := make([]string, 0)
-		for i := 0; i < len(fieldNames) - 1; i++ {
+		for i := 0; i < len(fieldNames)-1; i++ {
 			fieldNamesWithCamelCase = append(fieldNamesWithCamelCase, doCamelCase(string(fieldNames[i])))
 		}
 		prefix := strings.Join(fieldNamesWithCamelCase, ".")
-		reservedJSONName := getReservedJSONName(fieldName, messageNameToFieldsToJSONName,fieldNameToType)
+		reservedJSONName := getReservedJSONName(fieldName, messageNameToFieldsToJSONName, fieldNameToType)
 		if reservedJSONName != "" {
 			return prefix + "." + reservedJSONName
 		}
@@ -1980,10 +1980,9 @@ func getReservedJSONName(fieldName string, messageNameToFieldsToJSONName map[str
 		firstVariable := fieldNames[0]
 		firstType := fieldNameToType[firstVariable]
 		firstTypeShortNames := strings.Split(firstType, ".")
-		firstTypeShortName := firstTypeShortNames[len(firstTypeShortNames) - 1]
+		firstTypeShortName := firstTypeShortNames[len(firstTypeShortNames)-1]
 		return messageNameToFieldsToJSONName[firstTypeShortName][fieldNames[1]]
 	}
 	fieldNames := strings.Split(fieldName, ".")
 	return getReservedJSONName(strings.Join(fieldNames[1:], "."), messageNameToFieldsToJSONName, fieldNameToType)
 }
-


### PR DESCRIPTION
This PR prepends the service name to the method name to generate unique operation IDs. Prior to this change, the swagger generator would produce spec non-compliant swagger when multiple services had shared method names. This is quite problematic for generic CRUD services with method names like `Create`, `Delete`, etc.