### PR TITLE
Fix verb parsing

### DIFF
--- a/internal/descriptor/registry_test.go
+++ b/internal/descriptor/registry_test.go
@@ -780,6 +780,9 @@ func assertStringSlice(t *testing.T, message string, got, want []string) {
 	}
 }
 
+// TestVariableVerbparsing is a higher-level test than at the parser level of
+// the special logic around ensuring verbs are correctly parsed if the last
+// segment is a variable.
 func TestVariableVerbParsing(t *testing.T) {
 	reg := NewRegistry()
 	fd := loadFile(t, reg, `

--- a/internal/descriptor/registry_test.go
+++ b/internal/descriptor/registry_test.go
@@ -779,36 +779,3 @@ func assertStringSlice(t *testing.T, message string, got, want []string) {
 		}
 	}
 }
-
-// TestVariableVerbparsing is a higher-level test than at the parser level of
-// the special logic around ensuring verbs are correctly parsed if the last
-// segment is a variable.
-func TestVariableVerbParsing(t *testing.T) {
-	reg := NewRegistry()
-	fd := loadFile(t, reg, `
-		name: 'example.proto'
-		package: 'example'
-		message_type <
-			name: 'B'
-			field <
-				name: 'name'
-				label: LABEL_OPTIONAL
-				type: TYPE_STRING
-				number: 1
-			>
-		>
-		service <
-			name: "BService"
-			method <
-				name: "Meth"
-				input_type: "B"
-				output_type: "B"
-				options <
-					[google.api.http] < post: "/v1/b/{name}:foo:bar" body: "*" >
-				>
-			>
-		>
-	`)
-
-	_ = fd
-}

--- a/internal/descriptor/registry_test.go
+++ b/internal/descriptor/registry_test.go
@@ -779,3 +779,33 @@ func assertStringSlice(t *testing.T, message string, got, want []string) {
 		}
 	}
 }
+
+func TestVariableVerbParsing(t *testing.T) {
+	reg := NewRegistry()
+	fd := loadFile(t, reg, `
+		name: 'example.proto'
+		package: 'example'
+		message_type <
+			name: 'B'
+			field <
+				name: 'name'
+				label: LABEL_OPTIONAL
+				type: TYPE_STRING
+				number: 1
+			>
+		>
+		service <
+			name: "BService"
+			method <
+				name: "Meth"
+				input_type: "B"
+				output_type: "B"
+				options <
+					[google.api.http] < post: "/v1/b/{name}:foo:bar" body: "*" >
+				>
+			>
+		>
+	`)
+
+	_ = fd
+}

--- a/internal/httprule/parse_test.go
+++ b/internal/httprule/parse_test.go
@@ -13,6 +13,7 @@ func TestTokenize(t *testing.T) {
 	for _, spec := range []struct {
 		src    string
 		tokens []string
+		verb   string
 	}{
 		{
 			src:    "",
@@ -81,22 +82,51 @@ func TestTokenize(t *testing.T) {
 				eof,
 			},
 		},
+		{
+			src: "v1/a/{endpoint}:a",
+			tokens: []string{
+				"v1", "/",
+				"a", "/",
+				"{", "endpoint", "}",
+				eof,
+			},
+			verb: "a",
+		},
+		{
+			src: "v1/a/{endpoint}:a:b",
+			tokens: []string{
+				"v1", "/",
+				"a", "/",
+				"{", "endpoint", "}",
+				eof,
+			},
+			verb: "a:b",
+		},
 	} {
 		tokens, verb := tokenize(spec.src)
 		if got, want := tokens, spec.tokens; !reflect.DeepEqual(got, want) {
 			t.Errorf("tokenize(%q) = %q, _; want %q, _", spec.src, got, want)
 		}
-		if got, want := verb, ""; got != want {
-			t.Errorf("tokenize(%q) = _, %q; want _, %q", spec.src, got, want)
-		}
 
-		src := fmt.Sprintf("%s:%s", spec.src, "LOCK")
-		tokens, verb = tokenize(src)
-		if got, want := tokens, spec.tokens; !reflect.DeepEqual(got, want) {
-			t.Errorf("tokenize(%q) = %q, _; want %q, _", src, got, want)
-		}
-		if got, want := verb, "LOCK"; got != want {
-			t.Errorf("tokenize(%q) = _, %q; want _, %q", src, got, want)
+		switch {
+		case spec.verb != "":
+			if got, want := verb, spec.verb; !reflect.DeepEqual(got, want) {
+				t.Errorf("tokenize(%q) = %q, _; want %q, _", spec.src, got, want)
+			}
+
+		default:
+			if got, want := verb, ""; got != want {
+				t.Errorf("tokenize(%q) = _, %q; want _, %q", spec.src, got, want)
+			}
+
+			src := fmt.Sprintf("%s:%s", spec.src, "LOCK")
+			tokens, verb = tokenize(src)
+			if got, want := tokens, spec.tokens; !reflect.DeepEqual(got, want) {
+				t.Errorf("tokenize(%q) = %q, _; want %q, _", src, got, want)
+			}
+			if got, want := verb, "LOCK"; got != want {
+				t.Errorf("tokenize(%q) = _, %q; want _, %q", src, got, want)
+			}
 		}
 	}
 }
@@ -209,7 +239,8 @@ func TestParseSegments(t *testing.T) {
 				"a", "/", "b", "/", "*", "/", "c",
 				"}", "/",
 				"**",
-				eof},
+				eof,
+			},
 			want: []segment{
 				literal("v1"),
 				variable{

--- a/internal/httprule/parse_test.go
+++ b/internal/httprule/parse_test.go
@@ -93,14 +93,14 @@ func TestTokenize(t *testing.T) {
 			verb: "a",
 		},
 		{
-			src: "v1/a/{endpoint}:a:b",
+			src: "v1/a/{endpoint}:b:c",
 			tokens: []string{
 				"v1", "/",
 				"a", "/",
 				"{", "endpoint", "}",
 				eof,
 			},
-			verb: "a:b",
+			verb: "b:c",
 		},
 	} {
 		tokens, verb := tokenize(spec.src)

--- a/runtime/mux_test.go
+++ b/runtime/mux_test.go
@@ -308,6 +308,28 @@ func TestMuxServeHTTP(t *testing.T) {
 			},
 			respStatus: http.StatusBadRequest,
 		},
+		{
+			patterns: []stubPattern{
+				{
+					method: "POST",
+					ops:    []int{int(utilities.OpLitPush), 0, int(utilities.OpPush), 0, int(utilities.OpConcatN), 1, int(utilities.OpCapture), 1},
+					pool:   []string{"foo", "id"},
+				},
+				{
+					method: "POST",
+					ops:    []int{int(utilities.OpLitPush), 0, int(utilities.OpPush), 0, int(utilities.OpConcatN), 1, int(utilities.OpCapture), 1},
+					pool:   []string{"foo", "id"},
+					verb:   "verb:subverb",
+				},
+			},
+			reqMethod: "POST",
+			reqPath:   "/foo/bar:verb:subverb",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+			},
+			respStatus:  http.StatusOK,
+			respContent: "POST /foo/{id=*}:verb:subverb",
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			var opts []runtime.ServeMuxOption
@@ -437,5 +459,4 @@ func TestServeMux_HandlePath(t *testing.T) {
 			}
 		})
 	}
-
 }


### PR DESCRIPTION
This is a long description for a very small change, apologies.

According to http.proto
(https://github.com/grpc-ecosystem/grpc-gateway/blob/master/third_party/googleapis/google/api/http.proto#L232)
the path template consists of a slash, one or more segments, and a verb.
The verb is specified as ':' followed by a LITERAL that matches literal
text in the path.

In the upstream http.proto
(https://github.com/googleapis/googleapis/blob/master/google/api/http.proto#L242)
they expand on the meaning of this:

> The syntax `LITERAL` matches literal text in the URL path. If the
> `LITERAL` contains any reserved character, such characters should be
> percent-encoded before the matching.

Unfortunately it doesn't say which characters are reserved. In some cases
it follows RFC 6570 (which reserves colon in some instances) and in
other cases it doesn't.

The intent, however, is pretty clear: after any segments, which are
delimited with a slash, a colon followed by a string indicates a verb.

The problem is that currently in some cases this parsing fails within
the generator. This works, but if you examine the generated code you'll
see that the verb is considered to be "e" rather than "d:e":

> /a/b/c:d:e

However if there is a path variable:

> /a/b/{name}:d:e

it simply errors out during generation.

The problem appears to be that when looking for the verb, it looks for
the last index of a colon instead of the first. This changes the logic
to look for the _first_ index of a colon. As you can see from the
associated test cases, this results in the behavior that a verb that
itself contains a colon is parsed as a verb.

There is a potential drawback, which is that if we suppose that
according to the spec a LITERAL can contain a colon, it means a LITERAL
in a segment can also contain a colon. So in reality you can never know
whether parsing the first or last colon is actually the right thing to
do when trying to figure out the verb.

Arguably, the only way to truly fix this would be to implement a custom
option that indicates what the desired verb is.
