### PR TITLE
Change FieldMask OpenAPI type to string.

### DIFF
--- a/docs/docs/mapping/patch.md
+++ b/docs/docs/mapping/patch.md
@@ -94,7 +94,7 @@ that is what we specify in the field_mask.
 
 ```shell
 $ curl \
-	--data '{"abe":{"single_nested":{"amount":457},"string_value":"some value that won't get updated because not in the field mask"},"update_mask":{"paths":["single_nested"]}}' \
+	--data '{"abe":{"single_nested":{"amount":457},"string_value":"some value that will not get updated because not in the field mask"},"update_mask":"singleNested"}}' \
 	-X PATCH \
 	http://address:port/v2a/example/a_bit_of_everything/1
 ```

--- a/docs/docs/mapping/patch.md
+++ b/docs/docs/mapping/patch.md
@@ -82,7 +82,7 @@ else in our resource the same.
 
 ```shell
 $ curl \
-	--data '{"string_value": "strprefix/foo"}' \
+	--data '{"stringValue": "strprefix/foo"}' \
 	-X PATCH \
 	http://address:port/v2/example/a_bit_of_everything/1
 ```
@@ -94,7 +94,7 @@ that is what we specify in the field_mask.
 
 ```shell
 $ curl \
-	--data '{"abe":{"single_nested":{"amount":457},"string_value":"some value that will not get updated because not in the field mask"},"update_mask":"singleNested"}}' \
+	--data '{"abe":{"singleNested":{"amount":457},"stringValue":"some value that will not get updated because not in the field mask"},"updateMask":"singleNested"}}' \
 	-X PATCH \
 	http://address:port/v2a/example/a_bit_of_everything/1
 ```

--- a/examples/internal/clients/abe/api/swagger.yaml
+++ b/examples/internal/clients/abe/api/swagger.yaml
@@ -1916,11 +1916,9 @@ paths:
         in: "query"
         description: "The paths to update."
         required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
+        type: "string"
         x-exportParamName: "UpdateMask"
+        x-optionalDataType: "String"
       responses:
         200:
           description: "A successful response."
@@ -1962,11 +1960,9 @@ paths:
         in: "query"
         description: "The paths to update."
         required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
+        type: "string"
         x-exportParamName: "UpdateMask"
+        x-optionalDataType: "String"
       responses:
         200:
           description: "A successful response."
@@ -2683,10 +2679,8 @@ definitions:
       abe:
         $ref: "#/definitions/examplepbABitOfEverything"
       updateMask:
-        type: "array"
+        type: "string"
         description: "The paths to update."
-        items:
-          type: "string"
     title: "UpdateV2Request request for update includes the message and the update\
       \ mask"
   pathenumPathEnum:

--- a/examples/internal/clients/abe/api_a_bit_of_everything_service.go
+++ b/examples/internal/clients/abe/api_a_bit_of_everything_service.go
@@ -3582,13 +3582,13 @@ ABitOfEverythingServiceApiService
  * @param abeUuid
  * @param body
  * @param optional nil or *ABitOfEverythingServiceUpdateV2Opts - Optional Parameters:
-     * @param "UpdateMask" (optional.Interface of []string) -  The paths to update.
+     * @param "UpdateMask" (optional.String) -  The paths to update.
 
 @return interface{}
 */
 
 type ABitOfEverythingServiceUpdateV2Opts struct { 
-	UpdateMask optional.Interface
+	UpdateMask optional.String
 }
 
 func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV2(ctx context.Context, abeUuid string, body ExamplepbABitOfEverything, localVarOptionals *ABitOfEverythingServiceUpdateV2Opts) (interface{}, *http.Response, error) {
@@ -3609,7 +3609,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV2(ctx 
 	localVarFormParams := url.Values{}
 
 	if localVarOptionals != nil && localVarOptionals.UpdateMask.IsSet() {
-		localVarQueryParams.Add("updateMask", parameterToString(localVarOptionals.UpdateMask.Value(), "multi"))
+		localVarQueryParams.Add("updateMask", parameterToString(localVarOptionals.UpdateMask.Value(), ""))
 	}
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{"application/json", "application/x-foo-mime"}
@@ -3740,13 +3740,13 @@ ABitOfEverythingServiceApiService
  * @param abeUuid
  * @param body
  * @param optional nil or *ABitOfEverythingServiceUpdateV22Opts - Optional Parameters:
-     * @param "UpdateMask" (optional.Interface of []string) -  The paths to update.
+     * @param "UpdateMask" (optional.String) -  The paths to update.
 
 @return interface{}
 */
 
 type ABitOfEverythingServiceUpdateV22Opts struct { 
-	UpdateMask optional.Interface
+	UpdateMask optional.String
 }
 
 func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV22(ctx context.Context, abeUuid string, body ExamplepbABitOfEverything, localVarOptionals *ABitOfEverythingServiceUpdateV22Opts) (interface{}, *http.Response, error) {
@@ -3767,7 +3767,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV22(ctx
 	localVarFormParams := url.Values{}
 
 	if localVarOptionals != nil && localVarOptionals.UpdateMask.IsSet() {
-		localVarQueryParams.Add("updateMask", parameterToString(localVarOptionals.UpdateMask.Value(), "multi"))
+		localVarQueryParams.Add("updateMask", parameterToString(localVarOptionals.UpdateMask.Value(), ""))
 	}
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{"application/json", "application/x-foo-mime"}

--- a/examples/internal/clients/abe/model_examplepb_update_v2_request.go
+++ b/examples/internal/clients/abe/model_examplepb_update_v2_request.go
@@ -13,5 +13,5 @@ package abe
 type ExamplepbUpdateV2Request struct {
 	Abe *ExamplepbABitOfEverything `json:"abe,omitempty"`
 	// The paths to update.
-	UpdateMask []string `json:"updateMask,omitempty"`
+	UpdateMask string `json:"updateMask,omitempty"`
 }

--- a/examples/internal/clients/echo/api/swagger.yaml
+++ b/examples/internal/clients/echo/api/swagger.yaml
@@ -433,11 +433,9 @@ paths:
       - name: "updateMask"
         in: "query"
         required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
+        type: "string"
         x-exportParamName: "UpdateMask"
+        x-optionalDataType: "String"
       responses:
         200:
           description: "A successful response."
@@ -468,16 +466,12 @@ definitions:
       body:
         $ref: "#/definitions/examplepbDynamicMessage"
       updateMask:
-        type: "array"
-        items:
-          type: "string"
+        type: "string"
     example:
       body:
         structField: "{}"
         valueField: "{}"
-      updateMask:
-      - "updateMask"
-      - "updateMask"
+      updateMask: "updateMask"
   examplepbEmbedded:
     type: "object"
     properties:

--- a/examples/internal/clients/echo/api_echo_service.go
+++ b/examples/internal/clients/echo/api_echo_service.go
@@ -933,13 +933,13 @@ EchoServiceApiService EchoPatch method receives a NonStandardUpdateRequest and r
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param body
  * @param optional nil or *EchoServiceEchoPatchOpts - Optional Parameters:
-     * @param "UpdateMask" (optional.Interface of []string) - 
+     * @param "UpdateMask" (optional.String) - 
 
 @return ExamplepbDynamicMessageUpdate
 */
 
 type EchoServiceEchoPatchOpts struct { 
-	UpdateMask optional.Interface
+	UpdateMask optional.String
 }
 
 func (a *EchoServiceApiService) EchoServiceEchoPatch(ctx context.Context, body ExamplepbDynamicMessage, localVarOptionals *EchoServiceEchoPatchOpts) (ExamplepbDynamicMessageUpdate, *http.Response, error) {
@@ -959,7 +959,7 @@ func (a *EchoServiceApiService) EchoServiceEchoPatch(ctx context.Context, body E
 	localVarFormParams := url.Values{}
 
 	if localVarOptionals != nil && localVarOptionals.UpdateMask.IsSet() {
-		localVarQueryParams.Add("updateMask", parameterToString(localVarOptionals.UpdateMask.Value(), "multi"))
+		localVarQueryParams.Add("updateMask", parameterToString(localVarOptionals.UpdateMask.Value(), ""))
 	}
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{"application/json"}

--- a/examples/internal/clients/echo/model_examplepb_dynamic_message_update.go
+++ b/examples/internal/clients/echo/model_examplepb_dynamic_message_update.go
@@ -11,5 +11,5 @@ package echo
 
 type ExamplepbDynamicMessageUpdate struct {
 	Body *ExamplepbDynamicMessage `json:"body,omitempty"`
-	UpdateMask []string `json:"updateMask,omitempty"`
+	UpdateMask string `json:"updateMask,omitempty"`
 }

--- a/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
+++ b/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
@@ -2264,11 +2264,7 @@
             "description": "The paths to update.",
             "in": "query",
             "required": false,
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "collectionFormat": "multi"
+            "type": "string"
           }
         ],
         "tags": [
@@ -2328,11 +2324,7 @@
             "description": "The paths to update.",
             "in": "query",
             "required": false,
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "collectionFormat": "multi"
+            "type": "string"
           }
         ],
         "tags": [
@@ -3264,10 +3256,7 @@
           "$ref": "#/definitions/examplepbABitOfEverything"
         },
         "updateMask": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "type": "string",
           "description": "The paths to update."
         }
       },

--- a/examples/internal/proto/examplepb/echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/echo_service.swagger.json
@@ -526,11 +526,7 @@
             "name": "updateMask",
             "in": "query",
             "required": false,
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "collectionFormat": "multi"
+            "type": "string"
           }
         ],
         "tags": [
@@ -559,10 +555,7 @@
           "$ref": "#/definitions/examplepbDynamicMessage"
         },
         "updateMask": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "type": "string"
         }
       }
     },

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -30,10 +30,7 @@ import (
 // https://github.com/protocolbuffers/protobuf-go/blob/v1.25.0/encoding/protojson/well_known_types.go
 var wktSchemas = map[string]schemaCore{
 	".google.protobuf.FieldMask": {
-		Type: "array",
-		Items: (*openapiItemsObject)(&schemaCore{
-			Type: "string",
-		}),
+		Type: "string",
 	},
 	".google.protobuf.Timestamp": {
 		Type:   "string",

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -851,11 +851,7 @@ func TestMessageToQueryParametersWellKnownTypes(t *testing.T) {
 					Name:     "a_field_mask",
 					In:       "query",
 					Required: false,
-					Type:     "array",
-					Items: &openapiItemsObject{
-						Type: "string",
-					},
-					CollectionFormat: "multi",
+					Type:     "string",
 				},
 				{
 					Name:     "a_timestamp",
@@ -2443,10 +2439,7 @@ func TestSchemaOfField(t *testing.T) {
 			refs: make(refMap),
 			expected: openapiSchemaObject{
 				schemaCore: schemaCore{
-					Type: "array",
-					Items: &openapiItemsObject{
-						Type: "string",
-					},
+					Type: "string",
 				},
 			},
 		},


### PR DESCRIPTION
#### References to other Issues or PRs

RESOLVES https://github.com/grpc-ecosystem/grpc-gateway/issues/1816

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed
 - sets type for `FieldMask` to string
 - adjust test expectations accordingly
 - update examples generated code accordingly
 - updates `patch.md` doc to contains the corect format for the FieldMask in the example
	- also changes the case to smallCamel that is the what the Marshaler accepts
