### PR TITLE
Add module generator option

### DIFF
--- a/protoc-gen-grpc-gateway/internal/gengateway/generator_test.go
+++ b/protoc-gen-grpc-gateway/internal/gengateway/generator_test.go
@@ -1,6 +1,7 @@
 package gengateway
 
 import (
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -100,9 +101,11 @@ func TestGenerateServiceWithoutBindings(t *testing.T) {
 
 func TestGenerateOutputPath(t *testing.T) {
 	cases := []struct {
-		file     *descriptor.File
-		pathType pathType
-		expected string
+		file          *descriptor.File
+		pathType      pathType
+		modulePath    string
+		expected      string
+		expectedError error
 	}{
 		{
 			file: newExampleFileDescriptorWithGoPkg(
@@ -142,13 +145,79 @@ func TestGenerateOutputPath(t *testing.T) {
 			pathType: pathTypeSourceRelative,
 			expected: ".",
 		},
+		{
+			file: newExampleFileDescriptorWithGoPkg(
+				&descriptor.GoPackage{
+					Path: "example.com/path/root",
+					Name: "example_pb",
+				},
+			),
+			modulePath: "example.com/path/root",
+			expected:   ".",
+		},
+		{
+			file: newExampleFileDescriptorWithGoPkg(
+				&descriptor.GoPackage{
+					Path: "example.com/path/to/example",
+					Name: "example_pb",
+				},
+			),
+			modulePath: "example.com/path/to",
+			expected:   "example",
+		},
+		{
+			file: newExampleFileDescriptorWithGoPkg(
+				&descriptor.GoPackage{
+					Path: "example.com/path/to/example/with/many/nested/paths",
+					Name: "example_pb",
+				},
+			),
+			modulePath: "example.com/path/to",
+			expected:   "example/with/many/nested/paths",
+		},
+
+		// Error cases
+		{
+			file: newExampleFileDescriptorWithGoPkg(
+				&descriptor.GoPackage{
+					Path: "example.com/path/root",
+					Name: "example_pb",
+				},
+			),
+			modulePath:    "example.com/path/root",
+			pathType:      pathTypeSourceRelative, // Not allowed
+			expectedError: errors.New("cannot use module= with paths=source_relative"),
+		},
+		{
+			file: newExampleFileDescriptorWithGoPkg(
+				&descriptor.GoPackage{
+					Path: "example.com/path/rootextra",
+					Name: "example_pb",
+				},
+			),
+			modulePath:    "example.com/path/root",
+			expectedError: errors.New("example.com/path/rootextra: file go path does not match module prefix: example.com/path/root/"),
+		},
 	}
 
 	for _, c := range cases {
-		g := &generator{pathType: c.pathType}
+		g := &generator{
+			pathType:   c.pathType,
+			modulePath: c.modulePath,
+		}
 
 		file := c.file
 		gots, err := g.Generate([]*descriptor.File{crossLinkFixture(file)})
+
+		// If we expect an error response, check it matches what we want
+		if c.expectedError != nil {
+			if err == nil || err.Error() != c.expectedError.Error() {
+				t.Errorf("Generate(%#v) failed with %v; wants error of: %v", file, err, c.expectedError)
+			}
+			return
+		}
+
+		// Handle case where we don't expect an error
 		if err != nil {
 			t.Errorf("Generate(%#v) failed with %v; wants success", file, err)
 			return

--- a/protoc-gen-grpc-gateway/internal/gengateway/generator_test.go
+++ b/protoc-gen-grpc-gateway/internal/gengateway/generator_test.go
@@ -186,7 +186,7 @@ func TestGenerateOutputPath(t *testing.T) {
 			),
 			modulePath:    "example.com/path/root",
 			pathType:      pathTypeSourceRelative, // Not allowed
-			expectedError: errors.New("cannot use module= with paths=source_relative"),
+			expectedError: errors.New("cannot use module= with paths="),
 		},
 		{
 			file: newExampleFileDescriptorWithGoPkg(

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -30,6 +30,7 @@ var (
 	allowDeleteBody            = flag.Bool("allow_delete_body", false, "unless set, HTTP DELETE methods may not have a body")
 	grpcAPIConfiguration       = flag.String("grpc_api_configuration", "", "path to gRPC API Configuration in YAML format")
 	pathType                   = flag.String("paths", "", "specifies how the paths of generated files are structured")
+	modulePath                 = flag.String("module", "", "specifies a module prefix that will be stripped from the go package to determine the output directory")
 	allowRepeatedFieldsInBody  = flag.Bool("allow_repeated_fields_in_body", false, "allows to use repeated field in `body` and `response_body` field of `google.api.http` annotation option")
 	repeatedPathParamSeparator = flag.String("repeated_path_param_separator", "csv", "configures how repeated fields should be split. Allowed values are `csv`, `pipes`, `ssv` and `tsv`.")
 	allowPatchFeature          = flag.Bool("allow_patch_feature", true, "determines whether to use PATCH feature involving update masks (using google.protobuf.FieldMask).")
@@ -81,7 +82,7 @@ func main() {
 		}
 	}
 
-	g := gengateway.New(reg, *useRequestContext, *registerFuncSuffix, *pathType, *allowPatchFeature)
+	g := gengateway.New(reg, *useRequestContext, *registerFuncSuffix, *pathType, *modulePath, *allowPatchFeature)
 
 	if *grpcAPIConfiguration != "" {
 		if err := reg.LoadGrpcAPIServiceFromYAML(*grpcAPIConfiguration); err != nil {


### PR DESCRIPTION
The go protobuf compiler recently added a `module` option define a module prefix which is trimmed from the name of go package to determine the output directory. Currently when using `paths=import` a protobuf file with the `go_package` being `example.com/path/to/example` would be output under `./example.com/path/to/example/myfile.pb.go`. This would usually be fine with `GOROOT` but with go modules it's less useful as the output directory structure does not have to be `example.com/path/to` etc.

I have tried to mirror the behaviour from the protobuf generator. The commit for which is here: https://go-review.googlesource.com/c/protobuf/+/219298/
