### PR TITLE
Add ignore for golang.org/x/oauth2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,8 @@
             "packageNames": [
                 "github.com/golang/protobuf",
                 "google.golang.org/genproto",
-                "io_bazel_rules_go"
+                "io_bazel_rules_go",
+                "golang.org/x/oauth2"
             ],
             "enabled": false
         },


### PR DESCRIPTION
Updating this past our current version pulls in golang/protobuf v1.4.2,
which we can't do without breaking users.