### PR TITLE
Update protoc-gen-grpc-gateway go get command

### DIFF
--- a/docs/docs/tutorials/introduction.md
+++ b/docs/docs/tutorials/introduction.md
@@ -30,7 +30,7 @@ We will be using a Go gRPC server in the examples, so please install Go first fr
 After installing Go, use `go get` to download the following packages:
 
 ```sh
-$ go get github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway
+$ go get github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
 $ go get google.golang.org/protobuf/cmd/protoc-gen-go
 $ go get google.golang.org/grpc/cmd/protoc-gen-go-grpc
 ```


### PR DESCRIPTION
go get github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway returns an error:

Tue Jan 26 10:03 PM ~: go get github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway
package github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway: cannot find package "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway" in any of:
	/usr/lib/go-1.13/src/github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway (from $GOROOT)
	/home/userhome/go/src/github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway (from $GOPATH

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

#### Other comments
