### PR TITLE
protoc-gen-swagger, Fix for infinite loop on circular references in query parameters 

### DIFF
--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -229,7 +229,7 @@ func nestedQueryParams(message *descriptor.Message, field *descriptor.Field, pre
         // Check for cyclical message reference:
         isCycle := touched[*msg.Name]
         if isCycle {
-            return nil, fmt.Errorf("Recursive types are not allowed for query parameters, cycle found on %s", fieldType)
+            return nil, fmt.Errorf("Recursive types are not allowed for query parameters, cycle found on %q", fieldType)
         }
         // Update map with the massage name so a cycle further down the recursive path can be detected. 
         touched[*msg.Name] = true

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -120,17 +120,17 @@ func messageToQueryParameters(message *descriptor.Message, reg *descriptor.Regis
 	return params, nil
 }
 
-// queryParams converts a field to a list of swagger query parameters recursively throught the use of nestedQueryParams.
+// queryParams converts a field to a list of swagger query parameters recursively through the use of nestedQueryParams.
 func queryParams(message *descriptor.Message, field *descriptor.Field, prefix string, reg *descriptor.Registry, pathParams []descriptor.Parameter) (params []swaggerParameterObject, err error) {
     return nestedQueryParams(message, field, prefix, reg, pathParams, map[string]bool{})
 }
 
 // nestedQueryParams converts a field to a list of swagger query parameters recursively.
-// This function is a helper function for queryParams, that keeps track of circular message references
+// This function is a helper function for queryParams, that keeps track of cyclical message references
 //  through the use of
 //      touched map[string]bool
-// If a circular reference is discovered, a error is returned, as circular datastructures isnt allowed
-//  in query-parameters.
+// If a cycle is discovered, an error is returned, as cyclical data structures aren't allowed
+//  in query parameters.
 func nestedQueryParams(message *descriptor.Message, field *descriptor.Field, prefix string, reg *descriptor.Registry, pathParams []descriptor.Parameter, touched map[string]bool) (params []swaggerParameterObject, err error) {
 	// make sure the parameter is not already listed as a path parameter
 	for _, pathParam := range pathParams {
@@ -226,12 +226,12 @@ func nestedQueryParams(message *descriptor.Message, field *descriptor.Field, pre
 	if err != nil {
 		return nil, fmt.Errorf("unknown message type %s", fieldType)
 	}
-        // Check for circular message reference:
-        isCircular := touched[*msg.Name]
-        if isCircular {
-            return nil, fmt.Errorf("Recursive types are not allowed for query parameters, Circle found on %s", fieldType)
+        // Check for cyclical message reference:
+        isCycle := touched[*msg.Name]
+        if isCycle {
+            return nil, fmt.Errorf("Recursive types are not allowed for query parameters, cycle found on %s", fieldType)
         }
-        // Update touched-map with the massage name so a circle further down the recursive path can be detected. 
+        // Update map with the massage name so a cycle further down the recursive path can be detected. 
         touched[*msg.Name] = true
 
 	for _, nestedField := range msg.Fields {

--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -407,6 +407,124 @@ func TestMessageToQueryParameters(t *testing.T) {
 	}
 }
 
+// TestMessagetoQueryParametersRecursive, is a check that circular references between messages
+//  is handled gracefully. The goal is to insure that atemps to add messages with circular
+//  references to query-parameters returns a error message.
+func TestMessageToQueryParametersRecursive(t *testing.T) {
+	type test struct {
+		MsgDescs []*protodescriptor.DescriptorProto
+		Message  string
+	}
+
+	tests := []test{
+                // First test:
+                // Here we test that a message that references it self through a field will return a error.
+                // Example proto:
+                // message DirectRecursiveMessage {
+                //      DirectRecursiveMessage nested = 1;
+                // }
+		{
+			MsgDescs: []*protodescriptor.DescriptorProto{
+				&protodescriptor.DescriptorProto{
+					Name: proto.String("DirectRecursiveMessage"),
+					Field: []*protodescriptor.FieldDescriptorProto{
+                                                {
+                                                        Name:     proto.String("nested"),
+                                                        Label:    protodescriptor.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+                                                        Type:     protodescriptor.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+                                                        TypeName: proto.String(".example.DirectRecursiveMessage"),
+                                                        Number:   proto.Int32(1),
+						},
+					},
+				},
+			},
+			Message: "DirectRecursiveMessage",
+		},
+                // Second test:
+                // Here we test that a circle through multiple messages also is detected and that a error is returned.
+                // Sample:
+                // message Root { NodeMessage nested = 1; }
+                // message NodeMessage { CircleMessage nested = 1; }
+                // message CircleMessage { Root nested = 1; }
+		{
+			MsgDescs: []*protodescriptor.DescriptorProto{
+				&protodescriptor.DescriptorProto{
+					Name: proto.String("RootMessage"),
+					Field: []*protodescriptor.FieldDescriptorProto{
+                                                {
+                                                        Name:     proto.String("nested"),
+                                                        Label:    protodescriptor.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+                                                        Type:     protodescriptor.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+                                                        TypeName: proto.String(".example.NodeMessage"),
+                                                        Number:   proto.Int32(1),
+						},
+					},
+				},
+				&protodescriptor.DescriptorProto{
+					Name: proto.String("NodeMessage"),
+					Field: []*protodescriptor.FieldDescriptorProto{
+                                                {
+                                                        Name:     proto.String("nested"),
+                                                        Label:    protodescriptor.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+                                                        Type:     protodescriptor.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+                                                        TypeName: proto.String(".example.CircleMessage"),
+                                                        Number:   proto.Int32(1),
+						},
+					},
+				},
+				&protodescriptor.DescriptorProto{
+					Name: proto.String("CircleMessage"),
+					Field: []*protodescriptor.FieldDescriptorProto{
+                                                {
+                                                        Name:     proto.String("nested"),
+                                                        Label:    protodescriptor.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+                                                        Type:     protodescriptor.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+                                                        TypeName: proto.String(".example.RootMessage"),
+                                                        Number:   proto.Int32(1),
+						},
+					},
+				},
+			},
+			Message: "RootMessage",
+		},
+	}
+
+	for _, test := range tests {
+		reg := descriptor.NewRegistry()
+		msgs := []*descriptor.Message{}
+		for _, msgdesc := range test.MsgDescs {
+			msgs = append(msgs, &descriptor.Message{DescriptorProto: msgdesc})
+		}
+		file := descriptor.File{
+			FileDescriptorProto: &protodescriptor.FileDescriptorProto{
+				SourceCodeInfo: &protodescriptor.SourceCodeInfo{},
+				Name:           proto.String("example.proto"),
+				Package:        proto.String("example"),
+				Dependency:     []string{},
+				MessageType:    test.MsgDescs,
+				Service:        []*protodescriptor.ServiceDescriptorProto{},
+			},
+			GoPkg: descriptor.GoPackage{
+				Path: "example.com/path/to/example/example.pb",
+				Name: "example_pb",
+			},
+			Messages: msgs,
+		}
+		reg.Load(&plugin.CodeGeneratorRequest{
+			ProtoFile: []*protodescriptor.FileDescriptorProto{file.FileDescriptorProto},
+		})
+
+		message, err := reg.LookupMsg("", ".example."+test.Message)
+		if err != nil {
+			t.Fatalf("failed to lookup message: %s", err)
+		}
+		_, err = messageToQueryParameters(message, reg, []descriptor.Parameter{})
+		if err == nil {
+			t.Fatalf("It should not be allowed to have recursive query parameters")
+		}
+	}
+}
+
 func TestMessageToQueryParametersWithJsonName(t *testing.T) {
 	type test struct {
 		MsgDescs []*protodescriptor.DescriptorProto

--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -407,9 +407,9 @@ func TestMessageToQueryParameters(t *testing.T) {
 	}
 }
 
-// TestMessagetoQueryParametersRecursive, is a check that circular references between messages
-//  is handled gracefully. The goal is to insure that atemps to add messages with circular
-//  references to query-parameters returns a error message.
+// TestMessagetoQueryParametersRecursive, is a check that cyclical references between messages
+//  are handled gracefully. The goal is to insure that attempts to add messages with cyclical
+//  references to query-parameters returns an error message.
 func TestMessageToQueryParametersRecursive(t *testing.T) {
 	type test struct {
 		MsgDescs []*protodescriptor.DescriptorProto
@@ -418,7 +418,7 @@ func TestMessageToQueryParametersRecursive(t *testing.T) {
 
 	tests := []test{
                 // First test:
-                // Here we test that a message that references it self through a field will return a error.
+                // Here we test that a message that references it self through a field will return an error.
                 // Example proto:
                 // message DirectRecursiveMessage {
                 //      DirectRecursiveMessage nested = 1;
@@ -441,7 +441,7 @@ func TestMessageToQueryParametersRecursive(t *testing.T) {
 			Message: "DirectRecursiveMessage",
 		},
                 // Second test:
-                // Here we test that a circle through multiple messages also is detected and that a error is returned.
+                // Here we test that a circle through multiple messages also is detected and that an error is returned.
                 // Sample:
                 // message Root { NodeMessage nested = 1; }
                 // message NodeMessage { CircleMessage nested = 1; }

--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -441,11 +441,11 @@ func TestMessageToQueryParametersRecursive(t *testing.T) {
 			Message: "DirectRecursiveMessage",
 		},
                 // Second test:
-                // Here we test that a circle through multiple messages also is detected and that an error is returned.
+                // Here we test that a cycle through multiple messages is detected and that an error is returned.
                 // Sample:
                 // message Root { NodeMessage nested = 1; }
-                // message NodeMessage { CircleMessage nested = 1; }
-                // message CircleMessage { Root nested = 1; }
+                // message NodeMessage { CycleMessage nested = 1; }
+                // message CycleMessage { Root nested = 1; }
 		{
 			MsgDescs: []*protodescriptor.DescriptorProto{
 				&protodescriptor.DescriptorProto{
@@ -467,13 +467,13 @@ func TestMessageToQueryParametersRecursive(t *testing.T) {
                                                         Name:     proto.String("nested"),
                                                         Label:    protodescriptor.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
                                                         Type:     protodescriptor.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-                                                        TypeName: proto.String(".example.CircleMessage"),
+                                                        TypeName: proto.String(".example.CycleMessage"),
                                                         Number:   proto.Int32(1),
 						},
 					},
 				},
 				&protodescriptor.DescriptorProto{
-					Name: proto.String("CircleMessage"),
+					Name: proto.String("CycleMessage"),
 					Field: []*protodescriptor.FieldDescriptorProto{
                                                 {
                                                         Name:     proto.String("nested"),


### PR DESCRIPTION

**Added function nestedQueryParams** in *proto-gen-swagger/genswagger/template.go* with *map[string]bool* parameter for keeping track of and detecting circular references.
**Added test TestMessageToQueryParametersRecursive** in *proto-gen-swagger/genswagger/template_test.go* for testing gracefully handling of circular references between messages.
See issue #1167