### PR TITLE
add mux.HandlePath method (v2)

### DIFF
--- a/docs/_docs/inject_router.md
+++ b/docs/_docs/inject_router.md
@@ -1,0 +1,53 @@
+---
+category: documentation
+title: Adding custom routes to the mux
+---
+
+# Adding custom routes to the mux
+
+The gRPC-gateway allows you to add custom routes to the serve mux, for example if you want to support a use case that isn't supported by the grpc-gateway, like file uploads.
+
+## Example
+
+```go
+package main
+
+import (
+	"context"
+	"net/http"
+	
+	pb "github.com/grpc-ecosystem/grpc-gateway/v2/examples/internal/helloworld"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+)
+
+func main() {
+	ctx := context.TODO()
+	mux := runtime.NewServeMux()
+	// Register generated routes to mux
+	err := pb.RegisterGreeterHandlerServer(ctx, mux, &GreeterServer{})
+	if err != nil {
+		panic(err)
+	}
+	// Register custom route for  GET /hello/{name}
+	err = mux.HandlePath("GET", "/hello/{name}", func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+		w.Write([]byte("hello " + pathParams["name"]))
+	})
+	if err != nil {
+		panic(err)
+	}
+	http.ListenAndServe(":8080", mux)
+}
+
+
+// GreeterServer is the server API for Greeter service.
+type GreeterServer struct {
+	
+}
+
+// SayHello implement to say hello
+func (h *GreeterServer) SayHello(ctx context.Context, req *pb.HelloRequest) (*pb.HelloReply, error) {
+	return &pb.HelloReply{
+		Message: "hello " + req.Name,
+	}, nil
+}
+```

--- a/runtime/BUILD.bazel
+++ b/runtime/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     ],
     importpath = "github.com/grpc-ecosystem/grpc-gateway/v2/runtime",
     deps = [
+        "//internal/httprule:go_default_library",
         "//utilities:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@go_googleapis//google/api:httpbody_go_proto",

--- a/runtime/mux_test.go
+++ b/runtime/mux_test.go
@@ -374,3 +374,55 @@ func TestDefaultHeaderMatcher(t *testing.T) {
 		})
 	}
 }
+
+
+
+var defaultRouteMatcherTests = []struct {
+	name   string
+	method string
+	path   string
+	valid  bool
+}{
+	{
+		"Simple Endpoint",
+		"GET",
+		"/v1/{bucket}/do:action",
+		true,
+	},
+	{
+		"Complex Endpoint",
+		"POST",
+		"/v1/b/{bucket_name=buckets/*}/o/{name}",
+		true,
+	},
+	{
+		"Wildcard Endpoint",
+		"GET",
+		"/v1/endpoint/*",
+		true,
+	},
+	{
+		"Invalid Endpoint",
+		"POST",
+		"v1/b/:name/do",
+		false,
+	},
+}
+
+func TestServeMux_HandlePath(t *testing.T) {
+	mux := runtime.NewServeMux()
+	testFn := func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+	}
+	for _, tt := range defaultRouteMatcherTests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := mux.HandlePath(tt.method, tt.path, testFn)
+			if tt.valid && err != nil {
+				t.Errorf("The route %v with method %v and path %v invalid, got %v", tt.name, tt.method, tt.path, err)
+			}
+			if !tt.valid && err == nil {
+				t.Errorf("The route %v with method %v and path %v should be invalid", tt.name, tt.method, tt.path)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
in v2, we can not use `internal/httprule` from outside, so we need add this new method for add custom pattern from out side.

#### Brief description of what is fixed or changed

with this feature, People can add custom pattern From outsiede

exmaple

```go
mux.HandlePath("GET", "/v1/user/{user_id}/data", ...)
```

#### Other comments

in v1 we can use bellow code, but in v2 the `httprule` in internal, we can not use it from outside

```go
// HandlePath associates "h" to the pair of HTTP method and path pattern.
func HandlePath(method string, path string, h runtime.HandlerFunc) {
	compiler, err := httprule.Parse(path)
	if err != nil {
		log.Fatalf("Parse path to compiler failed: %v", err)
	}
	tp := compiler.Compile()
	pattern := runtime.MustPattern(runtime.NewPattern(tp.Version, tp.OpCodes, tp.Pool, tp.Verb))
	mux.Handle(method, pattern, h)
}
// exmaple
HandlePath("GET", "/v1/user/{user_id}/data", ...)
```