### PR TITLE
docs/Gemfile.lock: Fix dependabot security warning

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
       liquid (= 4.0.3)
       mercenary (~> 0.3)
       minima (= 2.5.1)
-      nokogiri (>= 1.10.4, < 2.0)
+      nokogiri (>= 1.11.0, < 2.0)
       rouge (= 3.23.0)
       terminal-table (~> 1.4)
     github-pages-health-check (1.16.1)


### PR DESCRIPTION
Quoting:

> 1 nokogiri vulnerability found in docs/Gemfile.lock on Dec 31, 2020
>
> ## Remediation
>
> Upgrade nokogiri to version 1.11.0 or later. For example:
>
> ```
> gem "nokogiri", ">= 1.11.0"
> ```
>
> Always verify the validity and compatibility of suggestions with your codebase.
>
> Details
>
> - GHSA-vr8q-g5c7-m54m
> - low severity
> - Vulnerable versions: <= 1.10.10
> -Patched version: 1.11.0
>
> ## Severity
>
> Nokogiri maintainers have evaluated this as Low Severity (CVSS3 2.6).

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->


#### Brief description of what is fixed or changed

Bumps the nokogiri version per https://github.com/grpc-ecosystem/grpc-gateway/security/dependabot/docs/Gemfile.lock/nokogiri/open

#### Other comments

I'm not a rubyista, but this single line change seems safe.

See alert here: https://github.com/grpc-ecosystem/grpc-gateway/security/dependabot/docs/Gemfile.lock/nokogiri/open (link might break once the issue is resolved)