### PR TITLE
protoc-gen-swagger: remove boolean format

### DIFF
--- a/examples/internal/clients/abe/api/swagger.yaml
+++ b/examples/internal/clients/abe/api/swagger.yaml
@@ -197,7 +197,6 @@ paths:
         in: "query"
         required: false
         type: "boolean"
-        format: "boolean"
         x-exportParamName: "BoolValue"
         x-optionalDataType: "Bool"
       - name: "string_value"
@@ -487,7 +486,6 @@ paths:
         in: "query"
         required: false
         type: "boolean"
-        format: "boolean"
         x-exportParamName: "BoolValue"
         x-optionalDataType: "Bool"
       - name: "string_value"
@@ -768,7 +766,6 @@ paths:
         in: "query"
         required: false
         type: "boolean"
-        format: "boolean"
         x-exportParamName: "BoolValue"
         x-optionalDataType: "Bool"
       - name: "bytes_value"
@@ -1064,7 +1061,6 @@ paths:
         in: "query"
         required: false
         type: "boolean"
-        format: "boolean"
         x-exportParamName: "BoolValue"
         x-optionalDataType: "Bool"
       - name: "string_value"
@@ -1335,7 +1331,6 @@ paths:
         in: "path"
         required: true
         type: "boolean"
-        format: "boolean"
         x-exportParamName: "BoolValue"
       - name: "string_value"
         in: "path"
@@ -1662,7 +1657,6 @@ paths:
         type: "array"
         items:
           type: "boolean"
-          format: "boolean"
         collectionFormat: "csv"
         minItems: 1
         x-exportParamName: "PathRepeatedBoolValue"
@@ -2357,7 +2351,6 @@ definitions:
         format: "int64"
       bool_value:
         type: "boolean"
-        format: "boolean"
       string_value:
         type: "string"
       bytes_value:
@@ -2496,7 +2489,6 @@ definitions:
         type: "array"
         items:
           type: "boolean"
-          format: "boolean"
       path_repeated_string_value:
         type: "array"
         items:

--- a/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
+++ b/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
@@ -261,8 +261,7 @@
             "name": "bool_value",
             "in": "query",
             "required": false,
-            "type": "boolean",
-            "format": "boolean"
+            "type": "boolean"
           },
           {
             "name": "string_value",
@@ -577,8 +576,7 @@
             "name": "bool_value",
             "in": "query",
             "required": false,
-            "type": "boolean",
-            "format": "boolean"
+            "type": "boolean"
           },
           {
             "name": "string_value",
@@ -886,8 +884,7 @@
             "name": "bool_value",
             "in": "query",
             "required": false,
-            "type": "boolean",
-            "format": "boolean"
+            "type": "boolean"
           },
           {
             "name": "bytes_value",
@@ -1208,8 +1205,7 @@
             "name": "bool_value",
             "in": "query",
             "required": false,
-            "type": "boolean",
-            "format": "boolean"
+            "type": "boolean"
           },
           {
             "name": "string_value",
@@ -1512,8 +1508,7 @@
             "name": "bool_value",
             "in": "path",
             "required": true,
-            "type": "boolean",
-            "format": "boolean"
+            "type": "boolean"
           },
           {
             "name": "string_value",
@@ -1946,8 +1941,7 @@
             "required": true,
             "type": "array",
             "items": {
-              "type": "boolean",
-              "format": "boolean"
+              "type": "boolean"
             },
             "collectionFormat": "csv",
             "minItems": 1
@@ -2846,8 +2840,7 @@
           "format": "int64"
         },
         "bool_value": {
-          "type": "boolean",
-          "format": "boolean"
+          "type": "boolean"
         },
         "string_value": {
           "type": "string"
@@ -3049,8 +3042,7 @@
         "path_repeated_bool_value": {
           "type": "array",
           "items": {
-            "type": "boolean",
-            "format": "boolean"
+            "type": "boolean"
           }
         },
         "path_repeated_string_value": {

--- a/examples/internal/proto/examplepb/stream.swagger.json
+++ b/examples/internal/proto/examplepb/stream.swagger.json
@@ -211,8 +211,7 @@
           "format": "int64"
         },
         "bool_value": {
-          "type": "boolean",
-          "format": "boolean"
+          "type": "boolean"
         },
         "string_value": {
           "type": "string"

--- a/examples/internal/proto/examplepb/use_go_template.swagger.json
+++ b/examples/internal/proto/examplepb/use_go_template.swagger.json
@@ -89,7 +89,6 @@
         },
         "access": {
           "type": "boolean",
-          "format": "boolean",
           "title": "Whether you have access or not"
         }
       }

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -538,9 +538,10 @@ func primitiveSchema(t pbdescriptor.FieldDescriptorProto_Type) (ftype, format st
 		// Ditto.
 		return "integer", "int64", true
 	case pbdescriptor.FieldDescriptorProto_TYPE_BOOL:
-		return "boolean", "boolean", true
+		// NOTE: in swagger specification, format should be empty on boolean type
+		return "boolean", "", true
 	case pbdescriptor.FieldDescriptorProto_TYPE_STRING:
-		// NOTE: in swagger specifition, format should be empty on string type
+		// NOTE: in swagger specification, format should be empty on string type
 		return "string", "", true
 	case pbdescriptor.FieldDescriptorProto_TYPE_BYTES:
 		return "string", "byte", true
@@ -1919,13 +1920,14 @@ func protoJSONSchemaTypeToFormat(in []swagger_options.JSONSchema_JSONSchemaSimpl
 	case swagger_options.JSONSchema_ARRAY:
 		return "array", ""
 	case swagger_options.JSONSchema_BOOLEAN:
-		return "boolean", "boolean"
+		// NOTE: in swagger specification, format should be empty on boolean type
+		return "boolean", ""
 	case swagger_options.JSONSchema_INTEGER:
 		return "integer", "int32"
 	case swagger_options.JSONSchema_NUMBER:
 		return "number", "double"
 	case swagger_options.JSONSchema_STRING:
-		// NOTE: in swagger specifition, format should be empty on string type
+		// NOTE: in swagger specification, format should be empty on string type
 		return "string", ""
 	default:
 		// Maybe panic?


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to grpc-gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #1463

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

Removed format field on boolean type.

#### Other comments

This PR supplements #1466 
