### PR TITLE
Add `descriptor` to `deps` of `go_gen_grpc_gateway`.

### DIFF
--- a/examples/internal/proto/examplepb/BUILD.bazel
+++ b/examples/internal/proto/examplepb/BUILD.bazel
@@ -16,6 +16,7 @@ package(default_visibility = ["//visibility:public"])
 # gazelle:exclude stream.pb.gw.go
 # gazelle:exclude use_go_template.pb.gw.go
 # gazelle:exclude wrappers.pb.gw.go
+# gazelle:go_grpc_compilers @io_bazel_rules_go//proto:go_grpc,//protoc-gen-grpc-gateway:go_gen_grpc_gateway
 
 genrule(
     name = "generated_proto",
@@ -58,7 +59,7 @@ go_proto_library(
     name = "examplepb_go_proto",
     compilers = [
         "@io_bazel_rules_go//proto:go_grpc",
-        "//protoc-gen-grpc-gateway:go_gen_grpc_gateway",  # keep
+        "//protoc-gen-grpc-gateway:go_gen_grpc_gateway",
     ],
     importpath = "github.com/grpc-ecosystem/grpc-gateway/examples/internal/proto/examplepb",
     proto = ":examplepb_proto",
@@ -67,7 +68,6 @@ go_proto_library(
         "//examples/internal/proto/sub:go_default_library",
         "//examples/internal/proto/sub2:go_default_library",
         "//protoc-gen-swagger/options:go_default_library",
-        "@com_github_golang_protobuf//descriptor:go_default_library_gen",  # keep
         "@go_googleapis//google/api:annotations_go_proto",
     ],
 )

--- a/protoc-gen-grpc-gateway/BUILD.bazel
+++ b/protoc-gen-grpc-gateway/BUILD.bazel
@@ -35,6 +35,7 @@ go_proto_compiler(
     deps = [
         "//runtime:go_default_library",
         "//utilities:go_default_library",
+        "@com_github_golang_protobuf//descriptor:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",

--- a/runtime/internal/examplepb/BUILD.bazel
+++ b/runtime/internal/examplepb/BUILD.bazel
@@ -19,9 +19,6 @@ go_proto_library(
     name = "examplepb_go_proto",
     importpath = "github.com/grpc-ecosystem/grpc-gateway/runtime/internal/examplepb",
     proto = ":examplepb_proto",
-    deps = [
-        "@com_github_golang_protobuf//descriptor:go_default_library_gen",  # keep
-    ],
 )
 
 go_library(


### PR DESCRIPTION
Fixes #1392

Tested by running `bazel build //examples/internal/proto/examplepb:all`, which failed prior to this PR with the `"@com_github_golang_protobuf//descriptor:go_default_library_gen",  # keep` line removed.  While I was here, I also removed the remaining `# keep` lines in favour of a gazelle directive.