### PR TITLE
Update docs for bug fix and expanding HTTP status codes in Customizing your gateway

### DIFF
--- a/docs/docs/mapping/customizing_openapi_output.md
+++ b/docs/docs/mapping/customizing_openapi_output.md
@@ -11,7 +11,7 @@ parent: Mapping
 
 ## In proto comments
 
-You can provide comments directly in your Protocol Buffer defintions and they will be translated into comments in the generated OpenAPI definitions:
+You can provide comments directly in your Protocol Buffer definitions and they will be translated into comments in the generated OpenAPI definitions:
 
 ```protobuf
 message MyMessage {


### PR DESCRIPTION
- Calls to `ResponseWriter.Header()` should be after `delete()`. Per `Header()`:

```
// Changing the header map after a call to WriteHeader (or
// Write) has no effect unless the modified headers are
// trailers.
```

- Include a section on modeling responses in proto definitions that most closely resemble the default style. DELETE is a little off due to hard-coded behavior for `google.protobuf.Empty` in `genopenapi/template.go`, but it's close.
- Drop a small hint that `grpc.SetHeader()` has an error to be considered.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

See above.
