### PR TITLE
Add option to disable new operationID generation

### DIFF
--- a/protoc-gen-grpc-gateway/descriptor/registry.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry.go
@@ -82,6 +82,10 @@ type Registry struct {
 	// disableDefaultErrors disables the generation of the default error types.
 	// This is useful for users who have defined custom error handling.
 	disableDefaultErrors bool
+
+	// simpleOperationIDs removes the service prefix from the generated
+	// operationIDs. This risks generating duplicate operationIDs.
+	simpleOperationIDs bool
 }
 
 type repeatedFieldSeparator struct {
@@ -508,6 +512,16 @@ func (r *Registry) SetDisableDefaultErrors(use bool) {
 // GetDisableDefaultErrors returns disableDefaultErrors
 func (r *Registry) GetDisableDefaultErrors() bool {
 	return r.disableDefaultErrors
+}
+
+// SetSimpleOperationIDs sets simpleOperationIDs
+func (r *Registry) SetSimpleOperationIDs(use bool) {
+	r.simpleOperationIDs = use
+}
+
+// GetSimpleOperationIDs returns simpleOperationIDs
+func (r *Registry) GetSimpleOperationIDs() bool {
+	return r.simpleOperationIDs
 }
 
 // sanitizePackageName replaces unallowed character in package name

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -977,11 +977,13 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
 						}
 					}
 				}
-				if bIdx == 0 {
-					operationObject.OperationID = fmt.Sprintf("%s_%s", svc.GetName(), meth.GetName())
-				} else {
+				operationObject.OperationID = fmt.Sprintf("%s_%s", svc.GetName(), meth.GetName())
+				if reg.GetSimpleOperationIDs() {
+					operationObject.OperationID = fmt.Sprintf("%s", meth.GetName())
+				}
+				if bIdx != 0 {
 					// OperationID must be unique in an OpenAPI v2 definition.
-					operationObject.OperationID = fmt.Sprintf("%s_%s%d", svc.GetName(), meth.GetName(), bIdx+1)
+					operationObject.OperationID += strconv.Itoa(bIdx + 1)
 				}
 
 				// Fill reference map with referenced request messages

--- a/protoc-gen-swagger/main.go
+++ b/protoc-gen-swagger/main.go
@@ -30,6 +30,7 @@ var (
 	useGoTemplate              = flag.Bool("use_go_templates", false, "if set, you can use Go templates in protofile comments")
 	disableDefaultErrors       = flag.Bool("disable_default_errors", false, "if set, disables generation of default errors. This is useful if you have defined custom error handling")
 	enumsAsInts                = flag.Bool("enums_as_ints", false, "whether to render enum values as integers, as opposed to string values")
+	simpleOperationIDs         = flag.Bool("simple_operation_ids", false, "whether to remove the service prefix in the operationID generation. Can introduce duplicate operationIDs, use with caution.")
 )
 
 // Variables set by goreleaser at build time
@@ -84,6 +85,7 @@ func main() {
 	reg.SetUseGoTemplate(*useGoTemplate)
 	reg.SetEnumsAsInts(*enumsAsInts)
 	reg.SetDisableDefaultErrors(*disableDefaultErrors)
+	reg.SetSimpleOperationIDs(*simpleOperationIDs)
 	if err := reg.SetRepeatedPathParamSeparator(*repeatedPathParamSeparator); err != nil {
 		emitError(err)
 		return


### PR DESCRIPTION
The new generation model, while correct, was causing
friction with some users. Add a flag to re-enable the old
behaviour.

CC @aselus-hub, @mouradmourafiq @dadgar 