### PR TITLE
refactor: upgrade protoc-gen-grpc-gateway to use the new Go code generator

### DIFF
--- a/internal/codegenerator/BUILD.bazel
+++ b/internal/codegenerator/BUILD.bazel
@@ -10,8 +10,8 @@ go_library(
     ],
     importpath = "github.com/grpc-ecosystem/grpc-gateway/v2/internal/codegenerator",
     deps = [
-        "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//types/pluginpb:go_default_library",
     ],
 )
 
@@ -21,8 +21,8 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "@com_github_google_go_cmp//cmp:go_default_library",
-        "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
         "@org_golang_google_protobuf//proto:go_default_library",
         "@org_golang_google_protobuf//testing/protocmp:go_default_library",
+        "@org_golang_google_protobuf//types/pluginpb:go_default_library",
     ],
 )

--- a/internal/codegenerator/parse_req.go
+++ b/internal/codegenerator/parse_req.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"io/ioutil"
 
-	pluginpb "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
 // ParseRequest parses a code generator request from a proto Message.

--- a/internal/codegenerator/parse_req_test.go
+++ b/internal/codegenerator/parse_req_test.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"testing"
 
-	pluginpb "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"github.com/google/go-cmp/cmp"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/codegenerator"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
 var parseReqTests = []struct {

--- a/internal/descriptor/BUILD.bazel
+++ b/internal/descriptor/BUILD.bazel
@@ -18,10 +18,10 @@ go_library(
         "@com_github_ghodss_yaml//:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@go_googleapis//google/api:annotations_go_proto",
-        "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
-        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
         "@org_golang_google_protobuf//encoding/protojson:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
+        "@org_golang_google_protobuf//types/pluginpb:go_default_library",
     ],
 )
 
@@ -37,9 +37,9 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//internal/httprule:go_default_library",
-        "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
-        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
         "@org_golang_google_protobuf//encoding/prototext:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
+        "@org_golang_google_protobuf//types/pluginpb:go_default_library",
     ],
 )

--- a/internal/descriptor/registry.go
+++ b/internal/descriptor/registry.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	descriptorpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
-	pluginpb "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
 // Registry is a registry of information extracted from pluginpb.CodeGeneratorRequest.

--- a/internal/descriptor/registry_test.go
+++ b/internal/descriptor/registry_test.go
@@ -3,9 +3,9 @@ package descriptor
 import (
 	"testing"
 
-	descriptorpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
-	pluginpb "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
 func loadFile(t *testing.T, reg *Registry, src string) *descriptorpb.FileDescriptorProto {

--- a/internal/descriptor/services.go
+++ b/internal/descriptor/services.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	descriptorpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule"
 	options "google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 // loadServices registers services and their methods from "targetFile" to "r".
@@ -37,7 +37,7 @@ func (r *Registry) loadServices(file *File) error {
 			}
 			if len(optsList) == 0 {
 				logFn := glog.V(1).Infof
-				if  r.warnOnUnboundMethods {
+				if r.warnOnUnboundMethods {
 					logFn = glog.Warningf
 				}
 				logFn("No HttpRule found for method: %s.%s", svc.GetName(), md.GetName())

--- a/internal/descriptor/services_test.go
+++ b/internal/descriptor/services_test.go
@@ -4,10 +4,10 @@ import (
 	"reflect"
 	"testing"
 
-	descriptorpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 func compilePath(t *testing.T, path string) httprule.Template {

--- a/internal/descriptor/types.go
+++ b/internal/descriptor/types.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	descriptorpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/casing"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
 // IsWellKnownType returns true if the provided fully qualified type name is considered 'well-known'.
@@ -41,7 +42,7 @@ func (p GoPackage) String() string {
 // File wraps descriptorpb.FileDescriptorProto for richer features.
 type File struct {
 	*descriptorpb.FileDescriptorProto
-	// GoPkg is the go package of the go file generated from this file..
+	// GoPkg is the go package of the go file generated from this file.
 	GoPkg GoPackage
 	// Messages is the list of messages defined in this file.
 	Messages []*Message
@@ -63,6 +64,14 @@ func (f *File) Pkg() string {
 // proto2 determines if the syntax of the file is proto2.
 func (f *File) proto2() bool {
 	return f.Syntax == nil || f.GetSyntax() == "proto2"
+}
+
+// ResponseFile wraps pluginpb.CodeGeneratorResponse_File.
+type ResponseFile struct {
+	*pluginpb.CodeGeneratorResponse_File
+
+	// GoPkg is the Go package of the generated file.
+	GoPkg GoPackage
 }
 
 // Message describes a protocol buffer message types

--- a/internal/descriptor/types_test.go
+++ b/internal/descriptor/types_test.go
@@ -3,8 +3,8 @@ package descriptor
 import (
 	"testing"
 
-	descriptorpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 func TestGoPackageStandard(t *testing.T) {

--- a/internal/generator/BUILD.bazel
+++ b/internal/generator/BUILD.bazel
@@ -6,8 +6,5 @@ go_library(
     name = "go_default_library",
     srcs = ["generator.go"],
     importpath = "github.com/grpc-ecosystem/grpc-gateway/v2/internal/generator",
-    deps = [
-        "//internal/descriptor:go_default_library",
-        "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
-    ],
+    deps = ["//internal/descriptor:go_default_library"],
 )

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2,12 +2,11 @@
 package generator
 
 import (
-	pluginpb "github.com/golang/protobuf/protoc-gen-go/plugin"
-	descriptorpb "github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor"
 )
 
 // Generator is an abstraction of code generators.
 type Generator interface {
 	// Generate generates output files from input .proto files.
-	Generate(targets []*descriptorpb.File) ([]*pluginpb.CodeGeneratorResponse_File, error)
+	Generate(targets []*descriptor.File) ([]*descriptor.ResponseFile, error)
 }

--- a/protoc-gen-grpc-gateway/BUILD.bazel
+++ b/protoc-gen-grpc-gateway/BUILD.bazel
@@ -8,12 +8,10 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway",
     deps = [
-        "//internal/codegenerator:go_default_library",
         "//internal/descriptor:go_default_library",
         "//protoc-gen-grpc-gateway/internal/gengateway:go_default_library",
         "@com_github_golang_glog//:go_default_library",
-        "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
-        "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//compiler/protogen:go_default_library",
     ],
 )
 

--- a/protoc-gen-grpc-gateway/internal/gengateway/BUILD.bazel
+++ b/protoc-gen-grpc-gateway/internal/gengateway/BUILD.bazel
@@ -16,8 +16,8 @@ go_library(
         "//internal/generator:go_default_library",
         "//utilities:go_default_library",
         "@com_github_golang_glog//:go_default_library",
-        "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//types/pluginpb:go_default_library",
     ],
 )
 
@@ -32,7 +32,7 @@ go_test(
     deps = [
         "//internal/descriptor:go_default_library",
         "//internal/httprule:go_default_library",
-        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
     ],
 )

--- a/protoc-gen-grpc-gateway/internal/gengateway/generator_test.go
+++ b/protoc-gen-grpc-gateway/internal/gengateway/generator_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	descriptorpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 func newExampleFileDescriptor() *descriptor.File {

--- a/protoc-gen-grpc-gateway/internal/gengateway/template_test.go
+++ b/protoc-gen-grpc-gateway/internal/gengateway/template_test.go
@@ -4,10 +4,10 @@ import (
 	"strings"
 	"testing"
 
-	descriptorpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 func crossLinkFixture(f *descriptor.File) *descriptor.File {

--- a/protoc-gen-openapiv2/BUILD.bazel
+++ b/protoc-gen-openapiv2/BUILD.bazel
@@ -11,8 +11,8 @@ go_library(
         "//internal/descriptor:go_default_library",
         "//protoc-gen-openapiv2/internal/genopenapi:go_default_library",
         "@com_github_golang_glog//:go_default_library",
-        "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//types/pluginpb:go_default_library",
     ],
 )
 

--- a/protoc-gen-openapiv2/internal/genopenapi/BUILD.bazel
+++ b/protoc-gen-openapiv2/internal/genopenapi/BUILD.bazel
@@ -22,11 +22,11 @@ go_library(
         "@com_github_golang_protobuf//descriptor:go_default_library_gen",
         "@go_googleapis//google/rpc:status_go_proto",
         "@io_bazel_rules_go//proto/wkt:any_go_proto",
-        "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
-        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
         "@io_bazel_rules_go//proto/wkt:struct_go_proto",
         "@org_golang_google_protobuf//encoding/protojson:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
+        "@org_golang_google_protobuf//types/pluginpb:go_default_library",
     ],
 )
 
@@ -41,9 +41,9 @@ go_test(
         "//protoc-gen-openapiv2/options:go_default_library",
         "//runtime:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
-        "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
-        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
-        "@io_bazel_rules_go//proto/wkt:struct_go_proto",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
+        "@org_golang_google_protobuf//types/known/structpb:go_default_library",
+        "@org_golang_google_protobuf//types/pluginpb:go_default_library",
     ],
 )

--- a/protoc-gen-openapiv2/internal/genopenapi/generator.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/generator.go
@@ -10,14 +10,14 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	descriptorpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
-	pluginpb "github.com/golang/protobuf/protoc-gen-go/plugin"
 	anypb "github.com/golang/protobuf/ptypes/any"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor"
 	gen "github.com/grpc-ecosystem/grpc-gateway/v2/internal/generator"
 	openapi_options "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/pluginpb"
 
 	//lint:ignore SA1019 known issue, will be replaced when possible
 	legacydescriptor "github.com/golang/protobuf/descriptor"
@@ -138,7 +138,7 @@ func extensionMarshalJSON(so interface{}, extensions []extension) ([]byte, error
 }
 
 // encodeOpenAPI converts OpenAPI file obj to pluginpb.CodeGeneratorResponse_File
-func encodeOpenAPI(file *wrapper) (*pluginpb.CodeGeneratorResponse_File, error) {
+func encodeOpenAPI(file *wrapper) (*descriptor.ResponseFile, error) {
 	var formatted bytes.Buffer
 	enc := json.NewEncoder(&formatted)
 	enc.SetIndent("", "  ")
@@ -149,14 +149,16 @@ func encodeOpenAPI(file *wrapper) (*pluginpb.CodeGeneratorResponse_File, error) 
 	ext := filepath.Ext(name)
 	base := strings.TrimSuffix(name, ext)
 	output := fmt.Sprintf("%s.swagger.json", base)
-	return &pluginpb.CodeGeneratorResponse_File{
-		Name:    proto.String(output),
-		Content: proto.String(formatted.String()),
+	return &descriptor.ResponseFile{
+		CodeGeneratorResponse_File: &pluginpb.CodeGeneratorResponse_File{
+			Name:    proto.String(output),
+			Content: proto.String(formatted.String()),
+		},
 	}, nil
 }
 
-func (g *generator) Generate(targets []*descriptor.File) ([]*pluginpb.CodeGeneratorResponse_File, error) {
-	var files []*pluginpb.CodeGeneratorResponse_File
+func (g *generator) Generate(targets []*descriptor.File) ([]*descriptor.ResponseFile, error) {
+	var files []*descriptor.ResponseFile
 	if g.reg.IsAllowMerge() {
 		var mergedTarget *descriptor.File
 		// try to find proto leader

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -15,13 +15,13 @@ import (
 	"text/template"
 
 	"github.com/golang/glog"
-	descriptorpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/casing"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor"
 	openapi_options "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 // wktSchemas are the schemas of well-known-types.

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -8,15 +8,15 @@ import (
 	"strings"
 	"testing"
 
-	descriptorpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
-	pluginpb "github.com/golang/protobuf/protoc-gen-go/plugin"
-	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/go-cmp/cmp"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule"
 	openapi_options "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
 var marshaler = &runtime.JSONPb{}

--- a/protoc-gen-openapiv2/main.go
+++ b/protoc-gen-openapiv2/main.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	pluginpb "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/codegenerator"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor"
-	genopenapi "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/internal/genopenapi"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/internal/genopenapi"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
 var (
@@ -131,8 +131,12 @@ func main() {
 	emitFiles(out)
 }
 
-func emitFiles(out []*pluginpb.CodeGeneratorResponse_File) {
-	emitResp(&pluginpb.CodeGeneratorResponse{File: out})
+func emitFiles(out []*descriptor.ResponseFile) {
+	files := make([]*pluginpb.CodeGeneratorResponse_File, len(out))
+	for idx, item := range out {
+		files[idx] = item.CodeGeneratorResponse_File
+	}
+	emitResp(&pluginpb.CodeGeneratorResponse{File: files})
 }
 
 func emitError(err error) {


### PR DESCRIPTION
#### References to other Issues or PRs

This is initial work to refactor how the gRPC Gateway files are generated in order to fix a problem described in https://github.com/grpc-ecosystem/grpc-gateway/issues/1612.

#### Brief description of what is fixed or changed

This change upgrades protoc-gen-grpc-gateway to use google.golang.org/protobuf/compiler/protogen which is the new package for writing protoc plugins generating Go code.

It also fixes all places to use packages from google.golang.org/protobuf module instead of github.com/golang/protobuf.

#### Other comments

I tested it by running `go test ./...` and regenerating all `examples/internal/proto/examplepb/*.gw.go` files using `protoc` with a new `bin/protoc-gen-grpc-gateway` binary. There were no changes.