### PR TITLE
Remove indirect github.com/golang/glog dependency of runtime package

### DIFF
--- a/internal/httprule/BUILD.bazel
+++ b/internal/httprule/BUILD.bazel
@@ -10,10 +10,7 @@ go_library(
         "types.go",
     ],
     importpath = "github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule",
-    deps = [
-        "//utilities:go_default_library",
-        "@com_github_golang_glog//:go_default_library",
-    ],
+    deps = ["//utilities:go_default_library"],
 )
 
 go_test(

--- a/internal/httprule/BUILD.bazel
+++ b/internal/httprule/BUILD.bazel
@@ -27,3 +27,4 @@ go_test(
         "@com_github_golang_glog//:go_default_library",
     ],
 )
+

--- a/internal/httprule/BUILD.bazel
+++ b/internal/httprule/BUILD.bazel
@@ -27,4 +27,3 @@ go_test(
         "@com_github_golang_glog//:go_default_library",
     ],
 )
-

--- a/internal/httprule/parse.go
+++ b/internal/httprule/parse.go
@@ -3,8 +3,6 @@ package httprule
 import (
 	"fmt"
 	"strings"
-
-	"github.com/golang/glog"
 )
 
 // InvalidTemplateError indicates that the path template is not valid.
@@ -100,16 +98,13 @@ type parser struct {
 
 // topLevelSegments is the target of this parser.
 func (p *parser) topLevelSegments() ([]segment, error) {
-	glog.V(1).Infof("Parsing %q", p.tokens)
 	segs, err := p.segments()
 	if err != nil {
 		return nil, err
 	}
-	glog.V(2).Infof("accept segments: %q; %q", p.accepted, p.tokens)
 	if _, err := p.accept(typeEOF); err != nil {
 		return nil, fmt.Errorf("unexpected token %q after segments %q", p.tokens[0], strings.Join(p.accepted, ""))
 	}
-	glog.V(2).Infof("accept eof: %q; %q", p.accepted, p.tokens)
 	return segs, nil
 }
 
@@ -118,7 +113,6 @@ func (p *parser) segments() ([]segment, error) {
 	if err != nil {
 		return nil, err
 	}
-	glog.V(2).Infof("accept segment: %q; %q", p.accepted, p.tokens)
 
 	segs := []segment{s}
 	for {
@@ -130,7 +124,6 @@ func (p *parser) segments() ([]segment, error) {
 			return segs, err
 		}
 		segs = append(segs, s)
-		glog.V(2).Infof("accept segment: %q; %q", p.accepted, p.tokens)
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to grpc-gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs
Similar intended fix as #118
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yep

#### Brief description of what is fixed or changed

Remove glog in dependency of runtime package so projects that have forked `glog` can use grpc-gateway without a flag collision. 

#1449 introduced the httprule import to mux.go which causes `glog` to be imported when runtime is imported.

#### Other comments
There are other glog imports in internal/, protoc-gen-grpc-gateway/, and protoc-gen-openapiv2/ that don't seem to cause flag collisions when creating a mux and using the generated .pb.gw.go files. I can remove or update those to use grpclog instead if desired.