### PR TITLE
Fix -module option for protoc-gen-grpc-gateway

### DIFF
--- a/protoc-gen-grpc-gateway/internal/gengateway/BUILD.bazel
+++ b/protoc-gen-grpc-gateway/internal/gengateway/BUILD.bazel
@@ -32,7 +32,9 @@ go_test(
     deps = [
         "//internal/descriptor:go_default_library",
         "//internal/httprule:go_default_library",
+        "@org_golang_google_protobuf//compiler/protogen:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
         "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
+        "@org_golang_google_protobuf//types/pluginpb:go_default_library",
     ],
 )

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -28,7 +28,7 @@ var (
 	allowDeleteBody            = flag.Bool("allow_delete_body", false, "unless set, HTTP DELETE methods may not have a body")
 	grpcAPIConfiguration       = flag.String("grpc_api_configuration", "", "path to gRPC API Configuration in YAML format")
 	pathType                   = flag.String("paths", "", "specifies how the paths of generated files are structured")
-	modulePath                 = flag.String("module", "", "specifies a module prefix that will be stripped from the go package to determine the output directory")
+	_                          = flag.String("module", "", "specifies a module prefix that will be stripped from the go package to determine the output directory")
 	allowRepeatedFieldsInBody  = flag.Bool("allow_repeated_fields_in_body", false, "allows to use repeated field in `body` and `response_body` field of `google.api.http` annotation option")
 	repeatedPathParamSeparator = flag.String("repeated_path_param_separator", "csv", "configures how repeated fields should be split. Allowed values are `csv`, `pipes`, `ssv` and `tsv`.")
 	allowPatchFeature          = flag.Bool("allow_patch_feature", true, "determines whether to use PATCH feature involving update masks (using google.protobuf.FieldMask).")
@@ -90,7 +90,7 @@ func main() {
 			targets = append(targets, f)
 		}
 
-		g := gengateway.New(reg, *useRequestContext, *registerFuncSuffix, *pathType, *modulePath, *allowPatchFeature, *standalone)
+		g := gengateway.New(reg, *useRequestContext, *registerFuncSuffix, *pathType, *allowPatchFeature, *standalone)
 		files, err := g.Generate(targets)
 		for _, f := range files {
 			glog.V(1).Infof("NewGeneratedFile %q in %s", f.GetName(), f.GoPkg)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #1753

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

When option `module=...` is used with protoc-gen-grpc-gateway v2, the module prefix is removed a [first time](https://github.com/grpc-ecosystem/grpc-gateway/blob/1aab03caf0bfadbf99a107ffdd86467ac9db7caa/protoc-gen-grpc-gateway/internal/gengateway/generator.go#L142-L145) by protoc-gen-grpc-gateway, then protogen attempts to remove the prefix a [second time](https://github.com/protocolbuffers/protobuf-go/blob/f62736dede0a74248d862247dbcb53ab69582a05/compiler/protogen/protogen.go#L431-L436). It then fails with an error "generated file does not match prefix".

This commit fixes this issue by removing the first prefix handling.