### PR TITLE
docs: fix some broken links and change godoc.org links to pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ header.
 * HTTP headers that start with 'Grpc-Metadata-' are mapped to gRPC metadata
 (prefixed with `grpcgateway-`).
 * While configurable, the default {un,}marshaling uses
-[jsonpb](https://godoc.org/github.com/golang/protobuf/jsonpb) with
+[jsonpb](https://pkg.go.dev/github.com/golang/protobuf/jsonpb) with
 `OrigName: true`.
 
 # Contribution

--- a/docs/_docs/customizingyourgateway.md
+++ b/docs/_docs/customizingyourgateway.md
@@ -11,8 +11,8 @@ order: 101
 
 You might want to serialize request/response messages in MessagePack instead of JSON, for example.
 
-1. Write a custom implementation of [`Marshaler`](http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#Marshaler)
-2. Register your marshaler with [`WithMarshalerOption`](http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#WithMarshalerOption)
+1. Write a custom implementation of [`Marshaler`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime?tab=doc#Marshaler)
+2. Register your marshaler with [`WithMarshalerOption`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime?tab=doc#WithMarshalerOption)
    e.g.
    ```go
    var m your.MsgPackMarshaler
@@ -78,10 +78,10 @@ Note that this will conflict with any methods having input messages with fields 
 also, this example code does not remove the query parameter `pretty` from further processing.
 
 ## Mapping from HTTP request headers to gRPC client metadata
-You might not like [the default mapping rule](http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#DefaultHeaderMatcher) and might want to pass through all the HTTP headers, for example.
+You might not like [the default mapping rule](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime?tab=doc#DefaultHeaderMatcher) and might want to pass through all the HTTP headers, for example.
 
-1. Write a [`HeaderMatcherFunc`](http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#HeaderMatcherFunc).
-2. Register the function with [`WithIncomingHeaderMatcher`](http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#WithIncomingHeaderMatcher)
+1. Write a [`HeaderMatcherFunc`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime?tab=doc#HeaderMatcherFunc).
+2. Register the function with [`WithIncomingHeaderMatcher`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime?tab=doc#WithIncomingHeaderMatcher)
 
   e.g.
   ```go
@@ -99,7 +99,7 @@ You might not like [the default mapping rule](http://godoc.org/github.com/grpc-e
 
   mux := runtime.NewServeMux(runtime.WithIncomingHeaderMatcher(CustomMatcher))
   ```
-To keep the [the default mapping rule](http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#DefaultHeaderMatcher) alongside with your own rules write:
+To keep the [the default mapping rule](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime?tab=doc#DefaultHeaderMatcher) alongside with your own rules write:
 
 ```go
 func CustomMatcher(key string) (string, bool) {
@@ -133,7 +133,7 @@ if md, ok := metadata.FromIncomingContext(ctx); ok {
 ```
 
 ## Mapping from gRPC server metadata to HTTP response headers
-ditto. Use [`WithOutgoingHeaderMatcher`](http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#WithOutgoingHeaderMatcher).
+ditto. Use [`WithOutgoingHeaderMatcher`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime?tab=doc#WithOutgoingHeaderMatcher).
 See [gRPC metadata docs](https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md)
 for more info on sending / receiving gRPC metadata.
 
@@ -166,7 +166,7 @@ Or you might want to mutate the response messages to be returned.
    	return nil
    }
    ```
-2. Register the filter with [`WithForwardResponseOption`](http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#WithForwardResponseOption)
+2. Register the filter with [`WithForwardResponseOption`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime?tab=doc#WithForwardResponseOption)
    
    e.g.
    ```go
@@ -323,7 +323,7 @@ the source error has no gRPC attributes).
 ## Replace a response forwarder per method
 You might want to keep the behavior of the current marshaler but change only a message forwarding of a certain API method.
 
-1. write a custom forwarder which is compatible to [`ForwardResponseMessage`](http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#ForwardResponseMessage) or [`ForwardResponseStream`](http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#ForwardResponseStream).
+1. write a custom forwarder which is compatible to [`ForwardResponseMessage`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime?tab=doc#ForwardResponseMessage) or [`ForwardResponseStream`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime?tab=doc#ForwardResponseStream).
 2. replace the default forwarder of the method with your one.
 
    e.g. add `forwarder_overwrite.go` into the go package of the generated code,

--- a/docs/_docs/examples.md
+++ b/docs/_docs/examples.md
@@ -12,6 +12,6 @@ Examples are available under `examples/internal` directory.
 * `server/main.go`: service implementation
 * `main.go`: entrypoint of the generated reverse proxy
 
-To use the same port for custom HTTP handlers (e.g. serving `swagger.json`), gRPC-gateway, and a gRPC server, see [this code example by CoreOS](https://github.com/philips/grpc-gateway-example/blob/master/cmd/serve.go) (and its accompanying [blog post](https://coreos.com/blog/gRPC-protobufs-swagger.html))
+To use the same port for custom HTTP handlers (e.g. serving `swagger.json`), gRPC-gateway, and a gRPC server, see [this code example by CoreOS](https://github.com/philips/grpc-gateway-example/blob/master/cmd/serve.go) (and its accompanying [blog post](https://coreos.com/blog/grpc-protobufs-swagger.html))
 
 

--- a/docs/_docs/faq.md
+++ b/docs/_docs/faq.md
@@ -16,7 +16,7 @@ See the question above at first.
 
 Grpc-gateway is intended to cover 80% of use cases without forcing you to write comprehensive but complicated annotations. So grpc-gateway itself does not always cover all the use cases you have by design. In other words, grpc-gateway automates typical boring boilerplate mapping between gRPC and HTTP/1 communication, but it does not do arbitrarily complex custom mappings for you.
 
-On the other hand, you can still add whatever you want as a middleware which wraps [`runtime.ServeMux`](http://godoc.org/github.com/grpc-ecosystem/grpc-gateway/runtime#ServeMux).  Since `runtime.ServeMux` is just a standard [`http.Handler`](http://golang.org/pkg/http#Handler), you can easily write a custom wrapper of `runtime.ServeMux`, leveraged with existing third-party libraries in Go.
+On the other hand, you can still add whatever you want as a middleware which wraps [`runtime.ServeMux`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime?tab=doc#ServeMux).  Since `runtime.ServeMux` is just a standard [`http.Handler`](http://golang.org/pkg/http#Handler), you can easily write a custom wrapper of `runtime.ServeMux`, leveraged with existing third-party libraries in Go.
 e.g. https://github.com/grpc-ecosystem/grpc-gateway/blob/master/examples/internal/main.go
 
 ## My gRPC server is written in (Scala|C++|Ruby|Haskell|....). Is there a (Scala|C++|Ruby|Haskell|....) version of grpc-gateway?

--- a/docs/_docs/features.md
+++ b/docs/_docs/features.md
@@ -13,7 +13,7 @@ category: documentation
 * Mapping streaming APIs to newline-delimited JSON streams
 * Mapping HTTP headers with `Grpc-Metadata-` prefix to gRPC metadata (prefixed with `grpcgateway-`)
 * Optionally emitting API definition for [Swagger](http://swagger.io).
-* Setting [gRPC timeouts](http://www.grpc.io/docs/guides/wire.html) through inbound HTTP `Grpc-Timeout` header.
+* Setting [gRPC timeouts](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) through inbound HTTP `Grpc-Timeout` header.
 * Partial support for [gRPC API Configuration](https://cloud.google.com/endpoints/docs/grpc/grpc-service-config) files as an alternative to annotation.
 
 ## Want to support

--- a/docs/_docs/usage.md
+++ b/docs/_docs/usage.md
@@ -68,7 +68,7 @@ Make sure that your `$GOPATH/bin` is in your `$PATH`.
     }
    ```
 
-   See [a_bit_of_everything.proto](examples/internal/proto/examplepb/a_bit_of_everything.proto)
+   See [a_bit_of_everything.proto](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/examples/internal/proto/examplepb/a_bit_of_everything.proto)
    for examples of more annotations you can add to customize gateway behavior
    and generated Swagger output.
 
@@ -201,8 +201,8 @@ output (for example, `json_names_for_fields` to output JSON names for fields
 instead of protobuf names). Run `protoc-gen-swagger --help` for more flag
 details. Further Swagger customization is possible by annotating your `.proto`
 files with options from
-[openapiv2.proto](protoc-gen-swagger/options/openapiv2.proto) - see
-[a_bit_of_everything.proto](examples/internal/proto/examplepb/a_bit_of_everything.proto)
+[openapiv2.proto](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/protoc-gen-swagger/options/openapiv2.proto) - see
+[a_bit_of_everything.proto](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/examples/internal/proto/examplepb/a_bit_of_everything.proto)
 for examples.
 
 # Mapping gRPC to HTTP


### PR DESCRIPTION
This fixes some broken links in docs.

**EDIT:**

This also changes `godoc.org` links to `pkg.go.dev`, as per below comments.