### PR TITLE
Pin protoc-gen-go-grpc to v1.0.0

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -58,6 +58,7 @@ go_proto_compiler(
     name = "go_grpc",
     options = [
         "paths=source_relative",
+        "require_unimplemented_servers=false",
     ],
     plugin = "@org_golang_google_grpc_cmd_protoc_gen_go_grpc//:protoc-gen-go-grpc",
     suffix = "_grpc.pb.go",

--- a/Makefile
+++ b/Makefile
@@ -174,12 +174,12 @@ $(OPENAPI_PLUGIN): $(OPENAPI_PLUGIN_SRC) $(OPENAPIV2_GO)
 	go build -o $@ $(OPENAPI_PLUGIN_PKG)
 
 $(EXAMPLE_SVCSRCS): $(GO_PLUGIN) $(GO_GRPC_PLUGIN) $(EXAMPLES)
-	protoc -I $(PROTOC_INC_PATH) -I. -I$(GOOGLEAPIS_DIR) --plugin=$(GO_PLUGIN) --plugin=$(GO_GRPC_PLUGIN) --go_out=paths=source_relative:. --go-grpc_out=paths=source_relative:. $(EXAMPLES)
+	protoc -I $(PROTOC_INC_PATH) -I. -I$(GOOGLEAPIS_DIR) --plugin=$(GO_PLUGIN) --plugin=$(GO_GRPC_PLUGIN) --go_out=paths=source_relative:. --go-grpc_out=paths=source_relative,require_unimplemented_servers=false:. $(EXAMPLES)
 $(EXAMPLE_DEPSRCS): $(GO_PLUGIN) $(GO_GRPC_PLUGIN) $(EXAMPLE_DEPS)
-	protoc -I $(PROTOC_INC_PATH) -I. --plugin=$(GO_PLUGIN) --plugin=$(GO_GRPC_PLUGIN) --go_out=paths=source_relative:. --go-grpc_out=paths=source_relative:. $(@:.pb.go=.proto)
+	protoc -I $(PROTOC_INC_PATH) -I. --plugin=$(GO_PLUGIN) --plugin=$(GO_GRPC_PLUGIN) --go_out=paths=source_relative:. --go-grpc_out=paths=source_relative,require_unimplemented_servers=false:. $(@:.pb.go=.proto)
 
 $(RUNTIME_TEST_SRCS): $(GO_PLUGIN) $(GO_GRPC_PLUGIN) $(RUNTIME_TEST_PROTO)
-	protoc -I $(PROTOC_INC_PATH) -I. -I$(GOOGLEAPIS_DIR) --plugin=$(GO_PLUGIN) --plugin=$(GO_GRPC_PLUGIN) --go_out=paths=source_relative:. --go-grpc_out=paths=source_relative:. $(RUNTIME_TEST_PROTO)
+	protoc -I $(PROTOC_INC_PATH) -I. -I$(GOOGLEAPIS_DIR) --plugin=$(GO_PLUGIN) --plugin=$(GO_GRPC_PLUGIN) --go_out=paths=source_relative:. --go-grpc_out=paths=source_relative,require_unimplemented_servers=false:. $(RUNTIME_TEST_PROTO)
 
 $(APICONFIG_SRCS): $(GO_PLUGIN) $(APICONFIG_PROTO)
 	protoc -I $(PROTOC_INC_PATH) -I. -I$(GOOGLEAPIS_DIR) --plugin=$(GO_PLUGIN) --go_out=paths=source_relative:. $(APICONFIG_PROTO)
@@ -202,12 +202,12 @@ $(EXAMPLE_OPENAPIMERGESRCS): $(OPENAPI_PLUGIN) $(OPENAPIMERGE_EXAMPLES)
 $(GENERATE_UNBOUND_METHODS_EXAMPLE_GWSRCS): $(GATEWAY_PLUGIN) $(GENERATE_UNBOUND_METHODS_EXAMPLE)
 	protoc -I $(PROTOC_INC_PATH) -I. -I$(GOOGLEAPIS_DIR) --plugin=$(GATEWAY_PLUGIN) --grpc-gateway_out=logtostderr=true,paths=source_relative,allow_repeated_fields_in_body=true,generate_unbound_methods=true$(ADDITIONAL_GW_FLAGS):. $(GENERATE_UNBOUND_METHODS_EXAMPLE)
 $(GENERATE_UNBOUND_METHODS_EXAMPLE_SVCSRCS): $(GO_PLUGIN) $(GENERATE_UNBOUND_METHODS_EXAMPLE)
-	protoc -I $(PROTOC_INC_PATH) -I. -I$(GOOGLEAPIS_DIR) --plugin=$(GO_PLUGIN) --plugin=$(GO_GRPC_PLUGIN) --go_out=paths=source_relative:. --go-grpc_out=paths=source_relative:. $(GENERATE_UNBOUND_METHODS_EXAMPLE)
+	protoc -I $(PROTOC_INC_PATH) -I. -I$(GOOGLEAPIS_DIR) --plugin=$(GO_PLUGIN) --plugin=$(GO_GRPC_PLUGIN) --go_out=paths=source_relative:. --go-grpc_out=paths=source_relative,require_unimplemented_servers=false:. $(GENERATE_UNBOUND_METHODS_EXAMPLE)
 $(GENERATE_UNBOUND_METHODS_EXAMPLE_OPENAPISRCS): $(OPENAPI_PLUGIN) $(GENERATE_UNBOUND_METHODS_EXAMPLE)
 	protoc -I $(PROTOC_INC_PATH) -I. -I$(GOOGLEAPIS_DIR) --plugin=$(OPENAPI_PLUGIN) --openapiv2_out=logtostderr=true,allow_repeated_fields_in_body=true,use_go_templates=true,generate_unbound_methods=true:. $(GENERATE_UNBOUND_METHODS_EXAMPLE)
 
 $(HELLOWORLD_SVCSRCS): $(GO_PLUGIN) $(GO_GRPC_PLUGIN) $(HELLOWORLD)
-	protoc -I $(PROTOC_INC_PATH) -I. -I$(GOOGLEAPIS_DIR) --plugin=$(GO_PLUGIN) --plugin=$(GO_GRPC_PLUGIN) --go_out=paths=source_relative:. --go-grpc_out=paths=source_relative:. $(HELLOWORLD)
+	protoc -I $(PROTOC_INC_PATH) -I. -I$(GOOGLEAPIS_DIR) --plugin=$(GO_PLUGIN) --plugin=$(GO_GRPC_PLUGIN) --go_out=paths=source_relative:. --go-grpc_out=paths=source_relative,require_unimplemented_servers=false:. $(HELLOWORLD)
 
 $(HELLOWORLD_GWSRCS):
 $(HELLOWORLD_GWSRCS): $(GATEWAY_PLUGIN) $(HELLOWORLD)

--- a/examples/internal/helloworld/helloworld_grpc.pb.go
+++ b/examples/internal/helloworld/helloworld_grpc.pb.go
@@ -11,7 +11,7 @@ import (
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion6
+const _ = grpc.SupportPackageIsVersion7
 
 // GreeterClient is the client API for Greeter service.
 //
@@ -38,16 +38,25 @@ func (c *greeterClient) SayHello(ctx context.Context, in *HelloRequest, opts ...
 }
 
 // GreeterServer is the server API for Greeter service.
+// All implementations should embed UnimplementedGreeterServer
+// for forward compatibility
 type GreeterServer interface {
 	SayHello(context.Context, *HelloRequest) (*HelloReply, error)
 }
 
-// UnimplementedGreeterServer can be embedded to have forward compatible implementations.
+// UnimplementedGreeterServer should be embedded to have forward compatible implementations.
 type UnimplementedGreeterServer struct {
 }
 
-func (*UnimplementedGreeterServer) SayHello(context.Context, *HelloRequest) (*HelloReply, error) {
+func (UnimplementedGreeterServer) SayHello(context.Context, *HelloRequest) (*HelloReply, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SayHello not implemented")
+}
+
+// UnsafeGreeterServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to GreeterServer will
+// result in compilation errors.
+type UnsafeGreeterServer interface {
+	mustEmbedUnimplementedGreeterServer()
 }
 
 func RegisterGreeterServer(s *grpc.Server, srv GreeterServer) {

--- a/examples/internal/proto/examplepb/a_bit_of_everything_grpc.pb.go
+++ b/examples/internal/proto/examplepb/a_bit_of_everything_grpc.pb.go
@@ -16,7 +16,7 @@ import (
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion6
+const _ = grpc.SupportPackageIsVersion7
 
 // ABitOfEverythingServiceClient is the client API for ABitOfEverythingService service.
 //
@@ -244,6 +244,8 @@ func (c *aBitOfEverythingServiceClient) OverwriteResponseContentType(ctx context
 }
 
 // ABitOfEverythingServiceServer is the server API for ABitOfEverythingService service.
+// All implementations should embed UnimplementedABitOfEverythingServiceServer
+// for forward compatibility
 type ABitOfEverythingServiceServer interface {
 	// Create a new ABitOfEverything
 	//
@@ -278,69 +280,76 @@ type ABitOfEverythingServiceServer interface {
 	OverwriteResponseContentType(context.Context, *empty.Empty) (*wrappers.StringValue, error)
 }
 
-// UnimplementedABitOfEverythingServiceServer can be embedded to have forward compatible implementations.
+// UnimplementedABitOfEverythingServiceServer should be embedded to have forward compatible implementations.
 type UnimplementedABitOfEverythingServiceServer struct {
 }
 
-func (*UnimplementedABitOfEverythingServiceServer) Create(context.Context, *ABitOfEverything) (*ABitOfEverything, error) {
+func (UnimplementedABitOfEverythingServiceServer) Create(context.Context, *ABitOfEverything) (*ABitOfEverything, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Create not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) CreateBody(context.Context, *ABitOfEverything) (*ABitOfEverything, error) {
+func (UnimplementedABitOfEverythingServiceServer) CreateBody(context.Context, *ABitOfEverything) (*ABitOfEverything, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateBody not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) CreateBook(context.Context, *CreateBookRequest) (*Book, error) {
+func (UnimplementedABitOfEverythingServiceServer) CreateBook(context.Context, *CreateBookRequest) (*Book, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateBook not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) Lookup(context.Context, *sub2.IdMessage) (*ABitOfEverything, error) {
+func (UnimplementedABitOfEverythingServiceServer) Lookup(context.Context, *sub2.IdMessage) (*ABitOfEverything, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Lookup not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) Update(context.Context, *ABitOfEverything) (*empty.Empty, error) {
+func (UnimplementedABitOfEverythingServiceServer) Update(context.Context, *ABitOfEverything) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Update not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) UpdateV2(context.Context, *UpdateV2Request) (*empty.Empty, error) {
+func (UnimplementedABitOfEverythingServiceServer) UpdateV2(context.Context, *UpdateV2Request) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateV2 not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) Delete(context.Context, *sub2.IdMessage) (*empty.Empty, error) {
+func (UnimplementedABitOfEverythingServiceServer) Delete(context.Context, *sub2.IdMessage) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Delete not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) GetQuery(context.Context, *ABitOfEverything) (*empty.Empty, error) {
+func (UnimplementedABitOfEverythingServiceServer) GetQuery(context.Context, *ABitOfEverything) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetQuery not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) GetRepeatedQuery(context.Context, *ABitOfEverythingRepeated) (*ABitOfEverythingRepeated, error) {
+func (UnimplementedABitOfEverythingServiceServer) GetRepeatedQuery(context.Context, *ABitOfEverythingRepeated) (*ABitOfEverythingRepeated, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetRepeatedQuery not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) Echo(context.Context, *sub.StringMessage) (*sub.StringMessage, error) {
+func (UnimplementedABitOfEverythingServiceServer) Echo(context.Context, *sub.StringMessage) (*sub.StringMessage, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Echo not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) DeepPathEcho(context.Context, *ABitOfEverything) (*ABitOfEverything, error) {
+func (UnimplementedABitOfEverythingServiceServer) DeepPathEcho(context.Context, *ABitOfEverything) (*ABitOfEverything, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeepPathEcho not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) NoBindings(context.Context, *duration.Duration) (*empty.Empty, error) {
+func (UnimplementedABitOfEverythingServiceServer) NoBindings(context.Context, *duration.Duration) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method NoBindings not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) Timeout(context.Context, *empty.Empty) (*empty.Empty, error) {
+func (UnimplementedABitOfEverythingServiceServer) Timeout(context.Context, *empty.Empty) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Timeout not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) ErrorWithDetails(context.Context, *empty.Empty) (*empty.Empty, error) {
+func (UnimplementedABitOfEverythingServiceServer) ErrorWithDetails(context.Context, *empty.Empty) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ErrorWithDetails not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) GetMessageWithBody(context.Context, *MessageWithBody) (*empty.Empty, error) {
+func (UnimplementedABitOfEverythingServiceServer) GetMessageWithBody(context.Context, *MessageWithBody) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetMessageWithBody not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) PostWithEmptyBody(context.Context, *Body) (*empty.Empty, error) {
+func (UnimplementedABitOfEverythingServiceServer) PostWithEmptyBody(context.Context, *Body) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PostWithEmptyBody not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) CheckGetQueryParams(context.Context, *ABitOfEverything) (*ABitOfEverything, error) {
+func (UnimplementedABitOfEverythingServiceServer) CheckGetQueryParams(context.Context, *ABitOfEverything) (*ABitOfEverything, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CheckGetQueryParams not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) CheckNestedEnumGetQueryParams(context.Context, *ABitOfEverything) (*ABitOfEverything, error) {
+func (UnimplementedABitOfEverythingServiceServer) CheckNestedEnumGetQueryParams(context.Context, *ABitOfEverything) (*ABitOfEverything, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CheckNestedEnumGetQueryParams not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) CheckPostQueryParams(context.Context, *ABitOfEverything) (*ABitOfEverything, error) {
+func (UnimplementedABitOfEverythingServiceServer) CheckPostQueryParams(context.Context, *ABitOfEverything) (*ABitOfEverything, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CheckPostQueryParams not implemented")
 }
-func (*UnimplementedABitOfEverythingServiceServer) OverwriteResponseContentType(context.Context, *empty.Empty) (*wrappers.StringValue, error) {
+func (UnimplementedABitOfEverythingServiceServer) OverwriteResponseContentType(context.Context, *empty.Empty) (*wrappers.StringValue, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method OverwriteResponseContentType not implemented")
+}
+
+// UnsafeABitOfEverythingServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to ABitOfEverythingServiceServer will
+// result in compilation errors.
+type UnsafeABitOfEverythingServiceServer interface {
+	mustEmbedUnimplementedABitOfEverythingServiceServer()
 }
 
 func RegisterABitOfEverythingServiceServer(s *grpc.Server, srv ABitOfEverythingServiceServer) {
@@ -821,16 +830,25 @@ func (c *camelCaseServiceNameClient) Empty(ctx context.Context, in *empty.Empty,
 }
 
 // CamelCaseServiceNameServer is the server API for CamelCaseServiceName service.
+// All implementations should embed UnimplementedCamelCaseServiceNameServer
+// for forward compatibility
 type CamelCaseServiceNameServer interface {
 	Empty(context.Context, *empty.Empty) (*empty.Empty, error)
 }
 
-// UnimplementedCamelCaseServiceNameServer can be embedded to have forward compatible implementations.
+// UnimplementedCamelCaseServiceNameServer should be embedded to have forward compatible implementations.
 type UnimplementedCamelCaseServiceNameServer struct {
 }
 
-func (*UnimplementedCamelCaseServiceNameServer) Empty(context.Context, *empty.Empty) (*empty.Empty, error) {
+func (UnimplementedCamelCaseServiceNameServer) Empty(context.Context, *empty.Empty) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Empty not implemented")
+}
+
+// UnsafeCamelCaseServiceNameServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to CamelCaseServiceNameServer will
+// result in compilation errors.
+type UnsafeCamelCaseServiceNameServer interface {
+	mustEmbedUnimplementedCamelCaseServiceNameServer()
 }
 
 func RegisterCamelCaseServiceNameServer(s *grpc.Server, srv CamelCaseServiceNameServer) {
@@ -893,16 +911,25 @@ func (c *anotherServiceWithNoBindingsClient) NoBindings(ctx context.Context, in 
 }
 
 // AnotherServiceWithNoBindingsServer is the server API for AnotherServiceWithNoBindings service.
+// All implementations should embed UnimplementedAnotherServiceWithNoBindingsServer
+// for forward compatibility
 type AnotherServiceWithNoBindingsServer interface {
 	NoBindings(context.Context, *empty.Empty) (*empty.Empty, error)
 }
 
-// UnimplementedAnotherServiceWithNoBindingsServer can be embedded to have forward compatible implementations.
+// UnimplementedAnotherServiceWithNoBindingsServer should be embedded to have forward compatible implementations.
 type UnimplementedAnotherServiceWithNoBindingsServer struct {
 }
 
-func (*UnimplementedAnotherServiceWithNoBindingsServer) NoBindings(context.Context, *empty.Empty) (*empty.Empty, error) {
+func (UnimplementedAnotherServiceWithNoBindingsServer) NoBindings(context.Context, *empty.Empty) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method NoBindings not implemented")
+}
+
+// UnsafeAnotherServiceWithNoBindingsServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to AnotherServiceWithNoBindingsServer will
+// result in compilation errors.
+type UnsafeAnotherServiceWithNoBindingsServer interface {
+	mustEmbedUnimplementedAnotherServiceWithNoBindingsServer()
 }
 
 func RegisterAnotherServiceWithNoBindingsServer(s *grpc.Server, srv AnotherServiceWithNoBindingsServer) {

--- a/examples/internal/proto/examplepb/echo_service_grpc.pb.go
+++ b/examples/internal/proto/examplepb/echo_service_grpc.pb.go
@@ -11,7 +11,7 @@ import (
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion6
+const _ = grpc.SupportPackageIsVersion7
 
 // EchoServiceClient is the client API for EchoService service.
 //
@@ -75,6 +75,8 @@ func (c *echoServiceClient) EchoPatch(ctx context.Context, in *DynamicMessageUpd
 }
 
 // EchoServiceServer is the server API for EchoService service.
+// All implementations should embed UnimplementedEchoServiceServer
+// for forward compatibility
 type EchoServiceServer interface {
 	// Echo method receives a simple message and returns it.
 	//
@@ -89,21 +91,28 @@ type EchoServiceServer interface {
 	EchoPatch(context.Context, *DynamicMessageUpdate) (*DynamicMessageUpdate, error)
 }
 
-// UnimplementedEchoServiceServer can be embedded to have forward compatible implementations.
+// UnimplementedEchoServiceServer should be embedded to have forward compatible implementations.
 type UnimplementedEchoServiceServer struct {
 }
 
-func (*UnimplementedEchoServiceServer) Echo(context.Context, *SimpleMessage) (*SimpleMessage, error) {
+func (UnimplementedEchoServiceServer) Echo(context.Context, *SimpleMessage) (*SimpleMessage, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Echo not implemented")
 }
-func (*UnimplementedEchoServiceServer) EchoBody(context.Context, *SimpleMessage) (*SimpleMessage, error) {
+func (UnimplementedEchoServiceServer) EchoBody(context.Context, *SimpleMessage) (*SimpleMessage, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method EchoBody not implemented")
 }
-func (*UnimplementedEchoServiceServer) EchoDelete(context.Context, *SimpleMessage) (*SimpleMessage, error) {
+func (UnimplementedEchoServiceServer) EchoDelete(context.Context, *SimpleMessage) (*SimpleMessage, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method EchoDelete not implemented")
 }
-func (*UnimplementedEchoServiceServer) EchoPatch(context.Context, *DynamicMessageUpdate) (*DynamicMessageUpdate, error) {
+func (UnimplementedEchoServiceServer) EchoPatch(context.Context, *DynamicMessageUpdate) (*DynamicMessageUpdate, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method EchoPatch not implemented")
+}
+
+// UnsafeEchoServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to EchoServiceServer will
+// result in compilation errors.
+type UnsafeEchoServiceServer interface {
+	mustEmbedUnimplementedEchoServiceServer()
 }
 
 func RegisterEchoServiceServer(s *grpc.Server, srv EchoServiceServer) {

--- a/examples/internal/proto/examplepb/flow_combination_grpc.pb.go
+++ b/examples/internal/proto/examplepb/flow_combination_grpc.pb.go
@@ -11,7 +11,7 @@ import (
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion6
+const _ = grpc.SupportPackageIsVersion7
 
 // FlowCombinationClient is the client API for FlowCombination service.
 //
@@ -267,6 +267,8 @@ func (x *flowCombinationRpcPathNestedStreamClient) Recv() (*EmptyProto, error) {
 }
 
 // FlowCombinationServer is the server API for FlowCombination service.
+// All implementations should embed UnimplementedFlowCombinationServer
+// for forward compatibility
 type FlowCombinationServer interface {
 	RpcEmptyRpc(context.Context, *EmptyProto) (*EmptyProto, error)
 	RpcEmptyStream(*EmptyProto, FlowCombination_RpcEmptyStreamServer) error
@@ -280,39 +282,46 @@ type FlowCombinationServer interface {
 	RpcPathNestedStream(*NestedProto, FlowCombination_RpcPathNestedStreamServer) error
 }
 
-// UnimplementedFlowCombinationServer can be embedded to have forward compatible implementations.
+// UnimplementedFlowCombinationServer should be embedded to have forward compatible implementations.
 type UnimplementedFlowCombinationServer struct {
 }
 
-func (*UnimplementedFlowCombinationServer) RpcEmptyRpc(context.Context, *EmptyProto) (*EmptyProto, error) {
+func (UnimplementedFlowCombinationServer) RpcEmptyRpc(context.Context, *EmptyProto) (*EmptyProto, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RpcEmptyRpc not implemented")
 }
-func (*UnimplementedFlowCombinationServer) RpcEmptyStream(*EmptyProto, FlowCombination_RpcEmptyStreamServer) error {
+func (UnimplementedFlowCombinationServer) RpcEmptyStream(*EmptyProto, FlowCombination_RpcEmptyStreamServer) error {
 	return status.Errorf(codes.Unimplemented, "method RpcEmptyStream not implemented")
 }
-func (*UnimplementedFlowCombinationServer) StreamEmptyRpc(FlowCombination_StreamEmptyRpcServer) error {
+func (UnimplementedFlowCombinationServer) StreamEmptyRpc(FlowCombination_StreamEmptyRpcServer) error {
 	return status.Errorf(codes.Unimplemented, "method StreamEmptyRpc not implemented")
 }
-func (*UnimplementedFlowCombinationServer) StreamEmptyStream(FlowCombination_StreamEmptyStreamServer) error {
+func (UnimplementedFlowCombinationServer) StreamEmptyStream(FlowCombination_StreamEmptyStreamServer) error {
 	return status.Errorf(codes.Unimplemented, "method StreamEmptyStream not implemented")
 }
-func (*UnimplementedFlowCombinationServer) RpcBodyRpc(context.Context, *NonEmptyProto) (*EmptyProto, error) {
+func (UnimplementedFlowCombinationServer) RpcBodyRpc(context.Context, *NonEmptyProto) (*EmptyProto, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RpcBodyRpc not implemented")
 }
-func (*UnimplementedFlowCombinationServer) RpcPathSingleNestedRpc(context.Context, *SingleNestedProto) (*EmptyProto, error) {
+func (UnimplementedFlowCombinationServer) RpcPathSingleNestedRpc(context.Context, *SingleNestedProto) (*EmptyProto, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RpcPathSingleNestedRpc not implemented")
 }
-func (*UnimplementedFlowCombinationServer) RpcPathNestedRpc(context.Context, *NestedProto) (*EmptyProto, error) {
+func (UnimplementedFlowCombinationServer) RpcPathNestedRpc(context.Context, *NestedProto) (*EmptyProto, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RpcPathNestedRpc not implemented")
 }
-func (*UnimplementedFlowCombinationServer) RpcBodyStream(*NonEmptyProto, FlowCombination_RpcBodyStreamServer) error {
+func (UnimplementedFlowCombinationServer) RpcBodyStream(*NonEmptyProto, FlowCombination_RpcBodyStreamServer) error {
 	return status.Errorf(codes.Unimplemented, "method RpcBodyStream not implemented")
 }
-func (*UnimplementedFlowCombinationServer) RpcPathSingleNestedStream(*SingleNestedProto, FlowCombination_RpcPathSingleNestedStreamServer) error {
+func (UnimplementedFlowCombinationServer) RpcPathSingleNestedStream(*SingleNestedProto, FlowCombination_RpcPathSingleNestedStreamServer) error {
 	return status.Errorf(codes.Unimplemented, "method RpcPathSingleNestedStream not implemented")
 }
-func (*UnimplementedFlowCombinationServer) RpcPathNestedStream(*NestedProto, FlowCombination_RpcPathNestedStreamServer) error {
+func (UnimplementedFlowCombinationServer) RpcPathNestedStream(*NestedProto, FlowCombination_RpcPathNestedStreamServer) error {
 	return status.Errorf(codes.Unimplemented, "method RpcPathNestedStream not implemented")
+}
+
+// UnsafeFlowCombinationServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to FlowCombinationServer will
+// result in compilation errors.
+type UnsafeFlowCombinationServer interface {
+	mustEmbedUnimplementedFlowCombinationServer()
 }
 
 func RegisterFlowCombinationServer(s *grpc.Server, srv FlowCombinationServer) {

--- a/examples/internal/proto/examplepb/generate_unbound_methods_grpc.pb.go
+++ b/examples/internal/proto/examplepb/generate_unbound_methods_grpc.pb.go
@@ -11,7 +11,7 @@ import (
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion6
+const _ = grpc.SupportPackageIsVersion7
 
 // GenerateUnboundMethodsEchoServiceClient is the client API for GenerateUnboundMethodsEchoService service.
 //
@@ -64,6 +64,8 @@ func (c *generateUnboundMethodsEchoServiceClient) EchoDelete(ctx context.Context
 }
 
 // GenerateUnboundMethodsEchoServiceServer is the server API for GenerateUnboundMethodsEchoService service.
+// All implementations should embed UnimplementedGenerateUnboundMethodsEchoServiceServer
+// for forward compatibility
 type GenerateUnboundMethodsEchoServiceServer interface {
 	// Echo method receives a simple message and returns it.
 	//
@@ -76,18 +78,25 @@ type GenerateUnboundMethodsEchoServiceServer interface {
 	EchoDelete(context.Context, *GenerateUnboundMethodsSimpleMessage) (*GenerateUnboundMethodsSimpleMessage, error)
 }
 
-// UnimplementedGenerateUnboundMethodsEchoServiceServer can be embedded to have forward compatible implementations.
+// UnimplementedGenerateUnboundMethodsEchoServiceServer should be embedded to have forward compatible implementations.
 type UnimplementedGenerateUnboundMethodsEchoServiceServer struct {
 }
 
-func (*UnimplementedGenerateUnboundMethodsEchoServiceServer) Echo(context.Context, *GenerateUnboundMethodsSimpleMessage) (*GenerateUnboundMethodsSimpleMessage, error) {
+func (UnimplementedGenerateUnboundMethodsEchoServiceServer) Echo(context.Context, *GenerateUnboundMethodsSimpleMessage) (*GenerateUnboundMethodsSimpleMessage, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Echo not implemented")
 }
-func (*UnimplementedGenerateUnboundMethodsEchoServiceServer) EchoBody(context.Context, *GenerateUnboundMethodsSimpleMessage) (*GenerateUnboundMethodsSimpleMessage, error) {
+func (UnimplementedGenerateUnboundMethodsEchoServiceServer) EchoBody(context.Context, *GenerateUnboundMethodsSimpleMessage) (*GenerateUnboundMethodsSimpleMessage, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method EchoBody not implemented")
 }
-func (*UnimplementedGenerateUnboundMethodsEchoServiceServer) EchoDelete(context.Context, *GenerateUnboundMethodsSimpleMessage) (*GenerateUnboundMethodsSimpleMessage, error) {
+func (UnimplementedGenerateUnboundMethodsEchoServiceServer) EchoDelete(context.Context, *GenerateUnboundMethodsSimpleMessage) (*GenerateUnboundMethodsSimpleMessage, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method EchoDelete not implemented")
+}
+
+// UnsafeGenerateUnboundMethodsEchoServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to GenerateUnboundMethodsEchoServiceServer will
+// result in compilation errors.
+type UnsafeGenerateUnboundMethodsEchoServiceServer interface {
+	mustEmbedUnimplementedGenerateUnboundMethodsEchoServiceServer()
 }
 
 func RegisterGenerateUnboundMethodsEchoServiceServer(s *grpc.Server, srv GenerateUnboundMethodsEchoServiceServer) {

--- a/examples/internal/proto/examplepb/non_standard_names_grpc.pb.go
+++ b/examples/internal/proto/examplepb/non_standard_names_grpc.pb.go
@@ -11,7 +11,7 @@ import (
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion6
+const _ = grpc.SupportPackageIsVersion7
 
 // NonStandardServiceClient is the client API for NonStandardService service.
 //
@@ -50,6 +50,8 @@ func (c *nonStandardServiceClient) UpdateWithJSONNames(ctx context.Context, in *
 }
 
 // NonStandardServiceServer is the server API for NonStandardService service.
+// All implementations should embed UnimplementedNonStandardServiceServer
+// for forward compatibility
 type NonStandardServiceServer interface {
 	// Apply field mask to empty NonStandardMessage and return result.
 	Update(context.Context, *NonStandardUpdateRequest) (*NonStandardMessage, error)
@@ -57,15 +59,22 @@ type NonStandardServiceServer interface {
 	UpdateWithJSONNames(context.Context, *NonStandardWithJSONNamesUpdateRequest) (*NonStandardMessageWithJSONNames, error)
 }
 
-// UnimplementedNonStandardServiceServer can be embedded to have forward compatible implementations.
+// UnimplementedNonStandardServiceServer should be embedded to have forward compatible implementations.
 type UnimplementedNonStandardServiceServer struct {
 }
 
-func (*UnimplementedNonStandardServiceServer) Update(context.Context, *NonStandardUpdateRequest) (*NonStandardMessage, error) {
+func (UnimplementedNonStandardServiceServer) Update(context.Context, *NonStandardUpdateRequest) (*NonStandardMessage, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Update not implemented")
 }
-func (*UnimplementedNonStandardServiceServer) UpdateWithJSONNames(context.Context, *NonStandardWithJSONNamesUpdateRequest) (*NonStandardMessageWithJSONNames, error) {
+func (UnimplementedNonStandardServiceServer) UpdateWithJSONNames(context.Context, *NonStandardWithJSONNamesUpdateRequest) (*NonStandardMessageWithJSONNames, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateWithJSONNames not implemented")
+}
+
+// UnsafeNonStandardServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to NonStandardServiceServer will
+// result in compilation errors.
+type UnsafeNonStandardServiceServer interface {
+	mustEmbedUnimplementedNonStandardServiceServer()
 }
 
 func RegisterNonStandardServiceServer(s *grpc.Server, srv NonStandardServiceServer) {

--- a/examples/internal/proto/examplepb/response_body_service_grpc.pb.go
+++ b/examples/internal/proto/examplepb/response_body_service_grpc.pb.go
@@ -11,7 +11,7 @@ import (
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion6
+const _ = grpc.SupportPackageIsVersion7
 
 // ResponseBodyServiceClient is the client API for ResponseBodyService service.
 //
@@ -91,6 +91,8 @@ func (x *responseBodyServiceGetResponseBodyStreamClient) Recv() (*ResponseBodyOu
 }
 
 // ResponseBodyServiceServer is the server API for ResponseBodyService service.
+// All implementations should embed UnimplementedResponseBodyServiceServer
+// for forward compatibility
 type ResponseBodyServiceServer interface {
 	GetResponseBody(context.Context, *ResponseBodyIn) (*ResponseBodyOut, error)
 	ListResponseBodies(context.Context, *ResponseBodyIn) (*RepeatedResponseBodyOut, error)
@@ -98,21 +100,28 @@ type ResponseBodyServiceServer interface {
 	GetResponseBodyStream(*ResponseBodyIn, ResponseBodyService_GetResponseBodyStreamServer) error
 }
 
-// UnimplementedResponseBodyServiceServer can be embedded to have forward compatible implementations.
+// UnimplementedResponseBodyServiceServer should be embedded to have forward compatible implementations.
 type UnimplementedResponseBodyServiceServer struct {
 }
 
-func (*UnimplementedResponseBodyServiceServer) GetResponseBody(context.Context, *ResponseBodyIn) (*ResponseBodyOut, error) {
+func (UnimplementedResponseBodyServiceServer) GetResponseBody(context.Context, *ResponseBodyIn) (*ResponseBodyOut, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetResponseBody not implemented")
 }
-func (*UnimplementedResponseBodyServiceServer) ListResponseBodies(context.Context, *ResponseBodyIn) (*RepeatedResponseBodyOut, error) {
+func (UnimplementedResponseBodyServiceServer) ListResponseBodies(context.Context, *ResponseBodyIn) (*RepeatedResponseBodyOut, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListResponseBodies not implemented")
 }
-func (*UnimplementedResponseBodyServiceServer) ListResponseStrings(context.Context, *ResponseBodyIn) (*RepeatedResponseStrings, error) {
+func (UnimplementedResponseBodyServiceServer) ListResponseStrings(context.Context, *ResponseBodyIn) (*RepeatedResponseStrings, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListResponseStrings not implemented")
 }
-func (*UnimplementedResponseBodyServiceServer) GetResponseBodyStream(*ResponseBodyIn, ResponseBodyService_GetResponseBodyStreamServer) error {
+func (UnimplementedResponseBodyServiceServer) GetResponseBodyStream(*ResponseBodyIn, ResponseBodyService_GetResponseBodyStreamServer) error {
 	return status.Errorf(codes.Unimplemented, "method GetResponseBodyStream not implemented")
+}
+
+// UnsafeResponseBodyServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to ResponseBodyServiceServer will
+// result in compilation errors.
+type UnsafeResponseBodyServiceServer interface {
+	mustEmbedUnimplementedResponseBodyServiceServer()
 }
 
 func RegisterResponseBodyServiceServer(s *grpc.Server, srv ResponseBodyServiceServer) {

--- a/examples/internal/proto/examplepb/stream_grpc.pb.go
+++ b/examples/internal/proto/examplepb/stream_grpc.pb.go
@@ -14,7 +14,7 @@ import (
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion6
+const _ = grpc.SupportPackageIsVersion7
 
 // StreamServiceClient is the client API for StreamService service.
 //
@@ -164,6 +164,8 @@ func (x *streamServiceDownloadClient) Recv() (*httpbody.HttpBody, error) {
 }
 
 // StreamServiceServer is the server API for StreamService service.
+// All implementations should embed UnimplementedStreamServiceServer
+// for forward compatibility
 type StreamServiceServer interface {
 	BulkCreate(StreamService_BulkCreateServer) error
 	List(*empty.Empty, StreamService_ListServer) error
@@ -171,21 +173,28 @@ type StreamServiceServer interface {
 	Download(*empty.Empty, StreamService_DownloadServer) error
 }
 
-// UnimplementedStreamServiceServer can be embedded to have forward compatible implementations.
+// UnimplementedStreamServiceServer should be embedded to have forward compatible implementations.
 type UnimplementedStreamServiceServer struct {
 }
 
-func (*UnimplementedStreamServiceServer) BulkCreate(StreamService_BulkCreateServer) error {
+func (UnimplementedStreamServiceServer) BulkCreate(StreamService_BulkCreateServer) error {
 	return status.Errorf(codes.Unimplemented, "method BulkCreate not implemented")
 }
-func (*UnimplementedStreamServiceServer) List(*empty.Empty, StreamService_ListServer) error {
+func (UnimplementedStreamServiceServer) List(*empty.Empty, StreamService_ListServer) error {
 	return status.Errorf(codes.Unimplemented, "method List not implemented")
 }
-func (*UnimplementedStreamServiceServer) BulkEcho(StreamService_BulkEchoServer) error {
+func (UnimplementedStreamServiceServer) BulkEcho(StreamService_BulkEchoServer) error {
 	return status.Errorf(codes.Unimplemented, "method BulkEcho not implemented")
 }
-func (*UnimplementedStreamServiceServer) Download(*empty.Empty, StreamService_DownloadServer) error {
+func (UnimplementedStreamServiceServer) Download(*empty.Empty, StreamService_DownloadServer) error {
 	return status.Errorf(codes.Unimplemented, "method Download not implemented")
+}
+
+// UnsafeStreamServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to StreamServiceServer will
+// result in compilation errors.
+type UnsafeStreamServiceServer interface {
+	mustEmbedUnimplementedStreamServiceServer()
 }
 
 func RegisterStreamServiceServer(s *grpc.Server, srv StreamServiceServer) {

--- a/examples/internal/proto/examplepb/unannotated_echo_service_grpc.pb.go
+++ b/examples/internal/proto/examplepb/unannotated_echo_service_grpc.pb.go
@@ -11,7 +11,7 @@ import (
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion6
+const _ = grpc.SupportPackageIsVersion7
 
 // UnannotatedEchoServiceClient is the client API for UnannotatedEchoService service.
 //
@@ -64,6 +64,8 @@ func (c *unannotatedEchoServiceClient) EchoDelete(ctx context.Context, in *Unann
 }
 
 // UnannotatedEchoServiceServer is the server API for UnannotatedEchoService service.
+// All implementations should embed UnimplementedUnannotatedEchoServiceServer
+// for forward compatibility
 type UnannotatedEchoServiceServer interface {
 	// Echo method receives a simple message and returns it.
 	//
@@ -76,18 +78,25 @@ type UnannotatedEchoServiceServer interface {
 	EchoDelete(context.Context, *UnannotatedSimpleMessage) (*UnannotatedSimpleMessage, error)
 }
 
-// UnimplementedUnannotatedEchoServiceServer can be embedded to have forward compatible implementations.
+// UnimplementedUnannotatedEchoServiceServer should be embedded to have forward compatible implementations.
 type UnimplementedUnannotatedEchoServiceServer struct {
 }
 
-func (*UnimplementedUnannotatedEchoServiceServer) Echo(context.Context, *UnannotatedSimpleMessage) (*UnannotatedSimpleMessage, error) {
+func (UnimplementedUnannotatedEchoServiceServer) Echo(context.Context, *UnannotatedSimpleMessage) (*UnannotatedSimpleMessage, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Echo not implemented")
 }
-func (*UnimplementedUnannotatedEchoServiceServer) EchoBody(context.Context, *UnannotatedSimpleMessage) (*UnannotatedSimpleMessage, error) {
+func (UnimplementedUnannotatedEchoServiceServer) EchoBody(context.Context, *UnannotatedSimpleMessage) (*UnannotatedSimpleMessage, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method EchoBody not implemented")
 }
-func (*UnimplementedUnannotatedEchoServiceServer) EchoDelete(context.Context, *UnannotatedSimpleMessage) (*UnannotatedSimpleMessage, error) {
+func (UnimplementedUnannotatedEchoServiceServer) EchoDelete(context.Context, *UnannotatedSimpleMessage) (*UnannotatedSimpleMessage, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method EchoDelete not implemented")
+}
+
+// UnsafeUnannotatedEchoServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to UnannotatedEchoServiceServer will
+// result in compilation errors.
+type UnsafeUnannotatedEchoServiceServer interface {
+	mustEmbedUnimplementedUnannotatedEchoServiceServer()
 }
 
 func RegisterUnannotatedEchoServiceServer(s *grpc.Server, srv UnannotatedEchoServiceServer) {

--- a/examples/internal/proto/examplepb/use_go_template_grpc.pb.go
+++ b/examples/internal/proto/examplepb/use_go_template_grpc.pb.go
@@ -11,7 +11,7 @@ import (
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion6
+const _ = grpc.SupportPackageIsVersion7
 
 // LoginServiceClient is the client API for LoginService service.
 //
@@ -76,6 +76,8 @@ func (c *loginServiceClient) Logout(ctx context.Context, in *LogoutRequest, opts
 }
 
 // LoginServiceServer is the server API for LoginService service.
+// All implementations should embed UnimplementedLoginServiceServer
+// for forward compatibility
 type LoginServiceServer interface {
 	// Login
 	//
@@ -109,15 +111,22 @@ type LoginServiceServer interface {
 	Logout(context.Context, *LogoutRequest) (*LogoutReply, error)
 }
 
-// UnimplementedLoginServiceServer can be embedded to have forward compatible implementations.
+// UnimplementedLoginServiceServer should be embedded to have forward compatible implementations.
 type UnimplementedLoginServiceServer struct {
 }
 
-func (*UnimplementedLoginServiceServer) Login(context.Context, *LoginRequest) (*LoginReply, error) {
+func (UnimplementedLoginServiceServer) Login(context.Context, *LoginRequest) (*LoginReply, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Login not implemented")
 }
-func (*UnimplementedLoginServiceServer) Logout(context.Context, *LogoutRequest) (*LogoutReply, error) {
+func (UnimplementedLoginServiceServer) Logout(context.Context, *LogoutRequest) (*LogoutReply, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Logout not implemented")
+}
+
+// UnsafeLoginServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to LoginServiceServer will
+// result in compilation errors.
+type UnsafeLoginServiceServer interface {
+	mustEmbedUnimplementedLoginServiceServer()
 }
 
 func RegisterLoginServiceServer(s *grpc.Server, srv LoginServiceServer) {

--- a/examples/internal/proto/examplepb/wrappers_grpc.pb.go
+++ b/examples/internal/proto/examplepb/wrappers_grpc.pb.go
@@ -13,7 +13,7 @@ import (
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion6
+const _ = grpc.SupportPackageIsVersion7
 
 // WrappersServiceClient is the client API for WrappersService service.
 //
@@ -140,6 +140,8 @@ func (c *wrappersServiceClient) CreateEmpty(ctx context.Context, in *empty.Empty
 }
 
 // WrappersServiceServer is the server API for WrappersService service.
+// All implementations should embed UnimplementedWrappersServiceServer
+// for forward compatibility
 type WrappersServiceServer interface {
 	Create(context.Context, *Wrappers) (*Wrappers, error)
 	CreateStringValue(context.Context, *wrappers.StringValue) (*wrappers.StringValue, error)
@@ -154,42 +156,49 @@ type WrappersServiceServer interface {
 	CreateEmpty(context.Context, *empty.Empty) (*empty.Empty, error)
 }
 
-// UnimplementedWrappersServiceServer can be embedded to have forward compatible implementations.
+// UnimplementedWrappersServiceServer should be embedded to have forward compatible implementations.
 type UnimplementedWrappersServiceServer struct {
 }
 
-func (*UnimplementedWrappersServiceServer) Create(context.Context, *Wrappers) (*Wrappers, error) {
+func (UnimplementedWrappersServiceServer) Create(context.Context, *Wrappers) (*Wrappers, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Create not implemented")
 }
-func (*UnimplementedWrappersServiceServer) CreateStringValue(context.Context, *wrappers.StringValue) (*wrappers.StringValue, error) {
+func (UnimplementedWrappersServiceServer) CreateStringValue(context.Context, *wrappers.StringValue) (*wrappers.StringValue, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateStringValue not implemented")
 }
-func (*UnimplementedWrappersServiceServer) CreateInt32Value(context.Context, *wrappers.Int32Value) (*wrappers.Int32Value, error) {
+func (UnimplementedWrappersServiceServer) CreateInt32Value(context.Context, *wrappers.Int32Value) (*wrappers.Int32Value, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateInt32Value not implemented")
 }
-func (*UnimplementedWrappersServiceServer) CreateInt64Value(context.Context, *wrappers.Int64Value) (*wrappers.Int64Value, error) {
+func (UnimplementedWrappersServiceServer) CreateInt64Value(context.Context, *wrappers.Int64Value) (*wrappers.Int64Value, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateInt64Value not implemented")
 }
-func (*UnimplementedWrappersServiceServer) CreateFloatValue(context.Context, *wrappers.FloatValue) (*wrappers.FloatValue, error) {
+func (UnimplementedWrappersServiceServer) CreateFloatValue(context.Context, *wrappers.FloatValue) (*wrappers.FloatValue, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateFloatValue not implemented")
 }
-func (*UnimplementedWrappersServiceServer) CreateDoubleValue(context.Context, *wrappers.DoubleValue) (*wrappers.DoubleValue, error) {
+func (UnimplementedWrappersServiceServer) CreateDoubleValue(context.Context, *wrappers.DoubleValue) (*wrappers.DoubleValue, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateDoubleValue not implemented")
 }
-func (*UnimplementedWrappersServiceServer) CreateBoolValue(context.Context, *wrappers.BoolValue) (*wrappers.BoolValue, error) {
+func (UnimplementedWrappersServiceServer) CreateBoolValue(context.Context, *wrappers.BoolValue) (*wrappers.BoolValue, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateBoolValue not implemented")
 }
-func (*UnimplementedWrappersServiceServer) CreateUInt32Value(context.Context, *wrappers.UInt32Value) (*wrappers.UInt32Value, error) {
+func (UnimplementedWrappersServiceServer) CreateUInt32Value(context.Context, *wrappers.UInt32Value) (*wrappers.UInt32Value, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateUInt32Value not implemented")
 }
-func (*UnimplementedWrappersServiceServer) CreateUInt64Value(context.Context, *wrappers.UInt64Value) (*wrappers.UInt64Value, error) {
+func (UnimplementedWrappersServiceServer) CreateUInt64Value(context.Context, *wrappers.UInt64Value) (*wrappers.UInt64Value, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateUInt64Value not implemented")
 }
-func (*UnimplementedWrappersServiceServer) CreateBytesValue(context.Context, *wrappers.BytesValue) (*wrappers.BytesValue, error) {
+func (UnimplementedWrappersServiceServer) CreateBytesValue(context.Context, *wrappers.BytesValue) (*wrappers.BytesValue, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateBytesValue not implemented")
 }
-func (*UnimplementedWrappersServiceServer) CreateEmpty(context.Context, *empty.Empty) (*empty.Empty, error) {
+func (UnimplementedWrappersServiceServer) CreateEmpty(context.Context, *empty.Empty) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateEmpty not implemented")
+}
+
+// UnsafeWrappersServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to WrappersServiceServer will
+// result in compilation errors.
+type UnsafeWrappersServiceServer interface {
+	mustEmbedUnimplementedWrappersServiceServer()
 }
 
 func RegisterWrappersServiceServer(s *grpc.Server, srv WrappersServiceServer) {

--- a/examples/internal/server/a_bit_of_everything.go
+++ b/examples/internal/server/a_bit_of_everything.go
@@ -28,8 +28,6 @@ import (
 var uuidgen = fastuuid.MustNewGenerator()
 
 type _ABitOfEverythingServer struct {
-	examples.UnimplementedABitOfEverythingServiceServer
-	examples.UnimplementedStreamServiceServer
 	v map[string]*examples.ABitOfEverything
 	m sync.Mutex
 }

--- a/examples/internal/server/echo.go
+++ b/examples/internal/server/echo.go
@@ -12,7 +12,6 @@ import (
 // Implements of EchoServiceServer
 
 type echoServer struct {
-	examples.UnimplementedEchoServiceServer
 }
 
 func newEchoServer() examples.EchoServiceServer {

--- a/examples/internal/server/flow_combination.go
+++ b/examples/internal/server/flow_combination.go
@@ -8,7 +8,6 @@ import (
 )
 
 type flowCombinationServer struct {
-	examples.UnimplementedFlowCombinationServer
 }
 
 func newFlowCombinationServer() examples.FlowCombinationServer {

--- a/examples/internal/server/non_standard_names.go
+++ b/examples/internal/server/non_standard_names.go
@@ -10,7 +10,6 @@ import (
 // Implements NonStandardServiceServer
 
 type nonStandardServer struct {
-	examples.UnimplementedNonStandardServiceServer
 }
 
 func newNonStandardServer() examples.NonStandardServiceServer {

--- a/examples/internal/server/responsebody.go
+++ b/examples/internal/server/responsebody.go
@@ -11,7 +11,6 @@ import (
 // Implements of ResponseBodyServiceServer
 
 type responseBodyServer struct {
-	examples.UnimplementedResponseBodyServiceServer
 }
 
 func newResponseBodyServer() examples.ResponseBodyServiceServer {

--- a/examples/internal/server/unannotatedecho.go
+++ b/examples/internal/server/unannotatedecho.go
@@ -12,7 +12,6 @@ import (
 // Implements of UnannotatedEchoServiceServer
 
 type unannotatedEchoServer struct {
-	examples.UnimplementedUnannotatedEchoServiceServer
 }
 
 func newUnannotatedEchoServer() examples.UnannotatedEchoServiceServer {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	google.golang.org/genproto v0.0.0-20201002142447-3860012362da
 	google.golang.org/grpc v1.32.0
-	google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200527211525-6c9e30c09db2
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.0.0
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v2 v2.2.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -366,8 +366,8 @@ google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.32.0 h1:zWTV+LMdc3kaiJMSTOFz2UgSBgx8RNQoTGiZu3fR9S0=
 google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200527211525-6c9e30c09db2 h1:KNluVV5ay+orsSPJ6XTpwJQ8qBhrBkOTmtBFGeDlBcY=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200527211525-6c9e30c09db2/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.0.0 h1:lQ+dE99pFsb8osbJB3oRfE5eW4Hx6a/lZQr8Jh+eoT4=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.0.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -366,8 +366,8 @@ def go_repositories():
     go_repository(
         name = "org_golang_google_grpc_cmd_protoc_gen_go_grpc",
         importpath = "google.golang.org/grpc/cmd/protoc-gen-go-grpc",
-        sum = "h1:KNluVV5ay+orsSPJ6XTpwJQ8qBhrBkOTmtBFGeDlBcY=",
-        version = "v0.0.0-20200527211525-6c9e30c09db2",
+        sum = "h1:lQ+dE99pFsb8osbJB3oRfE5eW4Hx6a/lZQr8Jh+eoT4=",
+        version = "v1.0.0",
     )
     go_repository(
         name = "org_golang_google_protobuf",

--- a/runtime/internal/examplepb/non_standard_names_grpc.pb.go
+++ b/runtime/internal/examplepb/non_standard_names_grpc.pb.go
@@ -11,7 +11,7 @@ import (
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion6
+const _ = grpc.SupportPackageIsVersion7
 
 // NonStandardServiceClient is the client API for NonStandardService service.
 //
@@ -50,6 +50,8 @@ func (c *nonStandardServiceClient) UpdateWithJSONNames(ctx context.Context, in *
 }
 
 // NonStandardServiceServer is the server API for NonStandardService service.
+// All implementations should embed UnimplementedNonStandardServiceServer
+// for forward compatibility
 type NonStandardServiceServer interface {
 	// Apply field mask to empty NonStandardMessage and return result.
 	Update(context.Context, *NonStandardUpdateRequest) (*NonStandardMessage, error)
@@ -57,15 +59,22 @@ type NonStandardServiceServer interface {
 	UpdateWithJSONNames(context.Context, *NonStandardWithJSONNamesUpdateRequest) (*NonStandardMessageWithJSONNames, error)
 }
 
-// UnimplementedNonStandardServiceServer can be embedded to have forward compatible implementations.
+// UnimplementedNonStandardServiceServer should be embedded to have forward compatible implementations.
 type UnimplementedNonStandardServiceServer struct {
 }
 
-func (*UnimplementedNonStandardServiceServer) Update(context.Context, *NonStandardUpdateRequest) (*NonStandardMessage, error) {
+func (UnimplementedNonStandardServiceServer) Update(context.Context, *NonStandardUpdateRequest) (*NonStandardMessage, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Update not implemented")
 }
-func (*UnimplementedNonStandardServiceServer) UpdateWithJSONNames(context.Context, *NonStandardWithJSONNamesUpdateRequest) (*NonStandardMessageWithJSONNames, error) {
+func (UnimplementedNonStandardServiceServer) UpdateWithJSONNames(context.Context, *NonStandardWithJSONNamesUpdateRequest) (*NonStandardMessageWithJSONNames, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateWithJSONNames not implemented")
+}
+
+// UnsafeNonStandardServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to NonStandardServiceServer will
+// result in compilation errors.
+type UnsafeNonStandardServiceServer interface {
+	mustEmbedUnimplementedNonStandardServiceServer()
 }
 
 func RegisterNonStandardServiceServer(s *grpc.Server, srv NonStandardServiceServer) {


### PR DESCRIPTION
This meant we could remove the embedding of the
UnimplementedXServer interfaces, since this requirement
is now configurable.

Supercedes #1660