### PR TITLE
Add an additional OpenAPI naming strategy to fix issues with OpenAPI names

### DIFF
--- a/internal/descriptor/registry.go
+++ b/internal/descriptor/registry.go
@@ -66,6 +66,8 @@ type Registry struct {
 	// all the elements of the FQN without any separator
 	useFQNForOpenAPIName bool
 
+	openAPINamingStrategy string
+
 	// useGoTemplate determines whether you want to use GO templates
 	// in your protofile comments
 	useGoTemplate bool
@@ -118,12 +120,13 @@ type repeatedFieldSeparator struct {
 // NewRegistry returns a new Registry.
 func NewRegistry() *Registry {
 	return &Registry{
-		msgs:              make(map[string]*Message),
-		enums:             make(map[string]*Enum),
-		files:             make(map[string]*File),
-		pkgMap:            make(map[string]string),
-		pkgAliases:        make(map[string]string),
-		externalHTTPRules: make(map[string][]*annotations.HttpRule),
+		msgs:                  make(map[string]*Message),
+		enums:                 make(map[string]*Enum),
+		files:                 make(map[string]*File),
+		pkgMap:                make(map[string]string),
+		pkgAliases:            make(map[string]string),
+		openAPINamingStrategy: "legacy",
+		externalHTTPRules:     make(map[string][]*annotations.HttpRule),
 		repeatedPathParamSeparator: repeatedFieldSeparator{
 			name: "csv",
 			sep:  ',',
@@ -474,14 +477,26 @@ func (r *Registry) GetUseJSONNamesForFields() bool {
 	return r.useJSONNamesForFields
 }
 
-// SetUseFQNForOpenAPIName sets useFQNForOpenAPIName
-func (r *Registry) SetUseFQNForOpenAPIName(use bool) {
-	r.useFQNForOpenAPIName = use
+// SetOpenAPINamingStrategy sets the naming strategy to be used.
+func (r *Registry) SetOpenAPINamingStrategy(strategy string) {
+	r.openAPINamingStrategy = strategy
 }
 
-// GetUseFQNForOpenAPIName returns useFQNForOpenAPIName
+// GetOpenAPINamingStrategy retrieves the naming strategy that is in use.
+func (r *Registry) GetOpenAPINamingStrategy() string {
+	return r.openAPINamingStrategy
+}
+
+// SetUseFQNForOpenAPIName sets useFQNForOpenAPIName
+// Deprecated: use SetOpenAPINamingStrategy instead.
+func (r *Registry) SetUseFQNForOpenAPIName(use bool) {
+	r.openAPINamingStrategy = "fqn"
+}
+
+// GetUseFQNForOpenAPIName returns useFQNForOpenAPIName.
+// Deprecated: Use GetOpenAPINamingStrategy().
 func (r *Registry) GetUseFQNForOpenAPIName() bool {
-	return r.useFQNForOpenAPIName
+	return r.openAPINamingStrategy == "fqn"
 }
 
 // GetMergeFileName return the target merge OpenAPI file name

--- a/internal/descriptor/registry.go
+++ b/internal/descriptor/registry.go
@@ -60,12 +60,14 @@ type Registry struct {
 	// with gRPC-Gateway response, if it uses json tags for marshaling.
 	useJSONNamesForFields bool
 
-	// useFQNForOpenAPIName if true OpenAPI names will use the full qualified name (FQN) from proto definition,
-	// and generate a dot-separated OpenAPI name concatenating all elements from the proto FQN.
-	// If false, the default behavior is to concat the last 2 elements of the FQN if they are unique, otherwise concat
-	// all the elements of the FQN without any separator
-	useFQNForOpenAPIName bool
-
+	// openAPINamingStrategy is the naming strategy to use for assigning OpenAPI name. This can be one of the following:
+	// - `legacy`: use the legacy naming strategy from protoc-gen-swagger, that generates unique but not necessarily
+	//             maximally concise names. Components are concatenated directly, e.g., `MyOuterMessageMyNestedMessage`.
+	// - `simple`: use a simple heuristic for generating unique and concise names. Components are concatenated using
+	//             dots as a separator, e.g., `MyOuterMesage.MyNestedMessage` (if `MyNestedMessage` alone is unique,
+	//             `MyNestedMessage` will be used as the OpenAPI name).
+	// - `fqn`:    always use the fully-qualified name of the proto message (leading dot removed) as the OpenAPI
+	//             name.
 	openAPINamingStrategy string
 
 	// useGoTemplate determines whether you want to use GO templates
@@ -125,8 +127,8 @@ func NewRegistry() *Registry {
 		files:                 make(map[string]*File),
 		pkgMap:                make(map[string]string),
 		pkgAliases:            make(map[string]string),
-		openAPINamingStrategy: "legacy",
 		externalHTTPRules:     make(map[string][]*annotations.HttpRule),
+		openAPINamingStrategy: "legacy",
 		repeatedPathParamSeparator: repeatedFieldSeparator{
 			name: "csv",
 			sep:  ',',

--- a/internal/descriptor/registry.go
+++ b/internal/descriptor/registry.go
@@ -60,7 +60,7 @@ type Registry struct {
 	// with gRPC-Gateway response, if it uses json tags for marshaling.
 	useJSONNamesForFields bool
 
-	// openAPINamingStrategy is the naming strategy to use for assigning OpenAPI name. This can be one of the following:
+	// openAPINamingStrategy is the naming strategy to use for assigning OpenAPI field and parameter names. This can be one of the following:
 	// - `legacy`: use the legacy naming strategy from protoc-gen-swagger, that generates unique but not necessarily
 	//             maximally concise names. Components are concatenated directly, e.g., `MyOuterMessageMyNestedMessage`.
 	// - `simple`: use a simple heuristic for generating unique and concise names. Components are concatenated using

--- a/protoc-gen-openapiv2/defs.bzl
+++ b/protoc-gen-openapiv2/defs.bzl
@@ -58,6 +58,7 @@ def _run_proto_gen_openapi(
         repeated_path_param_separator,
         include_package_in_tags,
         fqn_for_openapi_name,
+        openapi_naming_strategy,
         use_go_templates,
         disable_default_errors,
         enums_as_ints,
@@ -85,6 +86,9 @@ def _run_proto_gen_openapi(
 
     if fqn_for_openapi_name:
         args.add("--openapiv2_opt", "fqn_for_openapi_name=true")
+
+    if openapi_naming_strategy:
+        args.add("--openapiv2_opt", "openapi_naming_strategy=%s" % openapi_naming_strategy)
 
     if generate_unbound_methods:
         args.add("--openapiv2_opt", "generate_unbound_methods=true")
@@ -197,6 +201,7 @@ def _proto_gen_openapi_impl(ctx):
                     repeated_path_param_separator = ctx.attr.repeated_path_param_separator,
                     include_package_in_tags = ctx.attr.include_package_in_tags,
                     fqn_for_openapi_name = ctx.attr.fqn_for_openapi_name,
+                    openapi_naming_strategy = ctx.attr.openapi_naming_strategy,
                     use_go_templates = ctx.attr.use_go_templates,
                     disable_default_errors = ctx.attr.disable_default_errors,
                     enums_as_ints = ctx.attr.enums_as_ints,
@@ -254,7 +259,16 @@ protoc_gen_openapiv2 = rule(
             mandatory = False,
             doc = "if set, the object's OpenAPI names will use the fully" +
                   " qualified names from the proto definition" +
-                  " (ie my.package.MyMessage.MyInnerMessage",
+                  " (ie my.package.MyMessage.MyInnerMessage)",
+        ),
+        "openapi_naming_strategy": attr.string(
+            default = "",
+            mandatory = False,
+            values = ["", "simple", "legacy", "fqn"],
+            doc = "configures how OpenAPI names are determined." +
+                  " Allowed values are `` (empty), `simple`, `legacy` and `fqn`." +
+                  " If unset, either `legacy` or `fqn` are selected, depending" +
+                  " on the value of the `fqn_for_openapi_name` setting",
         ),
         "use_go_templates": attr.bool(
             default = False,

--- a/protoc-gen-openapiv2/internal/genopenapi/BUILD.bazel
+++ b/protoc-gen-openapiv2/internal/genopenapi/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "generator.go",
         "helpers.go",
         "helpers_go111_old.go",
+        "naming.go",
         "template.go",
         "types.go",
     ],
@@ -34,7 +35,10 @@ go_library(
 go_test(
     name = "go_default_test",
     size = "small",
-    srcs = ["template_test.go"],
+    srcs = [
+        "naming_test.go",
+        "template_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//internal/descriptor:go_default_library",

--- a/protoc-gen-openapiv2/internal/genopenapi/naming.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/naming.go
@@ -10,7 +10,7 @@ import (
 // fully-qualified proto message names, and returns a mapping from fully-qualified
 // name to OpenAPI name.
 func LookupNamingStrategy(strategyName string) func([]string) map[string]string {
-	switch strategyName {
+	switch strings.ToLower(strategyName) {
 	case "fqn":
 		return resolveNamesFQN
 	case "legacy":
@@ -32,7 +32,7 @@ func resolveNamesFQN(messages []string) map[string]string {
 	return uniqueNames
 }
 
-// resolveNamesLegacy takes the names of all protos and uniq-ifies them applying the legacy
+// resolveNamesLegacy takes the names of all proto messages and generates unique references by applying the legacy
 // heuristics for deriving unique names: starting from the bottom of the name hierarchy, it
 // determines the minimum number of components necessary to yield a unique name, adds one
 // to that number, and then concatenates those last components with no separator in between
@@ -44,7 +44,7 @@ func resolveNamesLegacy(messages []string) map[string]string {
 	return resolveNamesUniqueWithContext(messages, 1, "")
 }
 
-// resolveNamesSimple takes the names of all protos and uniq-ifies them using a simple
+// resolveNamesSimple takes the names of all proto messages and generates unique references by using a simple
 // heuristic: starting from the bottom of the name hierarchy, it determines the minimum
 // number of components necessary to yield a unique name, and then concatenates those last
 // components with a "." separator in between to form a unique name.
@@ -55,12 +55,11 @@ func resolveNamesSimple(messages []string) map[string]string {
 	return resolveNamesUniqueWithContext(messages, 0, ".")
 }
 
-// Take the names of every proto and "uniq-ify" them as follows:
-// first, separate each message name into its components by splitting at dots. Then,
+// Take the names of every proto message and generates a unique reference by:
+// first, separating each message name into its components by splitting at dots. Then,
 // take the shortest suffix slice from each components slice that is unique among all
 // messages, and convert it into a component name by taking extraContext additional
-// components into consideration and joining all components with componentSeparator
-// in between.
+// components into consideration and joining all components with componentSeparator.
 func resolveNamesUniqueWithContext(messages []string, extraContext int, componentSeparator string) map[string]string {
 	packagesByDepth := make(map[int][][]string)
 	uniqueNames := make(map[string]string)

--- a/protoc-gen-openapiv2/internal/genopenapi/naming.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/naming.go
@@ -1,0 +1,112 @@
+package genopenapi
+
+import (
+	"reflect"
+	"strings"
+)
+
+// LookupNamingStrategy looks up the given naming strategy and returns the naming
+// strategy function for it. The naming strategy function takes in the list of all
+// fully-qualified proto message names, and returns a mapping from fully-qualified
+// name to OpenAPI name.
+func LookupNamingStrategy(strategyName string) func([]string) map[string]string {
+	switch strategyName {
+	case "fqn":
+		return resolveNamesFQN
+	case "legacy":
+		return resolveNamesLegacy
+	case "simple":
+		return resolveNamesSimple
+	}
+	return nil
+}
+
+// resolveNamesFQN uses the fully-qualified proto message name as the
+// OpenAPI name, stripping the leading dot.
+func resolveNamesFQN(messages []string) map[string]string {
+	uniqueNames := make(map[string]string, len(messages))
+	for _, p := range messages {
+		// strip leading dot from proto fqn
+		uniqueNames[p] = p[1:]
+	}
+	return uniqueNames
+}
+
+// resolveNamesLegacy takes the names of all protos and uniq-ifies them applying the legacy
+// heuristics for deriving unique names: starting from the bottom of the name hierarchy, it
+// determines the minimum number of components necessary to yield a unique name, adds one
+// to that number, and then concatenates those last components with no separator in between
+// to form a unique name.
+//
+// E.g., if the fully qualified name is `.a.b.C.D`, and there are other messages with fully
+// qualified names ending in `.D` but not in `.C.D`, it assigns the unique name `bCD`.
+func resolveNamesLegacy(messages []string) map[string]string {
+	return resolveNamesUniqueWithContext(messages, 1, "")
+}
+
+// resolveNamesSimple takes the names of all protos and uniq-ifies them using a simple
+// heuristic: starting from the bottom of the name hierarchy, it determines the minimum
+// number of components necessary to yield a unique name, and then concatenates those last
+// components with a "." separator in between to form a unique name.
+//
+// E.g., if the fully qualified name is `.a.b.C.D`, and there are other messages with
+// fully qualified names ending in `.D` but not in `.C.D`, it assigns the unique name `C.D`.
+func resolveNamesSimple(messages []string) map[string]string {
+	return resolveNamesUniqueWithContext(messages, 0, ".")
+}
+
+// Take the names of every proto and "uniq-ify" them. The idea is to produce a
+// set of names that meet a couple of conditions. They must be stable, they
+// must be unique, and they must be shorter than the FQN.
+//
+// This likely could be made better. This will always generate the same names
+// but may not always produce optimal names. This is a reasonably close
+// approximation of what they should look like in most cases.
+func resolveNamesUniqueWithContext(messages []string, extraContext int, componentSeparator string) map[string]string {
+	packagesByDepth := make(map[int][][]string)
+	uniqueNames := make(map[string]string)
+
+	hierarchy := func(pkg string) []string {
+		return strings.Split(pkg, ".")
+	}
+
+	for _, p := range messages {
+		h := hierarchy(p)
+		for depth := range h {
+			if _, ok := packagesByDepth[depth]; !ok {
+				packagesByDepth[depth] = make([][]string, 0)
+			}
+			packagesByDepth[depth] = append(packagesByDepth[depth], h[len(h)-depth:])
+		}
+	}
+
+	count := func(list [][]string, item []string) int {
+		i := 0
+		for _, element := range list {
+			if reflect.DeepEqual(element, item) {
+				i++
+			}
+		}
+		return i
+	}
+
+	for _, p := range messages {
+		h := hierarchy(p)
+		depth := 0
+		for ; depth < len(h); depth++ {
+			// depth + extraContext > 0 ensures that we only break for values of depth when the
+			// resulting slice of name components is non-empty. Otherwise, we would return the
+			// empty string as the concise unique name is len(messages) == 1 (which is
+			// technically correct).
+			if depth+extraContext > 0 && count(packagesByDepth[depth], h[len(h)-depth:]) == 1 {
+				break
+			}
+		}
+		start := len(h) - depth - extraContext
+		if start < 0 {
+			start = 0
+		}
+		uniqueNames[p] = strings.Join(h[start:], componentSeparator)
+	}
+	return uniqueNames
+}

--- a/protoc-gen-openapiv2/internal/genopenapi/naming.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/naming.go
@@ -55,13 +55,12 @@ func resolveNamesSimple(messages []string) map[string]string {
 	return resolveNamesUniqueWithContext(messages, 0, ".")
 }
 
-// Take the names of every proto and "uniq-ify" them. The idea is to produce a
-// set of names that meet a couple of conditions. They must be stable, they
-// must be unique, and they must be shorter than the FQN.
-//
-// This likely could be made better. This will always generate the same names
-// but may not always produce optimal names. This is a reasonably close
-// approximation of what they should look like in most cases.
+// Take the names of every proto and "uniq-ify" them as follows:
+// first, separate each message name into its components by splitting at dots. Then,
+// take the shortest suffix slice from each components slice that is unique among all
+// messages, and convert it into a component name by taking extraContext additional
+// components into consideration and joining all components with componentSeparator
+// in between.
 func resolveNamesUniqueWithContext(messages []string, extraContext int, componentSeparator string) map[string]string {
 	packagesByDepth := make(map[int][][]string)
 	uniqueNames := make(map[string]string)

--- a/protoc-gen-openapiv2/internal/genopenapi/naming_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/naming_test.go
@@ -1,0 +1,53 @@
+package genopenapi
+
+import "testing"
+
+func TestNaming(t *testing.T) {
+	type expectedNames struct {
+		fqn, legacy, simple string
+	}
+	messageNameToExpected := map[string]expectedNames{
+		".A":     {"A", "A", "A"},
+		".a.B.C": {"a.B.C", "aBC", "B.C"},
+		".a.D.C": {"a.D.C", "aDC", "D.C"},
+		".a.E.F": {"a.E.F", "aEF", "a.E.F"},
+		".b.E.F": {"b.E.F", "bEF", "b.E.F"},
+		".c.G.H": {"c.G.H", "GH", "H"},
+	}
+
+	allMessageNames := make([]string, 0, len(messageNameToExpected))
+	for msgName := range messageNameToExpected {
+		allMessageNames = append(allMessageNames, msgName)
+	}
+
+	t.Run("fqn", func(t *testing.T) {
+		uniqueNames := resolveNamesFQN(allMessageNames)
+		for _, msgName := range allMessageNames {
+			expected := messageNameToExpected[msgName].fqn
+			actual := uniqueNames[msgName]
+			if expected != actual {
+				t.Errorf("fqn unique name %q does not match expected name %q", actual, expected)
+			}
+		}
+	})
+	t.Run("legacy", func(t *testing.T) {
+		uniqueNames := resolveNamesLegacy(allMessageNames)
+		for _, msgName := range allMessageNames {
+			expected := messageNameToExpected[msgName].legacy
+			actual := uniqueNames[msgName]
+			if expected != actual {
+				t.Errorf("legacy unique name %q does not match expected name %q", actual, expected)
+			}
+		}
+	})
+	t.Run("simple", func(t *testing.T) {
+		uniqueNames := resolveNamesSimple(allMessageNames)
+		for _, msgName := range allMessageNames {
+			expected := messageNameToExpected[msgName].simple
+			actual := uniqueNames[msgName]
+			if expected != actual {
+				t.Errorf("simple unique name %q does not match expected name %q", actual, expected)
+			}
+		}
+	})
+}

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -648,7 +648,7 @@ func lookupMsgAndOpenAPIName(location, name string, reg *descriptor.Registry) (*
 var registriesSeen = map[*descriptor.Registry]map[string]string{}
 var registriesSeenMutex sync.Mutex
 
-// Take the names of every proto and "uniq-ify" them, according to the given strategy.
+// Take the names of every proto message and generate a unique reference for each, according to the given strategy.
 func resolveFullyQualifiedNameToOpenAPINames(messages []string, namingStrategy string) map[string]string {
 	strategyFn := LookupNamingStrategy(namingStrategy)
 	if strategyFn == nil {

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -648,13 +648,7 @@ func lookupMsgAndOpenAPIName(location, name string, reg *descriptor.Registry) (*
 var registriesSeen = map[*descriptor.Registry]map[string]string{}
 var registriesSeenMutex sync.Mutex
 
-// Take the names of every proto and "uniq-ify" them. The idea is to produce a
-// set of names that meet a couple of conditions. They must be stable, they
-// must be unique, and they must be shorter than the FQN.
-//
-// This likely could be made better. This will always generate the same names
-// but may not always produce optimal names. This is a reasonably close
-// approximation of what they should look like in most cases.
+// Take the names of every proto and "uniq-ify" them, according to the given strategy.
 func resolveFullyQualifiedNameToOpenAPINames(messages []string, namingStrategy string) map[string]string {
 	strategyFn := LookupNamingStrategy(namingStrategy)
 	if strategyFn == nil {

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -2854,10 +2854,10 @@ func BenchmarkTemplateToOpenAPIPath(b *testing.B) {
 
 func TestResolveFullyQualifiedNameToOpenAPIName(t *testing.T) {
 	var tests = []struct {
-		input                string
-		output               string
-		listOfFQMNs          []string
-		useFQNForOpenAPIName bool
+		input          string
+		output         string
+		listOfFQMNs    []string
+		namingStrategy string
 	}{
 		{
 			".a.b.C",
@@ -2865,7 +2865,15 @@ func TestResolveFullyQualifiedNameToOpenAPIName(t *testing.T) {
 			[]string{
 				".a.b.C",
 			},
-			false,
+			"legacy",
+		},
+		{
+			".a.b.C",
+			"C",
+			[]string{
+				".a.b.C",
+			},
+			"simple",
 		},
 		{
 			".a.b.C",
@@ -2874,7 +2882,16 @@ func TestResolveFullyQualifiedNameToOpenAPIName(t *testing.T) {
 				".a.C",
 				".a.b.C",
 			},
-			false,
+			"legacy",
+		},
+		{
+			".a.b.C",
+			"b.C",
+			[]string{
+				".a.C",
+				".a.b.C",
+			},
+			"simple",
 		},
 		{
 			".a.b.C",
@@ -2884,7 +2901,17 @@ func TestResolveFullyQualifiedNameToOpenAPIName(t *testing.T) {
 				".a.C",
 				".a.b.C",
 			},
-			false,
+			"legacy",
+		},
+		{
+			".a.b.C",
+			"b.C",
+			[]string{
+				".C",
+				".a.C",
+				".a.b.C",
+			},
+			"simple",
 		},
 		{
 			".a.b.C",
@@ -2894,16 +2921,16 @@ func TestResolveFullyQualifiedNameToOpenAPIName(t *testing.T) {
 				".a.C",
 				".a.b.C",
 			},
-			true,
+			"fqn",
 		},
 	}
 
 	for _, data := range tests {
-		names := resolveFullyQualifiedNameToOpenAPINames(data.listOfFQMNs, data.useFQNForOpenAPIName)
+		names := resolveFullyQualifiedNameToOpenAPINames(data.listOfFQMNs, data.namingStrategy)
 		output := names[data.input]
 		if output != data.output {
-			t.Errorf("Expected fullyQualifiedNameToOpenAPIName(%v) to be %s but got %s",
-				data.input, data.output, output)
+			t.Errorf("Expected fullyQualifiedNameToOpenAPIName(%v, %s) to be %s but got %s",
+				data.input, data.namingStrategy, data.output, output)
 		}
 	}
 }

--- a/protoc-gen-openapiv2/main.go
+++ b/protoc-gen-openapiv2/main.go
@@ -85,18 +85,15 @@ func main() {
 	reg.SetAllowRepeatedFieldsInBody(*allowRepeatedFieldsInBody)
 	reg.SetIncludePackageInTags(*includePackageInTags)
 
-	legacyNamingStrategy := "legacy"
-	if *useFQNForOpenAPIName {
-		glog.Warning("The `fqn_for_openapi_name` flag is deprecated. Please use `-openapi_naming_strategy=fqn` instead.")
-		legacyNamingStrategy = "fqn"
-	}
 	namingStrategy := *openAPINamingStrategy
-	if namingStrategy == "" {
-		namingStrategy = legacyNamingStrategy
-	} else if namingStrategy != legacyNamingStrategy {
-		// this means that *useFQNForOpenAPIName is true, and *openAPINamingStrategy was set to
-		// a value other than "fqn".
-		glog.Fatal("The `openapi_naming_strategy` flag must be set to `fqn` or remain unset if `fqn_for_openapi_name` is set.")
+	if *useFQNForOpenAPIName {
+		if namingStrategy != "" {
+			glog.Fatal("The deprecated `fqn_for_openapi_name` flag must remain unset if `openapi_naming_strategy` is set.")
+		}
+		glog.Warning("The `fqn_for_openapi_name` flag is deprecated. Please use `openapi_naming_strategy=fqn` instead.")
+		namingStrategy = "fqn"
+	} else if namingStrategy == "" {
+		namingStrategy = "legacy"
 	}
 	if strategyFn := genopenapi.LookupNamingStrategy(namingStrategy); strategyFn == nil {
 		emitError(fmt.Errorf("invalid naming strategy %q", namingStrategy))

--- a/protoc-gen-openapiv2/main.go
+++ b/protoc-gen-openapiv2/main.go
@@ -26,7 +26,7 @@ var (
 	versionFlag                = flag.Bool("version", false, "print the current version")
 	allowRepeatedFieldsInBody  = flag.Bool("allow_repeated_fields_in_body", false, "allows to use repeated field in `body` and `response_body` field of `google.api.http` annotation option")
 	includePackageInTags       = flag.Bool("include_package_in_tags", false, "if unset, the gRPC service name is added to the `Tags` field of each operation. If set and the `package` directive is shown in the proto file, the package name will be prepended to the service name")
-	useFQNForOpenAPIName       = flag.Bool("fqn_for_openapi_name", false, "if set, the object's OpenAPI names will use the fully qualified names from the proto definition (ie my.package.MyMessage.MyInnerMessage")
+	useFQNForOpenAPIName       = flag.Bool("fqn_for_openapi_name", false, "if set, the object's OpenAPI names will use the fully qualified names from the proto definition (ie my.package.MyMessage.MyInnerMessage). DEPRECATED: prefer `openapi_naming_strategy=fqn`")
 	openAPINamingStrategy      = flag.String("openapi_naming_strategy", "", "use the given OpenAPI naming strategy. Allowed values are `legacy`, `fqn`, `simple`. If unset, either `legacy` or `fqn` are selected, depending on the value of the `fqn_for_openapi_name` flag")
 	useGoTemplate              = flag.Bool("use_go_templates", false, "if set, you can use Go templates in protofile comments")
 	disableDefaultErrors       = flag.Bool("disable_default_errors", false, "if set, disables generation of default errors. This is useful if you have defined custom error handling")
@@ -85,6 +85,8 @@ func main() {
 	reg.SetAllowRepeatedFieldsInBody(*allowRepeatedFieldsInBody)
 	reg.SetIncludePackageInTags(*includePackageInTags)
 
+	// Set the naming strategy either directly from the flag, or via the value of the legacy fqn_for_openapi_name
+	// flag.
 	namingStrategy := *openAPINamingStrategy
 	if *useFQNForOpenAPIName {
 		if namingStrategy != "" {

--- a/protoc-gen-openapiv2/main.go
+++ b/protoc-gen-openapiv2/main.go
@@ -27,6 +27,7 @@ var (
 	allowRepeatedFieldsInBody  = flag.Bool("allow_repeated_fields_in_body", false, "allows to use repeated field in `body` and `response_body` field of `google.api.http` annotation option")
 	includePackageInTags       = flag.Bool("include_package_in_tags", false, "if unset, the gRPC service name is added to the `Tags` field of each operation. If set and the `package` directive is shown in the proto file, the package name will be prepended to the service name")
 	useFQNForOpenAPIName       = flag.Bool("fqn_for_openapi_name", false, "if set, the object's OpenAPI names will use the fully qualified names from the proto definition (ie my.package.MyMessage.MyInnerMessage")
+	openAPINamingStrategy      = flag.String("openapi_naming_strategy", "", "use the given OpenAPI naming strategy. Allowed values are `legacy`, `fqn`, `simple`. If unset, either `legacy` or `fqn` are selected, depending on the value of the `fqn_for_openapi_name` flag")
 	useGoTemplate              = flag.Bool("use_go_templates", false, "if set, you can use Go templates in protofile comments")
 	disableDefaultErrors       = flag.Bool("disable_default_errors", false, "if set, disables generation of default errors. This is useful if you have defined custom error handling")
 	enumsAsInts                = flag.Bool("enums_as_ints", false, "whether to render enum values as integers, as opposed to string values")
@@ -83,7 +84,25 @@ func main() {
 	reg.SetUseJSONNamesForFields(*useJSONNamesForFields)
 	reg.SetAllowRepeatedFieldsInBody(*allowRepeatedFieldsInBody)
 	reg.SetIncludePackageInTags(*includePackageInTags)
-	reg.SetUseFQNForOpenAPIName(*useFQNForOpenAPIName)
+
+	legacyNamingStrategy := "legacy"
+	if *useFQNForOpenAPIName {
+		glog.Warning("The `fqn_for_openapi_name` flag is deprecated. Please use `-openapi_naming_strategy=fqn` instead.")
+		legacyNamingStrategy = "fqn"
+	}
+	namingStrategy := *openAPINamingStrategy
+	if namingStrategy == "" {
+		namingStrategy = legacyNamingStrategy
+	} else if namingStrategy != legacyNamingStrategy {
+		// this means that *useFQNForOpenAPIName is true, and *openAPINamingStrategy was set to
+		// a value other than "fqn".
+		glog.Fatal("The `openapi_naming_strategy` flag must be set to `fqn` or remain unset if `fqn_for_openapi_name` is set.")
+	}
+	if strategyFn := genopenapi.LookupNamingStrategy(namingStrategy); strategyFn == nil {
+		emitError(fmt.Errorf("invalid naming strategy %q", namingStrategy))
+		return
+	}
+	reg.SetOpenAPINamingStrategy(namingStrategy)
 	reg.SetUseGoTemplate(*useGoTemplate)
 	reg.SetEnumsAsInts(*enumsAsInts)
 	reg.SetDisableDefaultErrors(*disableDefaultErrors)

--- a/protoc-gen-openapiv2/main_test.go
+++ b/protoc-gen-openapiv2/main_test.go
@@ -22,6 +22,7 @@ func TestParseReqParam(t *testing.T) {
 		importPathV                string
 		mergeFileNameV             string
 		useFQNForOpenAPINameV      bool
+		openAPINamingStrategyV     string
 	}{
 		{
 			// this one must be first - with no leading clearFlags call it
@@ -52,14 +53,14 @@ func TestParseReqParam(t *testing.T) {
 			expected:         map[string]string{"a/b/c.proto": "github.com/x/y/z", "f/g/h.proto": "github.com/1/2/3/"},
 			request:          "allow_delete_body=false,allow_merge=false,Ma/b/c.proto=github.com/x/y/z,Mf/g/h.proto=github.com/1/2/3/",
 			allowDeleteBodyV: false, allowMergeV: false, allowRepeatedFieldsInBodyV: false, includePackageInTagsV: false,
-			fileV: "stdin", importPathV: "", mergeFileNameV: "apidocs",
+			fileV: "-", importPathV: "", mergeFileNameV: "apidocs",
 		},
 		{
 			name:             "Test 4",
 			expected:         map[string]string{},
 			request:          "",
 			allowDeleteBodyV: false, allowMergeV: false, allowRepeatedFieldsInBodyV: false, includePackageInTagsV: false,
-			fileV: "stdin", importPathV: "", mergeFileNameV: "apidocs",
+			fileV: "-", importPathV: "", mergeFileNameV: "apidocs",
 		},
 		{
 			name:             "Test 5",
@@ -67,7 +68,7 @@ func TestParseReqParam(t *testing.T) {
 			request:          "unknown_param=17",
 			expectedError:    errors.New("cannot set flag unknown_param=17: no such flag -unknown_param"),
 			allowDeleteBodyV: false, allowMergeV: false, allowRepeatedFieldsInBodyV: false, includePackageInTagsV: false,
-			fileV: "stdin", importPathV: "", mergeFileNameV: "apidocs",
+			fileV: "-", importPathV: "", mergeFileNameV: "apidocs",
 		},
 		{
 			name:             "Test 6",
@@ -75,7 +76,7 @@ func TestParseReqParam(t *testing.T) {
 			request:          "Mfoo",
 			expectedError:    errors.New("cannot set flag Mfoo: no such flag -Mfoo"),
 			allowDeleteBodyV: false, allowMergeV: false, allowRepeatedFieldsInBodyV: false, includePackageInTagsV: false,
-			fileV: "stdin", importPathV: "", mergeFileNameV: "apidocs",
+			fileV: "-", importPathV: "", mergeFileNameV: "apidocs",
 		},
 		{
 			name:             "Test 7",
@@ -98,7 +99,7 @@ func TestParseReqParam(t *testing.T) {
 			request:          "include_package_in_tags=3",
 			expectedError:    errors.New(`cannot set flag include_package_in_tags=3: parse error`),
 			allowDeleteBodyV: false, allowMergeV: false, allowRepeatedFieldsInBodyV: false, includePackageInTagsV: false,
-			fileV: "stdin", importPathV: "", mergeFileNameV: "apidocs",
+			fileV: "-", importPathV: "", mergeFileNameV: "apidocs",
 		},
 		{
 			name:             "Test 10",
@@ -106,14 +107,21 @@ func TestParseReqParam(t *testing.T) {
 			request:          "fqn_for_openapi_name=3",
 			expectedError:    errors.New(`cannot set flag fqn_for_openapi_name=3: parse error`),
 			allowDeleteBodyV: false, allowMergeV: false, allowRepeatedFieldsInBodyV: false, includePackageInTagsV: false, useFQNForOpenAPINameV: false,
-			fileV: "stdin", importPathV: "", mergeFileNameV: "apidocs",
+			fileV: "-", importPathV: "", mergeFileNameV: "apidocs",
 		},
 		{
 			name:             "Test 11",
 			expected:         map[string]string{},
 			request:          "fqn_for_openapi_name=true",
 			allowDeleteBodyV: false, allowMergeV: false, allowRepeatedFieldsInBodyV: false, includePackageInTagsV: false, useFQNForOpenAPINameV: true,
-			fileV: "stdin", importPathV: "", mergeFileNameV: "apidocs",
+			fileV: "-", importPathV: "", mergeFileNameV: "apidocs",
+		},
+		{
+			name:             "Test 12",
+			expected:         map[string]string{},
+			request:          "openapi_naming_strategy=simple",
+			allowDeleteBodyV: false, allowMergeV: false, allowRepeatedFieldsInBodyV: false, includePackageInTagsV: false, useFQNForOpenAPINameV: false, openAPINamingStrategyV: "simple",
+			fileV: "-", importPathV: "", mergeFileNameV: "apidocs",
 		},
 	}
 
@@ -140,15 +148,15 @@ func TestParseReqParam(t *testing.T) {
 					tt.Errorf("expected error malformed, expected %q, got %q", tc.expectedError.Error(), err.Error())
 				}
 			}
-			checkFlags(tc.allowDeleteBodyV, tc.allowMergeV, tc.allowRepeatedFieldsInBodyV, tc.includePackageInTagsV, tc.useFQNForOpenAPINameV, tc.fileV, tc.importPathV, tc.mergeFileNameV, tt, i)
+			checkFlags(tc.allowDeleteBodyV, tc.allowMergeV, tc.allowRepeatedFieldsInBodyV, tc.includePackageInTagsV, tc.useFQNForOpenAPINameV, tc.openAPINamingStrategyV, tc.fileV, tc.importPathV, tc.mergeFileNameV, tt, i)
 
-			clearFlags()
+			clearFlags(tt, f)
 		})
 	}
 
 }
 
-func checkFlags(allowDeleteV, allowMergeV, allowRepeatedFieldsInBodyV, includePackageInTagsV bool, useFQNForOpenAPINameV bool, fileV, importPathV, mergeFileNameV string, t *testing.T, tid int) {
+func checkFlags(allowDeleteV, allowMergeV, allowRepeatedFieldsInBodyV, includePackageInTagsV bool, useFQNForOpenAPINameV bool, openAPINamingStrategyV, fileV, importPathV, mergeFileNameV string, t *testing.T, tid int) {
 	if *importPrefix != importPathV {
 		t.Errorf("Test %v: import_prefix misparsed, expected '%v', got '%v'", tid, importPathV, *importPrefix)
 	}
@@ -173,14 +181,15 @@ func checkFlags(allowDeleteV, allowMergeV, allowRepeatedFieldsInBodyV, includePa
 	if *useFQNForOpenAPIName != useFQNForOpenAPINameV {
 		t.Errorf("Test %v: fqn_for_openapi_name misparsed, expected '%v', got '%v'", tid, useFQNForOpenAPINameV, *useFQNForOpenAPIName)
 	}
+	if *openAPINamingStrategy != openAPINamingStrategyV {
+		t.Errorf("Test %v: openapi_naming_strategy misparsed, expected '%v', got '%v'", tid, openAPINamingStrategyV, *openAPINamingStrategy)
+	}
 }
 
-func clearFlags() {
-	*importPrefix = ""
-	*file = "stdin"
-	*allowDeleteBody = false
-	*allowMerge = false
-	*allowRepeatedFieldsInBody = false
-	*includePackageInTags = false
-	*mergeFileName = "apidocs"
+func clearFlags(t *testing.T, f *flag.FlagSet) {
+	f.Visit(func(flg *flag.Flag) {
+		if err := flg.Value.Set(flg.DefValue); err != nil {
+			t.Errorf("Error resetting flag %s: %v", flg.Name, err)
+		}
+	})
 }


### PR DESCRIPTION
This PR takes up the suggestion from https://github.com/grpc-ecosystem/grpc-gateway/issues/877#issuecomment-469055509 to fix current issues with the OpenAPI naming strategy (see wider discussion in #877) by allowing the user to select one of several OpenAPI naming strategies.

**Compatibility concerns:** the existing `fqn_for_openapi_name` flag is deprecated by this change. It can still be used, but only if no value is specified for the `openapi_naming_strategy` flag. The old behavior with `fqn_for_openapi_name=false` can be enabled via `openapi_naming_strategy=legacy` (this is the default). The behavior with `fqn_for_openapi_name=true` can be enabled via `openapi_naming_strategy=fqn`.

**New feature:** A `simple` naming strategy is introduced that determines the OpenAPI name by looking at the _shortest non-empty_ suffix of the slice of name components (parts in the FQN separated by dots) that is unique, and then joins the elements in this suffix with a `.`. The previous `legacy` strategy would look at the shortest (possibly empty) suffix that is unique, then extend that suffix length by one, and join all components with no separator.

**Misc:** Flags in the `main_test.go` weren't properly cleared. Clearing logic has been rewritten by using the flag default values as the source of truth.

#### References to other Issues or PRs

Fixes #877

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

See above

#### Other comments

N/A