### PR TITLE
protoc-gen-grpc-gateway: fix bazel deps

### DIFF
--- a/protoc-gen-grpc-gateway/BUILD.bazel
+++ b/protoc-gen-grpc-gateway/BUILD.bazel
@@ -35,11 +35,10 @@ go_proto_compiler(
     deps = [
         "//runtime:go_default_library",
         "//utilities:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//grpclog:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
-        "@org_golang_x_net//context:go_default_library",
+        "@org_golang_google_protobuf//proto:go_default_library",
     ],
 )


### PR DESCRIPTION
The gateway plugin switched to using the new protobuf
backend a while back, but we forgot to change
the imports declared by the bazel compiler.
