### PR TITLE
fix rpc comment generation against allow_merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,8 @@ SWAGGER_EXAMPLES=examples/internal/proto/examplepb/echo_service.proto \
 	 examples/internal/proto/examplepb/unannotated_echo_service.proto \
 	 examples/internal/proto/examplepb/use_go_template.proto \
 	 examples/internal/proto/examplepb/response_body_service.proto
+SWAGGER_EXAMPLE_MERGE=examples/internal/proto/examplepb/swagger_merge_a.proto \
+	 examples/internal/proto/examplepb/swagger_merge_b.proto
 
 EXAMPLES=examples/internal/proto/examplepb/echo_service.proto \
 	 examples/internal/proto/examplepb/a_bit_of_everything.proto \
@@ -82,6 +84,7 @@ HELLOWORLD=examples/internal/helloworld/helloworld.proto
 EXAMPLE_SVCSRCS=$(EXAMPLES:.proto=.pb.go)
 EXAMPLE_GWSRCS=$(EXAMPLES:.proto=.pb.gw.go)
 EXAMPLE_SWAGGERSRCS=$(SWAGGER_EXAMPLES:.proto=.swagger.json)
+EXAMPLE_SWAGGER_MERGE=examples/internal/proto/examplepb/swagger_merge.swagger.json
 EXAMPLE_DEPS=examples/internal/proto/pathenum/path_enum.proto examples/internal/proto/sub/message.proto examples/internal/proto/sub2/message.proto
 EXAMPLE_DEPSRCS=$(EXAMPLE_DEPS:.proto=.pb.go)
 
@@ -176,6 +179,9 @@ $(EXAMPLE_SWAGGERSRCS): ADDITIONAL_SWG_FLAGS:=$(ADDITIONAL_SWG_FLAGS),grpc_api_c
 $(EXAMPLE_SWAGGERSRCS): $(SWAGGER_PLUGIN) $(SWAGGER_EXAMPLES)
 	protoc -I $(PROTOC_INC_PATH) -I. -I$(GOOGLEAPIS_DIR) --plugin=$(SWAGGER_PLUGIN) --swagger_out=logtostderr=true,allow_repeated_fields_in_body=true,use_go_templates=true,$(PKGMAP)$(ADDITIONAL_SWG_FLAGS):. $(SWAGGER_EXAMPLES)
 
+$(EXAMPLE_SWAGGER_MERGE): $(SWAGGER_PLUGIN) $(SWAGGER_EXAMPLE_MERGE)
+	protoc -I $(PROTOC_INC_PATH) -I. -I$(GOOGLEAPIS_DIR) --plugin=$(SWAGGER_PLUGIN) --swagger_out=logtostderr=true,allow_repeated_fields_in_body=true,use_go_templates=true,allow_merge=true,merge_file_name=$(EXAMPLE_SWAGGER_MERGE:.swagger.json=),$(PKGMAP):. $(SWAGGER_EXAMPLE_MERGE)
+
 $(HELLOWORLD_SVCSRCS): $(GO_PLUGIN) $(HELLOWORLD)
 	protoc -I $(PROTOC_INC_PATH) -I. -I$(GOOGLEAPIS_DIR) --plugin=$(GO_PLUGIN) --go_out=$(PKGMAP),plugins=grpc,paths=source_relative:. $(HELLOWORLD)
 
@@ -205,7 +211,7 @@ $(RESPONSE_BODY_EXAMPLE_SRCS): $(RESPONSE_BODY_EXAMPLE_SPEC)
 	@rm -f $(EXAMPLE_CLIENT_DIR)/responsebody/README.md \
 		$(EXAMPLE_CLIENT_DIR)/responsebody/git_push.sh
 
-examples: $(EXAMPLE_DEPSRCS) $(EXAMPLE_SVCSRCS) $(EXAMPLE_GWSRCS) $(EXAMPLE_SWAGGERSRCS) $(EXAMPLE_CLIENT_SRCS) $(HELLOWORLD_SVCSRCS) $(HELLOWORLD_GWSRCS)
+examples: $(EXAMPLE_DEPSRCS) $(EXAMPLE_SVCSRCS) $(EXAMPLE_GWSRCS) $(EXAMPLE_SWAGGERSRCS) $(EXAMPLE_SWAGGER_MERGE) $(EXAMPLE_CLIENT_SRCS) $(HELLOWORLD_SVCSRCS) $(HELLOWORLD_GWSRCS)
 testproto: $(RUNTIME_TEST_SRCS)
 test: examples testproto
 	go test -short -race ./...

--- a/examples/internal/proto/examplepb/BUILD.bazel
+++ b/examples/internal/proto/examplepb/BUILD.bazel
@@ -34,6 +34,8 @@ proto_library(
         "non_standard_names.proto",
         "response_body_service.proto",
         "stream.proto",
+        "swagger_merge_a.proto",
+        "swagger_merge_b.proto",
         "unannotated_echo_service.proto",
         "use_go_template.proto",
         "wrappers.proto",

--- a/examples/internal/proto/examplepb/swagger_merge.swagger.json
+++ b/examples/internal/proto/examplepb/swagger_merge.swagger.json
@@ -1,0 +1,311 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Merging Services",
+    "description": "This is an example of merging two proto files.",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/example/a/1": {
+      "post": {
+        "summary": "ServiceA.MethodOne receives InMessageA and returns OutMessageA",
+        "description": "Here is the detail explanation about ServiceA.MethodOne.",
+        "operationId": "ServiceA_MethodOne",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/examplepbOutMessageA"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "schema": {
+              "$ref": "#/definitions/runtimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/examplepbInMessageA"
+            }
+          }
+        ],
+        "tags": [
+          "ServiceA"
+        ]
+      }
+    },
+    "/v1/example/a/2": {
+      "post": {
+        "summary": "ServiceA.MethodTwo receives OutMessageA and returns InMessageA",
+        "description": "Here is the detail explanation about ServiceA.MethodTwo.",
+        "operationId": "ServiceA_MethodTwo",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/examplepbInMessageA"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "schema": {
+              "$ref": "#/definitions/runtimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/examplepbOutMessageA"
+            }
+          }
+        ],
+        "tags": [
+          "ServiceA"
+        ]
+      }
+    },
+    "/v1/example/b/1": {
+      "post": {
+        "summary": "ServiceB.MethodOne receives InMessageB and returns OutMessageB",
+        "description": "Here is the detail explanation about ServiceB.MethodOne.",
+        "operationId": "ServiceB_MethodOne",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/examplepbOutMessageB"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "schema": {
+              "$ref": "#/definitions/runtimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/examplepbInMessageB"
+            }
+          }
+        ],
+        "tags": [
+          "ServiceB"
+        ]
+      }
+    },
+    "/v1/example/b/2": {
+      "post": {
+        "summary": "ServiceB.MethodTwo receives OutMessageB and returns InMessageB",
+        "description": "Here is the detail explanation about ServiceB.MethodTwo.",
+        "operationId": "ServiceB_MethodTwo",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/examplepbInMessageB"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "schema": {
+              "$ref": "#/definitions/runtimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/examplepbOutMessageB"
+            }
+          }
+        ],
+        "tags": [
+          "ServiceB"
+        ]
+      }
+    },
+    "/v1/example/c/1": {
+      "post": {
+        "summary": "ServiceC.MethodOne receives InMessageA and returns OutMessageC",
+        "description": "Here is the detail explanation about ServiceC.MethodOne.",
+        "operationId": "ServiceC_MethodOne",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/examplepbOutMessageC"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "schema": {
+              "$ref": "#/definitions/runtimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/examplepbInMessageA"
+            }
+          }
+        ],
+        "tags": [
+          "ServiceC"
+        ]
+      }
+    },
+    "/v1/example/c/2": {
+      "post": {
+        "summary": "ServiceC.MethodTwo receives OutMessageA and returns InMessageA",
+        "description": "Here is the detail explanation about ServiceC.MethodTwo.",
+        "operationId": "ServiceC_MethodTwo",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/examplepbInMessageA"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "schema": {
+              "$ref": "#/definitions/runtimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/examplepbOutMessageA"
+            }
+          }
+        ],
+        "tags": [
+          "ServiceC"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "examplepbInMessageA": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Here is the explanation about InMessageA.values"
+        }
+      },
+      "description": "InMessageA represents a message to ServiceA and ServiceC."
+    },
+    "examplepbInMessageB": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Here is the explanation about InMessageB.values"
+        }
+      },
+      "description": "InMessageB represents a message to ServiceB."
+    },
+    "examplepbOutMessageA": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Here is the explanation about OutMessageA.value"
+        }
+      },
+      "description": "OutMessageA represents a message returned from ServiceA."
+    },
+    "examplepbOutMessageB": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Here is the explanation about OutMessageB.value"
+        }
+      },
+      "description": "OutMessageB represents a message returned from ServiceB."
+    },
+    "examplepbOutMessageC": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Here is the explanation about OutMessageC.value"
+        }
+      },
+      "description": "OutMessageC represents a message returned from ServiceC."
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "type_url": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "runtimeError": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/internal/proto/examplepb/swagger_merge_a.proto
+++ b/examples/internal/proto/examplepb/swagger_merge_a.proto
@@ -1,0 +1,71 @@
+syntax = "proto3";
+option go_package = "examplepb";
+
+// Merging Services
+//
+// This is an example of merging two proto files.
+package grpc.gateway.examples.internal.examplepb;
+
+import "google/api/annotations.proto";
+
+// InMessageA represents a message to ServiceA and ServiceC.
+message InMessageA {
+	// Here is the explanation about InMessageA.values
+	repeated string values = 1;
+}
+
+// OutMessageA represents a message returned from ServiceA.
+message OutMessageA {
+	// Here is the explanation about OutMessageA.value
+	string value = 1;
+}
+
+// OutMessageC represents a message returned from ServiceC.
+message OutMessageC {
+	// Here is the explanation about OutMessageC.value
+	string value = 1;
+}
+
+// ServiceA provices MethodOne and MethodTwo
+service ServiceA {
+	// ServiceA.MethodOne receives InMessageA and returns OutMessageA
+	//
+	// Here is the detail explanation about ServiceA.MethodOne.
+	rpc MethodOne(InMessageA) returns (OutMessageA) {
+		option (google.api.http) = {
+            post: "/v1/example/a/1"
+            body: "*"
+		};
+	}
+	// ServiceA.MethodTwo receives OutMessageA and returns InMessageA
+	//
+	// Here is the detail explanation about ServiceA.MethodTwo.
+	rpc MethodTwo(OutMessageA) returns (InMessageA) {
+		option (google.api.http) = {
+            post: "/v1/example/a/2"
+            body: "*"
+		};
+	}
+}
+
+// ServiceC service responds to incoming merge requests.
+service ServiceC {
+	// ServiceC.MethodOne receives InMessageA and returns OutMessageC
+	//
+	// Here is the detail explanation about ServiceC.MethodOne.
+	rpc MethodOne(InMessageA) returns (OutMessageC) {
+		option (google.api.http) = {
+            post: "/v1/example/c/1"
+            body: "*"
+		};
+	}
+	// ServiceC.MethodTwo receives OutMessageA and returns InMessageA
+	//
+	// Here is the detail explanation about ServiceC.MethodTwo.
+	rpc MethodTwo(OutMessageA) returns (InMessageA) {
+		option (google.api.http) = {
+            post: "/v1/example/c/2"
+            body: "*"
+		};
+	}
+}

--- a/examples/internal/proto/examplepb/swagger_merge_b.proto
+++ b/examples/internal/proto/examplepb/swagger_merge_b.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+option go_package = "examplepb";
+
+// Merging Services
+//
+// This is an example of merging two proto files.
+package grpc.gateway.examples.internal.examplepb;
+
+import "google/api/annotations.proto";
+
+// InMessageB represents a message to ServiceB.
+message InMessageB {
+	// Here is the explanation about InMessageB.values
+	string value = 1;
+}
+
+// OutMessageB represents a message returned from ServiceB.
+message OutMessageB {
+	// Here is the explanation about OutMessageB.value
+	repeated string values = 1;
+}
+
+// ServiceB service responds to incoming merge requests.
+service ServiceB {
+	// ServiceB.MethodOne receives InMessageB and returns OutMessageB
+	//
+	// Here is the detail explanation about ServiceB.MethodOne.
+	rpc MethodOne(InMessageB) returns (OutMessageB) {
+		option (google.api.http) = {
+            post: "/v1/example/b/1"
+            body: "*"
+		};
+	}
+	// ServiceB.MethodTwo receives OutMessageB and returns InMessageB
+	//
+	// Here is the detail explanation about ServiceB.MethodTwo.
+	rpc MethodTwo(OutMessageB) returns (InMessageB) {
+		option (google.api.http) = {
+            post: "/v1/example/b/2"
+            body: "*"
+		};
+	}
+}

--- a/protoc-gen-swagger/genswagger/generator.go
+++ b/protoc-gen-swagger/genswagger/generator.go
@@ -168,7 +168,7 @@ func (g *generator) Generate(targets []*descriptor.File) ([]*plugin.CodeGenerato
 		for _, f := range targets {
 			if mergedTarget == nil {
 				mergedTarget = f
-			} else {
+			} else if mergedTarget != f {
 				mergedTarget.Enums = append(mergedTarget.Enums, f.Enums...)
 				mergedTarget.Messages = append(mergedTarget.Messages, f.Messages...)
 				mergedTarget.Services = append(mergedTarget.Services, f.Services...)

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -759,7 +759,13 @@ func isResourceName(prefix string) bool {
 
 func renderServices(services []*descriptor.Service, paths swaggerPathsObject, reg *descriptor.Registry, requestResponseRefs, customRefs refMap, msgs []*descriptor.Message) error {
 	// Correctness of svcIdx and methIdx depends on 'services' containing the services in the same order as the 'file.Service' array.
+	svcBaseIdx := 0
+	var lastFile *descriptor.File = nil
 	for svcIdx, svc := range services {
+		if svc.File != lastFile {
+			lastFile = svc.File
+			svcBaseIdx = svcIdx
+		}
 		for methIdx, meth := range svc.Methods {
 			for bIdx, b := range meth.Bindings {
 				// Iterate over all the swagger parameters
@@ -1019,7 +1025,7 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
 					}
 				}
 
-				methComments := protoComments(reg, svc.File, nil, "Service", int32(svcIdx), methProtoPath, int32(methIdx))
+				methComments := protoComments(reg, svc.File, nil, "Service", int32(svcIdx-svcBaseIdx), methProtoPath, int32(methIdx))
 				if err := updateSwaggerDataFromComments(reg, operationObject, meth, methComments, false); err != nil {
 					panic(err)
 				}


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #664 

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?
Yes

#### Brief description of what is fixed or changed
Currently` protoc-gen-swagger` does not make rpc comments properly when you give `allow_merge=yes` option.
This PR fixes the problem.

For example, here is a diff between ones generated by current `master` and this PR:
```patch
diff --git a/examples/internal/proto/examplepb/swagger_merge.swagger.json b/examples/internal/proto/examplepb/swagger_merge.swagger.json
index b8d4ca0..39e37d5 100644
--- a/examples/internal/proto/examplepb/swagger_merge.swagger.json
+++ b/examples/internal/proto/examplepb/swagger_merge.swagger.json
@@ -82,6 +82,8 @@
     },
     "/v1/example/b/1": {
       "post": {
+        "summary": "ServiceB.MethodOne receives InMessageB and returns OutMessageB",
+        "description": "Here is the detail explanation about ServiceB.MethodOne.",
         "operationId": "ServiceB_MethodOne",
         "responses": {
           "200": {
@@ -114,6 +116,8 @@
     },
     "/v1/example/b/2": {
       "post": {
+        "summary": "ServiceB.MethodTwo receives OutMessageB and returns InMessageB",
+        "description": "Here is the detail explanation about ServiceB.MethodTwo.",
         "operationId": "ServiceB_MethodTwo",
         "responses": {
           "200": {
```