### PR TITLE
docs: change back name of file to OpenAPI

### DIFF
--- a/docs/_docs/usegotemplates.md
+++ b/docs/_docs/usegotemplates.md
@@ -92,7 +92,7 @@ This is how the OpenAPI file would be rendered in [Swagger UI](https://swagger.i
 
 This is how the OpenAPI file would be rendered in [Postman](https://www.getpostman.com/)
 
-![Screenshot Open APIfile in Postman](https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/master/docs/_imgs/gotemplates/postman.png)
+![Screenshot OpenAPI file in Postman](https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/master/docs/_imgs/gotemplates/postman.png)
 
 For a more detailed example of a protofile that has Go templates enabled,
 [see the examples](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/examples/internal/proto/examplepb/use_go_template.proto).

--- a/docs/_docs/usegotemplates.md
+++ b/docs/_docs/usegotemplates.md
@@ -86,13 +86,13 @@ The content of `tables.md`:
 
 This is how the OpenAPI file would be rendered in [Swagger UI](https://swagger.io/tools/swagger-ui/)
 
-![Screenshot swaggerfile in SwaggerUI](https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/master/docs/_imgs/gotemplates/swaggerui.png)
+![Screenshot OpenAPIfile in SwaggerUI](https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/master/docs/_imgs/gotemplates/swaggerui.png)
 
 ### Postman
 
 This is how the OpenAPI file would be rendered in [Postman](https://www.getpostman.com/)
 
-![Screenshot swaggerfile in Postman](https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/master/docs/_imgs/gotemplates/postman.png)
+![Screenshot OpenAPIfile in Postman](https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/master/docs/_imgs/gotemplates/postman.png)
 
 For a more detailed example of a protofile that has Go templates enabled,
 [see the examples](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/examples/internal/proto/examplepb/use_go_template.proto).

--- a/docs/_docs/usegotemplates.md
+++ b/docs/_docs/usegotemplates.md
@@ -86,13 +86,13 @@ The content of `tables.md`:
 
 This is how the OpenAPI file would be rendered in [Swagger UI](https://swagger.io/tools/swagger-ui/)
 
-![Screenshot OpenAPIfile in SwaggerUI](https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/master/docs/_imgs/gotemplates/swaggerui.png)
+![Screenshot OpenAPI file in SwaggerUI](https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/master/docs/_imgs/gotemplates/swaggerui.png)
 
 ### Postman
 
 This is how the OpenAPI file would be rendered in [Postman](https://www.getpostman.com/)
 
-![Screenshot OpenAPIfile in Postman](https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/master/docs/_imgs/gotemplates/postman.png)
+![Screenshot Open APIfile in Postman](https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/master/docs/_imgs/gotemplates/postman.png)
 
 For a more detailed example of a protofile that has Go templates enabled,
 [see the examples](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/examples/internal/proto/examplepb/use_go_template.proto).


### PR DESCRIPTION
Changed back the name of Swagger to OpenAPI as referenced in https://github.com/grpc-ecosystem/grpc-gateway/pull/1541#issuecomment-662384364
