### PR TITLE
Fix link to "gRPC API configuration" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Make sure that your `$GOBIN` is in your `$PATH`.
       If you do not want to (or cannot) modify the proto file for use with gRPC-Gateway you can
       alternatively use an external
       [gRPC Service Configuration](https://cloud.google.com/endpoints/docs/grpc/grpc-service-config) file.
-      [Check our documentation](https://grpc-ecosystem.github.io/grpc-gateway/docs/grpcapiconfiguration.html)
+      [Check our documentation](https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/grpc_api_configuration/)
       for more information.
 
    Here's what a `protoc` execution might look like with this option enabled:


### PR DESCRIPTION
https://grpc-ecosystem.github.io/grpc-gateway/docs/grpcapiconfiguration.html leads to a 404.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

N/A

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

Fix link to "gRPC API configuration" in README. The current one leads to a 404.

#### Other comments
