### PR TITLE
Sets proper context property for openapi_configuration  option

### DIFF
--- a/protoc-gen-openapiv2/defs.bzl
+++ b/protoc-gen-openapiv2/defs.bzl
@@ -201,7 +201,7 @@ def _proto_gen_openapi_impl(ctx):
                     disable_default_errors = ctx.attr.disable_default_errors,
                     enums_as_ints = ctx.attr.enums_as_ints,
                     simple_operation_ids = ctx.attr.simple_operation_ids,
-                    openapi_configuration = ctx.attr.openapi_configuration,
+                    openapi_configuration = ctx.file.openapi_configuration,
                     generate_unbound_methods = ctx.attr.generate_unbound_methods,
                 ),
             ),


### PR DESCRIPTION
#### References to other Issues or PRs

RESOLVES https://github.com/grpc-ecosystem/grpc-gateway/issues/1838

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

uses proper `ctx` property to pass `openapi_configuration` option to the `_run_proto_gen_openapi`
