### PR TITLE
fix: the default value of required property

### DIFF
--- a/examples/internal/clients/abe/api/swagger.yaml
+++ b/examples/internal/clients/abe/api/swagger.yaml
@@ -37,7 +37,7 @@ paths:
       parameters:
       - in: "body"
         name: "body"
-        required: true
+        required: false
         schema:
           $ref: "#/definitions/examplepbABitOfEverything"
         x-exportParamName: "Body"
@@ -702,7 +702,7 @@ paths:
         x-exportParamName: "StringValue"
       - in: "body"
         name: "body"
-        required: true
+        required: false
         schema:
           $ref: "#/definitions/ABitOfEverythingNested"
         x-exportParamName: "Body"
@@ -1441,7 +1441,7 @@ paths:
         x-exportParamName: "SingleNestedName"
       - in: "body"
         name: "body"
-        required: true
+        required: false
         schema:
           $ref: "#/definitions/examplepbABitOfEverything"
         x-exportParamName: "Body"
@@ -1512,7 +1512,7 @@ paths:
         x-exportParamName: "Uuid"
       - in: "body"
         name: "body"
-        required: true
+        required: false
         schema:
           $ref: "#/definitions/examplepbABitOfEverything"
         x-exportParamName: "Body"
@@ -1781,7 +1781,7 @@ paths:
       - in: "body"
         name: "body"
         description: "The book to create."
-        required: true
+        required: false
         schema:
           $ref: "#/definitions/examplepbBook"
         x-exportParamName: "Body"
@@ -1828,7 +1828,7 @@ paths:
         x-exportParamName: "AbeUuid"
       - in: "body"
         name: "body"
-        required: true
+        required: false
         schema:
           $ref: "#/definitions/examplepbABitOfEverything"
         x-exportParamName: "Body"
@@ -1874,7 +1874,7 @@ paths:
         x-exportParamName: "AbeUuid"
       - in: "body"
         name: "body"
-        required: true
+        required: false
         schema:
           $ref: "#/definitions/examplepbABitOfEverything"
         x-exportParamName: "Body"
@@ -1963,10 +1963,11 @@ paths:
       parameters:
       - in: "body"
         name: "body"
-        required: true
+        required: false
         schema:
           type: "string"
         x-exportParamName: "Body"
+        x-optionalDataType: "String"
       responses:
         200:
           description: "A successful response."
@@ -2096,7 +2097,7 @@ paths:
         x-exportParamName: "Name"
       - in: "body"
         name: "body"
-        required: true
+        required: false
         schema:
           $ref: "#/definitions/examplepbBody"
         x-exportParamName: "Body"
@@ -2161,7 +2162,7 @@ paths:
         x-exportParamName: "Id"
       - in: "body"
         name: "body"
-        required: true
+        required: false
         schema:
           $ref: "#/definitions/examplepbBody"
         x-exportParamName: "Body"
@@ -2234,7 +2235,7 @@ paths:
         x-exportParamName: "AbeUuid"
       - in: "body"
         name: "body"
-        required: true
+        required: false
         schema:
           $ref: "#/definitions/examplepbUpdateV2Request"
         x-exportParamName: "Body"

--- a/examples/internal/clients/abe/api_a_bit_of_everything_service.go
+++ b/examples/internal/clients/abe/api_a_bit_of_everything_service.go
@@ -790,9 +790,9 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCheckNestedEn
 ABitOfEverythingServiceApiService
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param stringValue
- * @param body
  * @param floatValue Float value field
  * @param optional nil or *ABitOfEverythingServiceCheckPostQueryParamsOpts - Optional Parameters:
+     * @param "Body" (optional.Interface of ABitOfEverythingNested) - 
      * @param "Uuid" (optional.String) - 
      * @param "DoubleValue" (optional.Float64) - 
      * @param "Int64Value" (optional.String) - 
@@ -827,6 +827,7 @@ ABitOfEverythingServiceApiService
 */
 
 type ABitOfEverythingServiceCheckPostQueryParamsOpts struct { 
+	Body optional.Interface
 	Uuid optional.String
 	DoubleValue optional.Float64
 	Int64Value optional.String
@@ -858,7 +859,7 @@ type ABitOfEverythingServiceCheckPostQueryParamsOpts struct {
 	Int64OverrideType optional.Int64
 }
 
-func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCheckPostQueryParams(ctx context.Context, stringValue string, body ABitOfEverythingNested, floatValue float32, localVarOptionals *ABitOfEverythingServiceCheckPostQueryParamsOpts) (ExamplepbABitOfEverything, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCheckPostQueryParams(ctx context.Context, stringValue string, floatValue float32, localVarOptionals *ABitOfEverythingServiceCheckPostQueryParamsOpts) (ExamplepbABitOfEverything, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -981,7 +982,14 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCheckPostQuer
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
+	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
+		
+		localVarOptionalBody, localVarOptionalBodyok := localVarOptionals.Body.Value().(ABitOfEverythingNested)
+		if !localVarOptionalBodyok {
+				return localVarReturnValue, nil, reportError("body should be ABitOfEverythingNested")
+		}
+		localVarPostBody = &localVarOptionalBody
+	}
 	if ctx != nil {
 		// API Key Authentication
 		if auth, ok := ctx.Value(ContextAPIKey).(APIKey); ok {
@@ -1271,11 +1279,17 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCreate(ctx co
 /* 
 ABitOfEverythingServiceApiService
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param body
+ * @param optional nil or *ABitOfEverythingServiceCreateBodyOpts - Optional Parameters:
+     * @param "Body" (optional.Interface of ExamplepbABitOfEverything) - 
 
 @return ExamplepbABitOfEverything
 */
-func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCreateBody(ctx context.Context, body ExamplepbABitOfEverything) (ExamplepbABitOfEverything, *http.Response, error) {
+
+type ABitOfEverythingServiceCreateBodyOpts struct { 
+	Body optional.Interface
+}
+
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCreateBody(ctx context.Context, localVarOptionals *ABitOfEverythingServiceCreateBodyOpts) (ExamplepbABitOfEverything, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -1309,7 +1323,14 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCreateBody(ct
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
+	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
+		
+		localVarOptionalBody, localVarOptionalBodyok := localVarOptionals.Body.Value().(ExamplepbABitOfEverything)
+		if !localVarOptionalBodyok {
+				return localVarReturnValue, nil, reportError("body should be ExamplepbABitOfEverything")
+		}
+		localVarPostBody = &localVarOptionalBody
+	}
 	if ctx != nil {
 		// API Key Authentication
 		if auth, ok := ctx.Value(ContextAPIKey).(APIKey); ok {
@@ -1418,18 +1439,19 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCreateBody(ct
 ABitOfEverythingServiceApiService Create a book.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param parent The publisher in which to create the book.  Format: &#x60;publishers/{publisher}&#x60;  Example: &#x60;publishers/1257894000000000000&#x60;
- * @param body The book to create.
  * @param optional nil or *ABitOfEverythingServiceCreateBookOpts - Optional Parameters:
+     * @param "Body" (optional.Interface of ExamplepbBook) -  The book to create.
      * @param "BookId" (optional.String) -  The ID to use for the book.  This must start with an alphanumeric character.
 
 @return ExamplepbBook
 */
 
 type ABitOfEverythingServiceCreateBookOpts struct { 
+	Body optional.Interface
 	BookId optional.String
 }
 
-func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCreateBook(ctx context.Context, parent string, body ExamplepbBook, localVarOptionals *ABitOfEverythingServiceCreateBookOpts) (ExamplepbBook, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCreateBook(ctx context.Context, parent string, localVarOptionals *ABitOfEverythingServiceCreateBookOpts) (ExamplepbBook, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -1467,7 +1489,14 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCreateBook(ct
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
+	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
+		
+		localVarOptionalBody, localVarOptionalBodyok := localVarOptionals.Body.Value().(ExamplepbBook)
+		if !localVarOptionalBodyok {
+				return localVarReturnValue, nil, reportError("body should be ExamplepbBook")
+		}
+		localVarPostBody = &localVarOptionalBody
+	}
 	if ctx != nil {
 		// API Key Authentication
 		if auth, ok := ctx.Value(ContextAPIKey).(APIKey); ok {
@@ -1576,11 +1605,17 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCreateBook(ct
 ABitOfEverythingServiceApiService
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param singleNestedName name is nested field.
- * @param body
+ * @param optional nil or *ABitOfEverythingServiceDeepPathEchoOpts - Optional Parameters:
+     * @param "Body" (optional.Interface of ExamplepbABitOfEverything) - 
 
 @return ExamplepbABitOfEverything
 */
-func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceDeepPathEcho(ctx context.Context, singleNestedName string, body ExamplepbABitOfEverything) (ExamplepbABitOfEverything, *http.Response, error) {
+
+type ABitOfEverythingServiceDeepPathEchoOpts struct { 
+	Body optional.Interface
+}
+
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceDeepPathEcho(ctx context.Context, singleNestedName string, localVarOptionals *ABitOfEverythingServiceDeepPathEchoOpts) (ExamplepbABitOfEverything, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -1615,7 +1650,14 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceDeepPathEcho(
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
+	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
+		
+		localVarOptionalBody, localVarOptionalBodyok := localVarOptionals.Body.Value().(ExamplepbABitOfEverything)
+		if !localVarOptionalBodyok {
+				return localVarReturnValue, nil, reportError("body should be ExamplepbABitOfEverything")
+		}
+		localVarPostBody = &localVarOptionalBody
+	}
 	if ctx != nil {
 		// API Key Authentication
 		if auth, ok := ctx.Value(ContextAPIKey).(APIKey); ok {
@@ -2012,11 +2054,17 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceErrorWithDeta
 ABitOfEverythingServiceApiService
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param id
- * @param body
+ * @param optional nil or *ABitOfEverythingServiceGetMessageWithBodyOpts - Optional Parameters:
+     * @param "Body" (optional.Interface of ExamplepbBody) - 
 
 @return interface{}
 */
-func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceGetMessageWithBody(ctx context.Context, id string, body ExamplepbBody) (interface{}, *http.Response, error) {
+
+type ABitOfEverythingServiceGetMessageWithBodyOpts struct { 
+	Body optional.Interface
+}
+
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceGetMessageWithBody(ctx context.Context, id string, localVarOptionals *ABitOfEverythingServiceGetMessageWithBodyOpts) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -2051,7 +2099,14 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceGetMessageWit
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
+	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
+		
+		localVarOptionalBody, localVarOptionalBodyok := localVarOptionals.Body.Value().(ExamplepbBody)
+		if !localVarOptionalBodyok {
+				return localVarReturnValue, nil, reportError("body should be ExamplepbBody")
+		}
+		localVarPostBody = &localVarOptionalBody
+	}
 	if ctx != nil {
 		// API Key Authentication
 		if auth, ok := ctx.Value(ContextAPIKey).(APIKey); ok {
@@ -2970,11 +3025,17 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceOverwriteResp
 ABitOfEverythingServiceApiService
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param name
- * @param body
+ * @param optional nil or *ABitOfEverythingServicePostWithEmptyBodyOpts - Optional Parameters:
+     * @param "Body" (optional.Interface of ExamplepbBody) - 
 
 @return interface{}
 */
-func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServicePostWithEmptyBody(ctx context.Context, name string, body ExamplepbBody) (interface{}, *http.Response, error) {
+
+type ABitOfEverythingServicePostWithEmptyBodyOpts struct { 
+	Body optional.Interface
+}
+
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServicePostWithEmptyBody(ctx context.Context, name string, localVarOptionals *ABitOfEverythingServicePostWithEmptyBodyOpts) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -3009,7 +3070,14 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServicePostWithEmpty
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
+	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
+		
+		localVarOptionalBody, localVarOptionalBodyok := localVarOptionals.Body.Value().(ExamplepbBody)
+		if !localVarOptionalBodyok {
+				return localVarReturnValue, nil, reportError("body should be ExamplepbBody")
+		}
+		localVarPostBody = &localVarOptionalBody
+	}
 	if ctx != nil {
 		// API Key Authentication
 		if auth, ok := ctx.Value(ContextAPIKey).(APIKey); ok {
@@ -3261,11 +3329,17 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceTimeout(ctx c
 ABitOfEverythingServiceApiService
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param uuid
- * @param body
+ * @param optional nil or *ABitOfEverythingServiceUpdateOpts - Optional Parameters:
+     * @param "Body" (optional.Interface of ExamplepbABitOfEverything) - 
 
 @return interface{}
 */
-func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdate(ctx context.Context, uuid string, body ExamplepbABitOfEverything) (interface{}, *http.Response, error) {
+
+type ABitOfEverythingServiceUpdateOpts struct { 
+	Body optional.Interface
+}
+
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdate(ctx context.Context, uuid string, localVarOptionals *ABitOfEverythingServiceUpdateOpts) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
 		localVarPostBody   interface{}
@@ -3300,7 +3374,14 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdate(ctx co
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
+	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
+		
+		localVarOptionalBody, localVarOptionalBodyok := localVarOptionals.Body.Value().(ExamplepbABitOfEverything)
+		if !localVarOptionalBodyok {
+				return localVarReturnValue, nil, reportError("body should be ExamplepbABitOfEverything")
+		}
+		localVarPostBody = &localVarOptionalBody
+	}
 	if ctx != nil {
 		// API Key Authentication
 		if auth, ok := ctx.Value(ContextAPIKey).(APIKey); ok {
@@ -3409,18 +3490,19 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdate(ctx co
 ABitOfEverythingServiceApiService
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param abeUuid
- * @param body
  * @param optional nil or *ABitOfEverythingServiceUpdateV2Opts - Optional Parameters:
+     * @param "Body" (optional.Interface of ExamplepbABitOfEverything) - 
      * @param "UpdateMaskPaths" (optional.Interface of []string) -  The set of field mask paths.
 
 @return interface{}
 */
 
 type ABitOfEverythingServiceUpdateV2Opts struct { 
+	Body optional.Interface
 	UpdateMaskPaths optional.Interface
 }
 
-func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV2(ctx context.Context, abeUuid string, body ExamplepbABitOfEverything, localVarOptionals *ABitOfEverythingServiceUpdateV2Opts) (interface{}, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV2(ctx context.Context, abeUuid string, localVarOptionals *ABitOfEverythingServiceUpdateV2Opts) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
 		localVarPostBody   interface{}
@@ -3458,7 +3540,14 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV2(ctx 
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
+	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
+		
+		localVarOptionalBody, localVarOptionalBodyok := localVarOptionals.Body.Value().(ExamplepbABitOfEverything)
+		if !localVarOptionalBodyok {
+				return localVarReturnValue, nil, reportError("body should be ExamplepbABitOfEverything")
+		}
+		localVarPostBody = &localVarOptionalBody
+	}
 	if ctx != nil {
 		// API Key Authentication
 		if auth, ok := ctx.Value(ContextAPIKey).(APIKey); ok {
@@ -3567,18 +3656,19 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV2(ctx 
 ABitOfEverythingServiceApiService
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param abeUuid
- * @param body
  * @param optional nil or *ABitOfEverythingServiceUpdateV22Opts - Optional Parameters:
+     * @param "Body" (optional.Interface of ExamplepbABitOfEverything) - 
      * @param "UpdateMaskPaths" (optional.Interface of []string) -  The set of field mask paths.
 
 @return interface{}
 */
 
 type ABitOfEverythingServiceUpdateV22Opts struct { 
+	Body optional.Interface
 	UpdateMaskPaths optional.Interface
 }
 
-func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV22(ctx context.Context, abeUuid string, body ExamplepbABitOfEverything, localVarOptionals *ABitOfEverythingServiceUpdateV22Opts) (interface{}, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV22(ctx context.Context, abeUuid string, localVarOptionals *ABitOfEverythingServiceUpdateV22Opts) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Patch")
 		localVarPostBody   interface{}
@@ -3616,7 +3706,14 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV22(ctx
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
+	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
+		
+		localVarOptionalBody, localVarOptionalBodyok := localVarOptionals.Body.Value().(ExamplepbABitOfEverything)
+		if !localVarOptionalBodyok {
+				return localVarReturnValue, nil, reportError("body should be ExamplepbABitOfEverything")
+		}
+		localVarPostBody = &localVarOptionalBody
+	}
 	if ctx != nil {
 		// API Key Authentication
 		if auth, ok := ctx.Value(ContextAPIKey).(APIKey); ok {
@@ -3725,11 +3822,17 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV22(ctx
 ABitOfEverythingServiceApiService
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param abeUuid
- * @param body
+ * @param optional nil or *ABitOfEverythingServiceUpdateV23Opts - Optional Parameters:
+     * @param "Body" (optional.Interface of ExamplepbUpdateV2Request) - 
 
 @return interface{}
 */
-func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV23(ctx context.Context, abeUuid string, body ExamplepbUpdateV2Request) (interface{}, *http.Response, error) {
+
+type ABitOfEverythingServiceUpdateV23Opts struct { 
+	Body optional.Interface
+}
+
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV23(ctx context.Context, abeUuid string, localVarOptionals *ABitOfEverythingServiceUpdateV23Opts) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Patch")
 		localVarPostBody   interface{}
@@ -3764,7 +3867,14 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV23(ctx
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
+	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
+		
+		localVarOptionalBody, localVarOptionalBodyok := localVarOptionals.Body.Value().(ExamplepbUpdateV2Request)
+		if !localVarOptionalBodyok {
+				return localVarReturnValue, nil, reportError("body should be ExamplepbUpdateV2Request")
+		}
+		localVarPostBody = &localVarOptionalBody
+	}
 	if ctx != nil {
 		// API Key Authentication
 		if auth, ok := ctx.Value(ContextAPIKey).(APIKey); ok {

--- a/examples/internal/clients/abe/api_echo_rpc.go
+++ b/examples/internal/clients/abe/api_echo_rpc.go
@@ -188,11 +188,17 @@ func (a *EchoRpcApiService) ABitOfEverythingServiceEcho(ctx context.Context, val
 EchoRpcApiService Summary: Echo rpc
 Description Echo
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param body
+ * @param optional nil or *ABitOfEverythingServiceEcho2Opts - Optional Parameters:
+     * @param "Body" (optional.String) - 
 
 @return SubStringMessage
 */
-func (a *EchoRpcApiService) ABitOfEverythingServiceEcho2(ctx context.Context, body string) (SubStringMessage, *http.Response, error) {
+
+type ABitOfEverythingServiceEcho2Opts struct { 
+	Body optional.String
+}
+
+func (a *EchoRpcApiService) ABitOfEverythingServiceEcho2(ctx context.Context, localVarOptionals *ABitOfEverythingServiceEcho2Opts) (SubStringMessage, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -226,7 +232,10 @@ func (a *EchoRpcApiService) ABitOfEverythingServiceEcho2(ctx context.Context, bo
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
+	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
+		localVarPostBody = &localVarOptionals.Body.Value()
+		
+	}
 	if ctx != nil {
 		// API Key Authentication
 		if auth, ok := ctx.Value(ContextAPIKey).(APIKey); ok {

--- a/examples/internal/clients/echo/api/swagger.yaml
+++ b/examples/internal/clients/echo/api/swagger.yaml
@@ -328,7 +328,7 @@ paths:
       parameters:
       - in: "body"
         name: "body"
-        required: true
+        required: false
         schema:
           $ref: "#/definitions/examplepbSimpleMessage"
         x-exportParamName: "Body"

--- a/examples/internal/clients/echo/api_echo_service.go
+++ b/examples/internal/clients/echo/api_echo_service.go
@@ -684,11 +684,17 @@ func (a *EchoServiceApiService) EchoServiceEcho5(ctx context.Context, noNote str
 /* 
 EchoServiceApiService EchoBody method receives a simple message and returns it.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param body
+ * @param optional nil or *EchoServiceEchoBodyOpts - Optional Parameters:
+     * @param "Body" (optional.Interface of ExamplepbSimpleMessage) - 
 
 @return ExamplepbSimpleMessage
 */
-func (a *EchoServiceApiService) EchoServiceEchoBody(ctx context.Context, body ExamplepbSimpleMessage) (ExamplepbSimpleMessage, *http.Response, error) {
+
+type EchoServiceEchoBodyOpts struct { 
+	Body optional.Interface
+}
+
+func (a *EchoServiceApiService) EchoServiceEchoBody(ctx context.Context, localVarOptionals *EchoServiceEchoBodyOpts) (ExamplepbSimpleMessage, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -722,7 +728,14 @@ func (a *EchoServiceApiService) EchoServiceEchoBody(ctx context.Context, body Ex
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
+	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
+		
+		localVarOptionalBody, localVarOptionalBodyok := localVarOptionals.Body.Value().(ExamplepbSimpleMessage)
+		if !localVarOptionalBodyok {
+				return localVarReturnValue, nil, reportError("body should be ExamplepbSimpleMessage")
+		}
+		localVarPostBody = &localVarOptionalBody
+	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/examples/internal/clients/unannotatedecho/api/swagger.yaml
+++ b/examples/internal/clients/unannotatedecho/api/swagger.yaml
@@ -79,7 +79,7 @@ paths:
       parameters:
       - in: "body"
         name: "body"
-        required: true
+        required: false
         schema:
           $ref: "#/definitions/examplepbUnannotatedSimpleMessage"
         x-exportParamName: "Body"

--- a/examples/internal/clients/unannotatedecho/api_unannotated_echo_service.go
+++ b/examples/internal/clients/unannotatedecho/api_unannotated_echo_service.go
@@ -241,11 +241,17 @@ func (a *UnannotatedEchoServiceApiService) UnannotatedEchoServiceEcho2(ctx conte
 /* 
 UnannotatedEchoServiceApiService EchoBody method receives a simple message and returns it.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param body
+ * @param optional nil or *UnannotatedEchoServiceEchoBodyOpts - Optional Parameters:
+     * @param "Body" (optional.Interface of ExamplepbUnannotatedSimpleMessage) - 
 
 @return ExamplepbUnannotatedSimpleMessage
 */
-func (a *UnannotatedEchoServiceApiService) UnannotatedEchoServiceEchoBody(ctx context.Context, body ExamplepbUnannotatedSimpleMessage) (ExamplepbUnannotatedSimpleMessage, *http.Response, error) {
+
+type UnannotatedEchoServiceEchoBodyOpts struct { 
+	Body optional.Interface
+}
+
+func (a *UnannotatedEchoServiceApiService) UnannotatedEchoServiceEchoBody(ctx context.Context, localVarOptionals *UnannotatedEchoServiceEchoBodyOpts) (ExamplepbUnannotatedSimpleMessage, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -279,7 +285,14 @@ func (a *UnannotatedEchoServiceApiService) UnannotatedEchoServiceEchoBody(ctx co
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
+	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
+		
+		localVarOptionalBody, localVarOptionalBodyok := localVarOptionals.Body.Value().(ExamplepbUnannotatedSimpleMessage)
+		if !localVarOptionalBodyok {
+				return localVarReturnValue, nil, reportError("body should be ExamplepbUnannotatedSimpleMessage")
+		}
+		localVarPostBody = &localVarOptionalBody
+	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
+++ b/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
@@ -66,7 +66,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbABitOfEverything"
             }
@@ -818,7 +818,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/ABitOfEverythingNested"
             }
@@ -1649,7 +1649,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbABitOfEverything"
             }
@@ -1804,7 +1804,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbABitOfEverything"
             }
@@ -2097,7 +2097,7 @@
             "name": "body",
             "description": "The book to create.",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbBook"
             }
@@ -2159,7 +2159,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbABitOfEverything"
             }
@@ -2223,7 +2223,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbABitOfEverything"
             }
@@ -2356,7 +2356,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string"
             }
@@ -2535,7 +2535,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbBody"
             }
@@ -2629,7 +2629,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbBody"
             }
@@ -2735,7 +2735,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbUpdateV2Request"
             }

--- a/examples/internal/proto/examplepb/echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/echo_service.swagger.json
@@ -399,7 +399,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbSimpleMessage"
             }

--- a/examples/internal/proto/examplepb/stream.swagger.json
+++ b/examples/internal/proto/examplepb/stream.swagger.json
@@ -64,7 +64,7 @@
             "name": "body",
             "description": " (streaming inputs)",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbABitOfEverything"
             }
@@ -106,7 +106,7 @@
             "name": "body",
             "description": " (streaming inputs)",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/subStringMessage"
             }

--- a/examples/internal/proto/examplepb/swagger_merge.swagger.json
+++ b/examples/internal/proto/examplepb/swagger_merge.swagger.json
@@ -35,7 +35,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbInMessageA"
             }
@@ -69,7 +69,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbOutMessageA"
             }
@@ -103,7 +103,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbInMessageB"
             }
@@ -137,7 +137,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbOutMessageB"
             }
@@ -171,7 +171,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbInMessageA"
             }
@@ -205,7 +205,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbOutMessageA"
             }

--- a/examples/internal/proto/examplepb/unannotated_echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/unannotated_echo_service.swagger.json
@@ -113,7 +113,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbUnannotatedSimpleMessage"
             }

--- a/examples/internal/proto/examplepb/use_go_template.swagger.json
+++ b/examples/internal/proto/examplepb/use_go_template.swagger.json
@@ -34,7 +34,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbLoginRequest"
             }
@@ -68,7 +68,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbLogoutRequest"
             }

--- a/examples/internal/proto/examplepb/wrappers.swagger.json
+++ b/examples/internal/proto/examplepb/wrappers.swagger.json
@@ -32,7 +32,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "$ref": "#/definitions/examplepbWrappers"
             }
@@ -64,7 +64,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "boolean"
             }
@@ -97,7 +97,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "format": "byte"
@@ -131,7 +131,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "number",
               "format": "double"
@@ -164,7 +164,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "properties": {}
             }
@@ -197,7 +197,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "number",
               "format": "float"
@@ -231,7 +231,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "integer",
               "format": "int32"
@@ -265,7 +265,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "format": "int64"
@@ -298,7 +298,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string"
             }
@@ -331,7 +331,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "integer",
               "format": "int64"
@@ -365,7 +365,7 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "format": "uint64"

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -907,7 +907,7 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
 						Name:        "body",
 						Description: desc,
 						In:          "body",
-						Required:    true,
+						Required:    false,
 						Schema:      &schema,
 					})
 					// add the parameters to the query string


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to grpc-gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #1627

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

The value of the required property in parameter object should be false by default if it is not in path.

> Determines whether this parameter is mandatory.
If the parameter is in "path", this property is required and its value MUST be true.
Otherwise, the property MAY be included and its default value is false.

https://swagger.io/specification/v2/

#### Other comments

I may need to fix some tests.