### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Make sure that your `$GOBIN` is in your `$PATH`.
    google/api/annotations.proto
    google/api/field_behaviour.proto
    google/api/http.proto
-   google/api/httbody.proto
+   google/api/httpbody.proto
    ```
 
    Here's what a `protoc` execution might look like:


### PR DESCRIPTION
`httbody.proto` -> `httpbody.proto`

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs
N/A

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?
Yes.

#### Brief description of what is fixed or changed
Fix a typo in setup instructions.

#### Other comments
N/A