### PR TITLE
Adds fqn_for_swagger_name to bazel defs

### DIFF
--- a/protoc-gen-swagger/defs.bzl
+++ b/protoc-gen-swagger/defs.bzl
@@ -53,7 +53,8 @@ def _run_proto_gen_swagger(
         protoc_gen_swagger,
         grpc_api_configuration,
         single_output,
-        json_names_for_fields):
+        json_names_for_fields,
+        fqn_for_swagger_name):
     args = actions.args()
 
     args.add("--plugin", "protoc-gen-swagger=%s" % protoc_gen_swagger.path)
@@ -68,6 +69,9 @@ def _run_proto_gen_swagger(
 
     if json_names_for_fields:
         args.add("--swagger_opt", "json_names_for_fields=true")
+
+    if fqn_for_swagger_name:
+        args.add("--swagger_opt", "fqn_for_swagger_name=true")
 
     proto_file_infos = _direct_source_infos(proto_info)
 
@@ -153,6 +157,7 @@ def _proto_gen_swagger_impl(ctx):
                     grpc_api_configuration = ctx.file.grpc_api_configuration,
                     single_output = ctx.attr.single_output,
                     json_names_for_fields = ctx.attr.json_names_for_fields,
+                    fqn_for_swagger_name = ctx.attr.fqn_for_swagger_name,
                 ),
             ),
         ),
@@ -173,6 +178,10 @@ protoc_gen_swagger = rule(
             mandatory = False,
         ),
         "json_names_for_fields": attr.bool(
+            default = False,
+            mandatory = False,
+        ),
+        "fqn_for_swagger_name": attr.bool(
             default = False,
             mandatory = False,
         ),


### PR DESCRIPTION
#### References to other Issues or PRs

https://github.com/grpc-ecosystem/grpc-gateway/pull/881

#### Brief description of what is fixed or changed

Support for setting the `fqn_for_swagger_name` flag was not exposed through the bazel rules. This follows the same pattern used for `json_names_for_fields`, but it begs the question to me as to whether there should be a more generic way to set these arguments, as there are a lot more flags that can be set that are not exposed.
