### PR TITLE
Add a ## Docs section to highlight the docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ This helps you provide your APIs in both gRPC and RESTful style at the same time
 <img src="docs/assets/images/architecture_introduction_diagram.svg" />
 </div>
 
+## Docs
+
+You can read our docs at:
+
+- https://grpc-ecosystem.github.io/grpc-gateway/
+
 ## Testimonials
 
 > We use the gRPC-Gateway to serve millions of API requests per day,


### PR DESCRIPTION
#### References to other Issues or PRs

As suggested on issue grpc-ecosystem/grpc-gateway#1882
I am creating this PR to make the link to the documentation site 
more visible on the README file.

#### Brief description of what is fixed or changed

Add a `### Docs` section to the README file.

#### Other comments

It was also suggested that I created a `### Customizing your gateway` section to the README, but I don't feel qualified yet for writing this section, so I just created this first one.

It is also worth noting that the docs already have a `Customizing your gateway` section which will be very helpful if more people find this page.
