### PR TITLE
Disable gRPC updates on v1

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,8 @@
                 "github.com/golang/protobuf",
                 "google.golang.org/genproto",
                 "io_bazel_rules_go",
-                "golang.org/x/oauth2"
+                "golang.org/x/oauth2",
+                "google.golang.org/grpc"
             ],
             "enabled": false
         },


### PR DESCRIPTION
The grpc-go project has switched to using google.golang.org/protobuf
as their generator base, which means depending on
v1.4.x of golang/protobuf, which we can't support.
