### PR TITLE
protoc-gen-swagger: Update internal mapping for boolean type

### DIFF
--- a/examples/internal/proto/examplepb/wrappers.swagger.json
+++ b/examples/internal/proto/examplepb/wrappers.swagger.json
@@ -50,8 +50,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "type": "boolean",
-              "format": "boolean"
+              "type": "boolean"
             }
           },
           "default": {
@@ -67,8 +66,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "boolean",
-              "format": "boolean"
+              "type": "boolean"
             }
           }
         ],
@@ -404,8 +402,7 @@
           "format": "double"
         },
         "bool_value": {
-          "type": "boolean",
-          "format": "boolean"
+          "type": "boolean"
         },
         "uint32_value": {
           "type": "integer",

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -65,7 +65,6 @@ var wktSchemas = map[string]schemaCore{
 	},
 	".google.protobuf.BoolValue": schemaCore{
 		Type:   "boolean",
-		Format: "boolean",
 	},
 	".google.protobuf.Empty": schemaCore{},
 	".google.protobuf.Struct": schemaCore{

--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -2066,7 +2066,6 @@ func TestSchemaOfField(t *testing.T) {
 			refs: make(refMap),
 			expected: schemaCore{
 				Type:   "boolean",
-				Format: "boolean",
 			},
 		},
 		{


### PR DESCRIPTION
Making boolean type consistent with OAS spec.

#### References to other Issues or PRs
Fixes #1463 

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?
Yes

#### Brief description of what is fixed or changed
Removed format field since it is not applicable to boolean type.

#### Other comments
N/A