### PR TITLE
adding UnimplementedGreeterServer to server struct

### DIFF
--- a/docs/docs/tutorials/adding_annotations.md
+++ b/docs/docs/tutorials/adding_annotations.md
@@ -117,7 +117,9 @@ import (
 	helloworldpb "github.com/myuser/myrepo/proto/helloworld"
 )
 
-type server struct{}
+type server struct{
+	helloworldpb.UnimplementedGreeterServer
+}
 
 func NewServer() *server {
 	return &server{}


### PR DESCRIPTION
The compiler produces an error without this. The error is:

```
cannot use &server literal (type *server) as type helloworld.GreeterServer in argument to helloworld.RegisterGreeterServer:
	*server does not implement helloworld.GreeterServer (missing helloworld.mustEmbedUnimplementedGreeterServer method)
```

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

#### Other comments
