### PR TITLE
Control warning behavior on unbound methods using a flag

### DIFF
--- a/protoc-gen-grpc-gateway/descriptor/registry.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry.go
@@ -86,6 +86,10 @@ type Registry struct {
 	// simpleOperationIDs removes the service prefix from the generated
 	// operationIDs. This risks generating duplicate operationIDs.
 	simpleOperationIDs bool
+
+	// warnOnUnboundMethods causes the registry to emit warning logs if an RPC method
+	// has no HttpRule annotation.
+	warnOnUnboundMethods bool
 }
 
 type repeatedFieldSeparator struct {
@@ -522,6 +526,11 @@ func (r *Registry) SetSimpleOperationIDs(use bool) {
 // GetSimpleOperationIDs returns simpleOperationIDs
 func (r *Registry) GetSimpleOperationIDs() bool {
 	return r.simpleOperationIDs
+}
+
+// SetWarnOnUnboundMethods sets warnOnUnboundMethods
+func (r *Registry) SetWarnOnUnboundMethods(warn bool) {
+	r.warnOnUnboundMethods = warn
 }
 
 // sanitizePackageName replaces unallowed character in package name

--- a/protoc-gen-grpc-gateway/descriptor/services.go
+++ b/protoc-gen-grpc-gateway/descriptor/services.go
@@ -35,7 +35,11 @@ func (r *Registry) loadServices(file *File) error {
 				optsList = append(optsList, opts)
 			}
 			if len(optsList) == 0 {
-				glog.Warningf("No HttpRule found for method: %s.%s", svc.GetName(), md.GetName())
+				logFn := glog.V(1).Infof
+				if  r.warnOnUnboundMethods {
+					logFn = glog.Warningf
+				}
+				logFn("No HttpRule found for method: %s.%s", svc.GetName(), md.GetName())
 			}
 			meth, err := r.newMethod(svc, md, optsList)
 			if err != nil {

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -36,6 +36,7 @@ var (
 	allowPatchFeature          = flag.Bool("allow_patch_feature", true, "determines whether to use PATCH feature involving update masks (using google.protobuf.FieldMask).")
 	allowColonFinalSegments    = flag.Bool("allow_colon_final_segments", false, "determines whether colons are permitted in the final segment of a path")
 	versionFlag                = flag.Bool("version", false, "print the current version")
+	warnOnUnboundMethods       = flag.Bool("warn_on_unbound_methods", false, "emit a warning message if an RPC method has no HttpRule annotation")
 )
 
 // Variables set by goreleaser at build time
@@ -96,6 +97,7 @@ func main() {
 	reg.SetAllowDeleteBody(*allowDeleteBody)
 	reg.SetAllowRepeatedFieldsInBody(*allowRepeatedFieldsInBody)
 	reg.SetAllowColonFinalSegments(*allowColonFinalSegments)
+	reg.SetWarnOnUnboundMethods(*warnOnUnboundMethods)
 	if err := reg.SetRepeatedPathParamSeparator(*repeatedPathParamSeparator); err != nil {
 		emitError(err)
 		return


### PR DESCRIPTION
The current behavior since #1178 is to emit a warning log for every unbound RPC method, causing a lot of noise in case the intention is to generate the gateway from a subset of the RPC methods. This PR allows us to control the logging behavior in case of encountering an unbound method, with the default behavior being log with severity `Info`.

