### PR TITLE
fix empty parameter fatal in protoc-gen-grpc-gateway 

### DIFF
--- a/protoc-gen-grpc-gateway/BUILD.bazel
+++ b/protoc-gen-grpc-gateway/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:compiler.bzl", "go_proto_compiler")
 
 package(default_visibility = ["//visibility:private"])
@@ -40,4 +40,11 @@ go_proto_compiler(
         "@org_golang_google_grpc//status:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//internal/descriptor:go_default_library"],
 )

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -107,6 +107,10 @@ func main() {
 }
 
 func parseFlags(reg *descriptor.Registry, parameter string) {
+	if parameter == "" {
+		return
+	}
+
 	for _, p := range strings.Split(parameter, ",") {
 		spec := strings.SplitN(p, "=", 2)
 		if len(spec) == 1 {

--- a/protoc-gen-grpc-gateway/main_test.go
+++ b/protoc-gen-grpc-gateway/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor"
+)
+
+func TestParseFlagsEmptyNoPanic(t *testing.T) {
+	reg := descriptor.NewRegistry()
+	parseFlags(reg, "")
+}
+
+func TestParseFlags(t *testing.T) {
+	reg := descriptor.NewRegistry()
+	parseFlags(reg, "allow_repeated_fields_in_body=true")
+	if *allowRepeatedFieldsInBody != true {
+		t.Errorf("flag allow_repeated_fields_in_body was not set correctly, wanted true got %v", *allowRepeatedFieldsInBody)
+	}
+}
+
+func TestParseFlagsMultiple(t *testing.T) {
+	reg := descriptor.NewRegistry()
+	parseFlags(reg, "allow_repeated_fields_in_body=true,import_prefix=foo")
+	if *allowRepeatedFieldsInBody != true {
+		t.Errorf("flag allow_repeated_fields_in_body was not set correctly, wanted 'true' got '%v'", *allowRepeatedFieldsInBody)
+	}
+	if *importPrefix != "foo" {
+		t.Errorf("flag importPrefix was not set correctly, wanted 'foo' got '%v'", *importPrefix)
+	}
+}


### PR DESCRIPTION
Fixes #1751

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

`Split()` on an empty parameter set for `protoc-gen-grpc-gateway` would cause a fatal since the for loop woulds still execute with an empty string.

Fixed with an early return and added some small tests.

```
F1014 11:23:06.564537  195394 main.go:115] Cannot set flag 
goroutine 1 [running]:
github.com/golang/glog.stacks(0xc000628000, 0xc0001ae680, 0x3c, 0x40)
        /home/danielhochman/go/pkg/mod/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b/glog.go:769 +0xb8
github.com/golang/glog.(*loggingT).output(0xb8c4c0, 0xc000000003, 0xc0001fbf80, 0xb5bcf1, 0x7, 0x73, 0x0)
        /home/danielhochman/go/pkg/mod/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b/glog.go:720 +0x372
github.com/golang/glog.(*loggingT).printf(0xb8c4c0, 0x3, 0x843bf2, 0x12, 0xc000295bc8, 0x1, 0x1)
        /home/danielhochman/go/pkg/mod/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b/glog.go:655 +0x14b
github.com/golang/glog.Fatalf(...)
        /home/danielhochman/go/pkg/mod/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b/glog.go:1148
main.parseFlags(0xc0001b4750, 0x0, 0x0)
        /home/danielhochman/go/src/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/main.go:115 +0x444
main.main.func1(0xc00039d5e0, 0x0, 0xc0001fa000)
        /home/danielhochman/go/src/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/main.go:68 +0x79
google.golang.org/protobuf/compiler/protogen.run(0xc0001977a0, 0x0, 0xc000295f30, 0xb8ce20, 0x7f326cb7ee98)
        /home/danielhochman/go/pkg/mod/google.golang.org/protobuf@v1.25.0/compiler/protogen/protogen.go:76 +0x142
google.golang.org/protobuf/compiler/protogen.Options.Run(0xc0001977a0, 0x0, 0xc000251f30)
        /home/danielhochman/go/pkg/mod/google.golang.org/protobuf@v1.25.0/compiler/protogen/protogen.go:54 +0x5a
main.main()
        /home/danielhochman/go/src/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/main.go:66 +0x2d1
--grpc-gateway_out: protoc-gen-grpc-gateway: Plugin failed with status code 255.
```

#### Other comments
