### PR TITLE
Use public key to authenticate for docker registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,34 +1,45 @@
 version: 2
 jobs:
   build:
+    environment:
+    ## Split key to avoid github revoking it
+      password0: '99544cdcb19ad4e3fd64'
+      password1: '3ec86b2e5a431be2d72c'
     docker:
       - image: docker.pkg.github.com/grpc-ecosystem/grpc-gateway/build-env:1.14
         auth:
-          username: $GITHUB_USER
-          password: $GITHUB_TOKEN
+          username: gateway-ci-user
+          password: ${password0}${password1}
     working_directory: /src/grpc-gateway
     steps:
       - checkout
       - run: go build ./...
   test:
+    environment:
+    ## Split key to avoid github revoking it
+      password0: '99544cdcb19ad4e3fd64'
+      password1: '3ec86b2e5a431be2d72c'
+      GLOG_logtostderr: '1'
     docker:
       - image: docker.pkg.github.com/grpc-ecosystem/grpc-gateway/build-env:1.14
         auth:
-          username: $GITHUB_USER
-          password: $GITHUB_TOKEN
+          username: gateway-ci-user
+          password: ${password0}${password1}
     working_directory: /src/grpc-gateway
-    environment:
-      GLOG_logtostderr: '1'
     steps:
       - checkout
       - run: go test -race -coverprofile=coverage.txt ./...
       - run: bash <(curl -s https://codecov.io/bash)
   node_test:
+    environment:
+    ## Split key to avoid github revoking it
+      password0: '99544cdcb19ad4e3fd64'
+      password1: '3ec86b2e5a431be2d72c'
     docker:
       - image: docker.pkg.github.com/grpc-ecosystem/grpc-gateway/build-env:1.14
         auth:
-          username: $GITHUB_USER
-          password: $GITHUB_TOKEN
+          username: gateway-ci-user
+          password: ${password0}${password1}
     working_directory: /src/grpc-gateway
     steps:
       - checkout
@@ -40,11 +51,15 @@ jobs:
           npm install &&
           ./node_modules/.bin/gulp
   generate:
+    environment:
+    ## Split key to avoid github revoking it
+      password0: '99544cdcb19ad4e3fd64'
+      password1: '3ec86b2e5a431be2d72c'
     docker:
       - image: docker.pkg.github.com/grpc-ecosystem/grpc-gateway/build-env:1.14
         auth:
-          username: $GITHUB_USER
-          password: $GITHUB_TOKEN
+          username: gateway-ci-user
+          password: ${password0}${password1}
     working_directory: /src/grpc-gateway
     steps:
       - checkout
@@ -54,11 +69,15 @@ jobs:
       - run: go mod tidy
       - run: git diff --exit-code
   lint:
+    environment:
+    ## Split key to avoid github revoking it
+      password0: '99544cdcb19ad4e3fd64'
+      password1: '3ec86b2e5a431be2d72c'
     docker:
       - image: docker.pkg.github.com/grpc-ecosystem/grpc-gateway/build-env:1.14
         auth:
-          username: $GITHUB_USER
-          password: $GITHUB_TOKEN
+          username: gateway-ci-user
+          password: ${password0}${password1}
     working_directory: /src/grpc-gateway
     steps:
       - checkout
@@ -102,11 +121,15 @@ jobs:
             (echo "ERROR: Bazel files not formatted, please run \`bazel run :buildifier\`" >&2; exit 1)'
           when: always
   gorelease:
+    environment:
+    ## Split key to avoid github revoking it
+      password0: '99544cdcb19ad4e3fd64'
+      password1: '3ec86b2e5a431be2d72c'
     docker:
       - image: docker.pkg.github.com/grpc-ecosystem/grpc-gateway/build-env:1.14
         auth:
-          username: $GITHUB_USER
-          password: $GITHUB_TOKEN
+          username: gateway-ci-user
+          password: ${password0}${password1}
     working_directory: /src/grpc-gateway
     steps:
       - checkout
@@ -118,11 +141,15 @@ jobs:
             go get golang.org/x/exp/cmd/gorelease@latest
       - run: gorelease
   release:
+    environment:
+    ## Split key to avoid github revoking it
+      password0: '99544cdcb19ad4e3fd64'
+      password1: '3ec86b2e5a431be2d72c'
     docker:
       - image: docker.pkg.github.com/grpc-ecosystem/grpc-gateway/build-env:1.14
         auth:
-          username: $GITHUB_USER
-          password: $GITHUB_TOKEN
+          username: gateway-ci-user
+          password: ${password0}${password1}
     working_directory: /src/grpc-gateway
     steps:
       - checkout


### PR DESCRIPTION
The token belongs to a user with no membership anywhere,
and it is limited to only reading github packages.

v1 cherry pick of https://github.com/grpc-ecosystem/grpc-gateway/pull/1253