### PR TITLE
feat: make default error handlers public

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -66,12 +66,12 @@ func HTTPError(ctx context.Context, mux *ServeMux, marshaler Marshaler, w http.R
 	mux.errorHandler(ctx, mux, marshaler, w, r, err)
 }
 
-// defaultHTTPErrorHandler is the default error handler.
+// DefaultHTTPErrorHandler is the default error handler.
 // If "err" is a gRPC Status, the function replies with the status code mapped by HTTPStatusFromCode.
 // If otherwise, it replies with http.StatusInternalServerError.
 //
 // The response body written by this function is a Status message marshaled by the Marshaler.
-func defaultHTTPErrorHandler(ctx context.Context, mux *ServeMux, marshaler Marshaler, w http.ResponseWriter, _ *http.Request, err error) {
+func DefaultHTTPErrorHandler(ctx context.Context, mux *ServeMux, marshaler Marshaler, w http.ResponseWriter, _ *http.Request, err error) {
 	// return Internal when Marshal failed
 	const fallback = `{"code": 13, "message": "failed to marshal error message"}`
 
@@ -109,6 +109,6 @@ func defaultHTTPErrorHandler(ctx context.Context, mux *ServeMux, marshaler Marsh
 	handleForwardResponseTrailer(w, md)
 }
 
-func defaultStreamErrorHandler(_ context.Context, err error) *status.Status {
+func DefaultStreamErrorHandler(_ context.Context, err error) *status.Status {
 	return status.Convert(err)
 }

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -139,8 +139,8 @@ func NewServeMux(opts ...ServeMuxOption) *ServeMux {
 		handlers:               make(map[string][]handler),
 		forwardResponseOptions: make([]func(context.Context, http.ResponseWriter, proto.Message) error, 0),
 		marshalers:             makeMarshalerMIMERegistry(),
-		errorHandler:           defaultHTTPErrorHandler,
-		streamErrorHandler:     defaultStreamErrorHandler,
+		errorHandler:           DefaultHTTPErrorHandler,
+		streamErrorHandler:     DefaultStreamErrorHandler,
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
Pre-v2 it was possible to define "error handling middleware" that
modified errors before delegating to the default error handler
(runtime.DefaultHTTPProtoErrorHandler).

In our case, we were using this capability to hook in a custom request
error logger.

By exposing the default error handlers, this remains possible on the v2
branch.