### PR TITLE
Eliminate log messages resulting from requests being sent over a Unix Domain Socket

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
@@ -128,8 +127,6 @@ func annotateContext(ctx context.Context, mux *ServeMux, req *http.Request) (con
 			} else {
 				pairs = append(pairs, strings.ToLower(xForwardedFor), fmt.Sprintf("%s, %s", fwd, remoteIP))
 			}
-		} else {
-			grpclog.Infof("invalid remote addr: %s", addr)
 		}
 	}
 


### PR DESCRIPTION
Fixes #1538 

Removed the "invalid remote addr" log that's printed when a http request's remote address is not an IP:port while setting the X-Forwarded-For header. This issue arose specifically when requests arrived via an abstract Unix Domain Socket.