### PR TITLE
forward trailers on error only if client send TE header

### DIFF
--- a/examples/internal/integration/integration_test.go
+++ b/examples/internal/integration/integration_test.go
@@ -272,7 +272,8 @@ func TestABE(t *testing.T) {
 	testABEBulkCreate(t, 8088)
 	testABEBulkCreateWithError(t, 8088)
 	testABELookup(t, 8088)
-	testABELookupNotFound(t, 8088)
+	testABELookupNotFound(t, 8088, true)
+	testABELookupNotFound(t, 8088, false)
 	testABEList(t, 8088)
 	testABEBulkEcho(t, 8088)
 	testABEBulkEchoZeroLength(t, 8088)
@@ -878,13 +879,25 @@ func getABE(t *testing.T, port int, uuid string) gw.ABitOfEverything {
 	return getRespBody
 }
 
-func testABELookupNotFound(t *testing.T, port int) {
+func testABELookupNotFound(t *testing.T, port int, useTrailers bool) {
 	apiURL := fmt.Sprintf("http://localhost:%d/v1/example/a_bit_of_everything", port)
 	uuid := "not_exist"
 	apiURL = fmt.Sprintf("%s/%s", apiURL, uuid)
-	resp, err := http.Get(apiURL)
+
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
-		t.Errorf("http.Get(%q) failed with %v; want success", apiURL, err)
+		t.Errorf("http.NewRequest() failed with %v; want success", err)
+		return
+	}
+
+	if useTrailers {
+		req.Header.Set("TE", "trailers")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Errorf("client.Do(%v) failed with %v; want success", req, err)
 		return
 	}
 	defer resp.Body.Close()
@@ -920,11 +933,22 @@ func testABELookupNotFound(t *testing.T, port int) {
 	if got, want := resp.Header.Get("Grpc-Metadata-Uuid"), uuid; got != want {
 		t.Errorf("Grpc-Metadata-Uuid was %s, wanted %s", got, want)
 	}
-	if got, want := resp.Trailer.Get("Grpc-Trailer-Foo"), "foo2"; got != want {
-		t.Errorf("Grpc-Trailer-Foo was %q, wanted %q", got, want)
+
+	var trailers = map[bool]map[string]string{
+		true: {
+			"Grpc-Trailer-Foo": "foo2",
+			"Grpc-Trailer-Bar": "bar2",
+		},
+		false: {
+			"Grpc-Trailer-Foo": "",
+			"Grpc-Trailer-Bar": "",
+		},
 	}
-	if got, want := resp.Trailer.Get("Grpc-Trailer-Bar"), "bar2"; got != want {
-		t.Errorf("Grpc-Trailer-Bar was %q, wanted %q", got, want)
+
+	for trailer, want := range trailers[useTrailers] {
+		if got := resp.Trailer.Get(trailer); got != want {
+			t.Errorf("%s was %q, wanted %q", trailer, got, want)
+		}
 	}
 }
 

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -155,6 +155,11 @@ func DefaultHTTPError(ctx context.Context, mux *ServeMux, marshaler Marshaler, w
 
 	handleForwardResponseServerMetadata(w, mux, md)
 
+	//RFC 7230 https://tools.ietf.org/html/rfc7230#section-4.1.2
+	//Unless the request includes a TE header field indicating "trailers"
+	//is acceptable, as described in Section 4.3, a server SHOULD NOT
+	//generate trailer fields that it believes are necessary for the user
+	//agent to receive.
 	var wantsTrailers bool
 
 	if te := r.Header.Get("TE"); strings.Contains(strings.ToLower(te), "trailers") {

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -155,11 +155,11 @@ func DefaultHTTPError(ctx context.Context, mux *ServeMux, marshaler Marshaler, w
 
 	handleForwardResponseServerMetadata(w, mux, md)
 
-	//RFC 7230 https://tools.ietf.org/html/rfc7230#section-4.1.2
-	//Unless the request includes a TE header field indicating "trailers"
-	//is acceptable, as described in Section 4.3, a server SHOULD NOT
-	//generate trailer fields that it believes are necessary for the user
-	//agent to receive.
+	// RFC 7230 https://tools.ietf.org/html/rfc7230#section-4.1.2
+	// Unless the request includes a TE header field indicating "trailers"
+	// is acceptable, as described in Section 4.3, a server SHOULD NOT
+	// generate trailer fields that it believes are necessary for the user
+	// agent to receive.
 	var wantsTrailers bool
 
 	if te := r.Header.Get("TE"); strings.Contains(strings.ToLower(te), "trailers") {

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/grpc-ecosystem/grpc-gateway/internal"
 	"google.golang.org/grpc/codes"
@@ -109,7 +110,7 @@ func MuxOrGlobalHTTPError(ctx context.Context, mux *ServeMux, marshaler Marshale
 //
 // The response body returned by this function is a JSON object,
 // which contains a member whose key is "error" and whose value is err.Error().
-func DefaultHTTPError(ctx context.Context, mux *ServeMux, marshaler Marshaler, w http.ResponseWriter, _ *http.Request, err error) {
+func DefaultHTTPError(ctx context.Context, mux *ServeMux, marshaler Marshaler, w http.ResponseWriter, r *http.Request, err error) {
 	const fallback = `{"error": "failed to marshal error message"}`
 
 	s, ok := status.FromError(err)
@@ -118,6 +119,7 @@ func DefaultHTTPError(ctx context.Context, mux *ServeMux, marshaler Marshaler, w
 	}
 
 	w.Header().Del("Trailer")
+	w.Header().Del("Transfer-Encoding")
 
 	contentType := marshaler.ContentType()
 	// Check marshaler on run time in order to keep backwards compatibility
@@ -152,14 +154,24 @@ func DefaultHTTPError(ctx context.Context, mux *ServeMux, marshaler Marshaler, w
 	}
 
 	handleForwardResponseServerMetadata(w, mux, md)
-	handleForwardResponseTrailerHeader(w, md)
+
+	var wantsTrailers bool
+
+	if te := r.Header.Get("TE"); strings.Contains(strings.ToLower(te), "trailers") {
+		wantsTrailers = true
+		handleForwardResponseTrailerHeader(w, md)
+		w.Header().Set("Transfer-Encoding", "chunked")
+	}
+
 	st := HTTPStatusFromCode(s.Code())
 	w.WriteHeader(st)
 	if _, err := w.Write(buf); err != nil {
 		grpclog.Infof("Failed to write response: %v", err)
 	}
 
-	handleForwardResponseTrailer(w, md)
+	if wantsTrailers {
+		handleForwardResponseTrailer(w, md)
+	}
 }
 
 // DefaultOtherErrorHandler is the default implementation of OtherErrorHandler.


### PR DESCRIPTION
This PR fixes https://github.com/linkerd/linkerd2/issues/4714 and fixes https://github.com/hyperium/hyper/issues/2171
According to RFC7230, server should send trailers only if client send TE header https://github.com/hyperium/hyper/issues/2171#issuecomment-607033300
