### PR TITLE
Install "patch" command in CircleCI build-env image

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -2,10 +2,12 @@ FROM golang:1.15.2
 
 # Warm apt cache and install dependencies
 # bzip2 is required by the node_tests (to extract its dependencies).
+# patch is required by bazel tests
 RUN apt-get update && \
     apt-get install -y wget unzip \
     openjdk-11-jre \
-    bzip2
+    bzip2 \
+    patch
 
 # Install swagger-codegen
 ENV SWAGGER_CODEGEN_VERSION=2.4.8


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to grpc-gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs
Cherry-pick of #1696 to master 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed
#1691 changed the CI executor for Bazel tests from using the`l.gcr.io/google/bazel:latest` image to the build-env, which does not have `patch` installed which is used during Bazel tests. (ex https://app.circleci.com/pipelines/github/grpc-ecosystem/grpc-gateway/1656/workflows/59f8aac6-36b1-4079-98fb-e16e49d54e55/jobs/19572)

Install `patch` command on CircleCI build-env image because it is required when running the Bazel test.


#### Other comments
Tested this by building an image from .circleci/Dockerfile without this Dockerfile change on the branch from #1694 and used it to run `bazel test //...` which gave a similar looking error from the above linked CircleCI job. Rebuilt the image with the Dockerfile changes and ran `bazel test //...` again and it passed.
