### PR TITLE
Multiple repeated fields are allowed

### DIFF
--- a/runtime/fieldmask.go
+++ b/runtime/fieldmask.go
@@ -88,7 +88,7 @@ func FieldMaskFromRequestBody(r io.Reader, msg proto.Message) (*field_mask.Field
 			fm.Paths = append(fm.Paths, item.path)
 		}
 	}
-	
+
 	return fm, nil
 }
 

--- a/runtime/fieldmask.go
+++ b/runtime/fieldmask.go
@@ -32,7 +32,6 @@ func FieldMaskFromRequestBody(r io.Reader, msg proto.Message) (*field_mask.Field
 	}
 
 	queue := []fieldMaskPathItem{{node: root, msg: msg.ProtoReflect()}}
-	var repeatedChild *fieldMaskPathItem
 	for len(queue) > 0 {
 		// dequeue an item
 		item := queue[0]
@@ -74,14 +73,9 @@ func FieldMaskFromRequestBody(r io.Reader, msg proto.Message) (*field_mask.Field
 
 				switch {
 				case fd.IsList(), fd.IsMap():
-					if repeatedChild != nil {
-						// This is implied by the rule that any repeated fields must be
-						// last in the paths.
-						// Ref: https://github.com/protocolbuffers/protobuf/blob/6b0ff74ecf63e26c7315f6745de36aff66deb59d/src/google/protobuf/field_mask.proto#L85-L86
-						return nil, fmt.Errorf("only one repeated value is allowed per field_mask")
-					}
-					repeatedChild = &child
-					// Don't add to paths until the end
+					// As per: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/field_mask.proto#L85-L86
+					// Do not recurse into repeated fields. The repeated field goes on the end of the path and we stop.
+					fm.Paths = append(fm.Paths, child.path)
 				case fd.Message() != nil:
 					child.msg = item.msg.Get(fd).Message()
 					fallthrough
@@ -94,13 +88,7 @@ func FieldMaskFromRequestBody(r io.Reader, msg proto.Message) (*field_mask.Field
 			fm.Paths = append(fm.Paths, item.path)
 		}
 	}
-
-	// Add any repeated fields last, as per
-	// https://github.com/protocolbuffers/protobuf/blob/6b0ff74ecf63e26c7315f6745de36aff66deb59d/src/google/protobuf/field_mask.proto#L85-L86
-	if repeatedChild != nil {
-		fm.Paths = append(fm.Paths, repeatedChild.path)
-	}
-
+	
 	return fm, nil
 }
 

--- a/runtime/fieldmask_test.go
+++ b/runtime/fieldmask_test.go
@@ -205,7 +205,7 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 						"amount": 20
 					}
 				],
-				"repeated_nested": [
+				"nested_annotation": [
 					{
 						"name": "foo",
 						"amount": 100
@@ -220,7 +220,7 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 			expected: &field_mask.FieldMask{
 				Paths: []string{
 					"nested",
-					"repeated_nested",
+					"nested_annotation",
 					"uuid",
 				},
 			},

--- a/runtime/fieldmask_test.go
+++ b/runtime/fieldmask_test.go
@@ -187,7 +187,7 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 				Paths: []string{
 					"mapped_string_value",
 					"another_string_value",
-					"uuid",					
+					"uuid",
 				},
 			},
 		},

--- a/runtime/fieldmask_test.go
+++ b/runtime/fieldmask_test.go
@@ -182,12 +182,12 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 	}{
 		{
 			name:  "map",
-			input: `{"mapped_string_value": {"a": "x"}, "uuid":"1234"}`, "another_string_value": {"b": "y"},
+			input: `{"mapped_string_value": {"a": "x"}, "another_string_value": {"b": "y"}, "uuid":"1234"}`,
 			expected: &field_mask.FieldMask{
 				Paths: []string{
 					"mapped_string_value",
-					"uuid",
 					"another_string_value",
+					"uuid",					
 				},
 			},
 		},

--- a/runtime/fieldmask_test.go
+++ b/runtime/fieldmask_test.go
@@ -185,8 +185,8 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 			input: `{"mapped_string_value": {"a": "x"}, "repeated_string_value": {"b": "y"}, "uuid":"1234"}`,
 			expected: &field_mask.FieldMask{
 				Paths: []string{
-					"mapped_string_value",
 					"repeated_string_value",
+					"mapped_string_value",					
 					"uuid",
 				},
 			},
@@ -219,8 +219,8 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 			}`,
 			expected: &field_mask.FieldMask{
 				Paths: []string{
-					"nested",
 					"nested_annotation",
+					"nested",					
 					"uuid",
 				},
 			},

--- a/runtime/fieldmask_test.go
+++ b/runtime/fieldmask_test.go
@@ -186,7 +186,7 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 			expected: &field_mask.FieldMask{
 				Paths: []string{
 					"mapped_string_value",
-					"repeated_string_value",					
+					"repeated_string_value",
 					"uuid",
 				},
 			},
@@ -220,8 +220,8 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 			expected: &field_mask.FieldMask{
 				Paths: []string{
 					"nested",
-					"uuid",
 					"nested_annotation",
+					"uuid",
 				},
 			},
 		},

--- a/runtime/fieldmask_test.go
+++ b/runtime/fieldmask_test.go
@@ -185,8 +185,8 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 			input: `{"mapped_string_value": {"a": "x"}, "repeated_string_value": {"b": "y"}, "uuid":"1234"}`,
 			expected: &field_mask.FieldMask{
 				Paths: []string{
-					"repeated_string_value",
-					"mapped_string_value",					
+					"mapped_string_value",
+					"repeated_string_value",					
 					"uuid",
 				},
 			},
@@ -219,9 +219,9 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 			}`,
 			expected: &field_mask.FieldMask{
 				Paths: []string{
-					"nested_annotation",
-					"nested",					
+					"nested",
 					"uuid",
+					"nested_annotation",
 				},
 			},
 		},

--- a/runtime/fieldmask_test.go
+++ b/runtime/fieldmask_test.go
@@ -185,8 +185,8 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 			input: `{"mapped_string_value": {"a": "x"}, "uuid":"1234"}`,
 			expected: &field_mask.FieldMask{
 				Paths: []string{
-					"uuid",
 					"mapped_string_value",
+					"uuid"
 				},
 			},
 		},

--- a/runtime/fieldmask_test.go
+++ b/runtime/fieldmask_test.go
@@ -182,11 +182,12 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 	}{
 		{
 			name:  "map",
-			input: `{"mapped_string_value": {"a": "x"}, "uuid":"1234"}`,
+			input: `{"mapped_string_value": {"a": "x"}, "uuid":"1234"}`, "another_string_value": {"b": "y"},
 			expected: &field_mask.FieldMask{
 				Paths: []string{
 					"mapped_string_value",
 					"uuid",
+					"another_string_value",
 				},
 			},
 		},
@@ -204,11 +205,22 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 						"amount": 20
 					}
 				],
+				"another_nested": [
+					{
+						"name": "foo",
+						"amount": 100
+					},
+					{
+						"name": "widget",
+						"amount": 200
+					}
+				],
 				"uuid":"1234"
 			}`,
 			expected: &field_mask.FieldMask{
 				Paths: []string{
 					"nested",
+					"another_nested",
 					"uuid",
 				},
 			},

--- a/runtime/fieldmask_test.go
+++ b/runtime/fieldmask_test.go
@@ -182,11 +182,11 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 	}{
 		{
 			name:  "map",
-			input: `{"mapped_string_value": {"a": "x"}, "another_string_value": {"b": "y"}, "uuid":"1234"}`,
+			input: `{"mapped_string_value": {"a": "x"}, "repeated_string_value": {"b": "y"}, "uuid":"1234"}`,
 			expected: &field_mask.FieldMask{
 				Paths: []string{
 					"mapped_string_value",
-					"another_string_value",
+					"repeated_string_value",
 					"uuid",
 				},
 			},
@@ -205,7 +205,7 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 						"amount": 20
 					}
 				],
-				"another_nested": [
+				"repeated_nested": [
 					{
 						"name": "foo",
 						"amount": 100
@@ -220,7 +220,7 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 			expected: &field_mask.FieldMask{
 				Paths: []string{
 					"nested",
-					"another_nested",
+					"repeated_nested",
 					"uuid",
 				},
 			},

--- a/runtime/fieldmask_test.go
+++ b/runtime/fieldmask_test.go
@@ -186,7 +186,7 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 			expected: &field_mask.FieldMask{
 				Paths: []string{
 					"mapped_string_value",
-					"uuid"
+					"uuid",
 				},
 			},
 		},

--- a/runtime/fieldmask_test.go
+++ b/runtime/fieldmask_test.go
@@ -208,8 +208,8 @@ func TestFieldMaskRepeatedFieldsLast(t *testing.T) {
 			}`,
 			expected: &field_mask.FieldMask{
 				Paths: []string{
-					"uuid",
 					"nested",
+					"uuid",
 				},
 			},
 		},


### PR DESCRIPTION
The protobuffer comments have been corrected here:
https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/field_mask.proto#L85-L86

The restriction was intended for the path string itself and not the
entire mask. There can be only one repeated field in a path string, and
when we get to it, the path string is done.

We found ourselves using multiple repeated fields in a message.

This fixes:

https://github.com/grpc-ecosystem/grpc-gateway/issues/1766
