### PR TITLE
unmarshal: avoid dereferencing nil pointers

### DIFF
--- a/runtime/marshal_jsonpb.go
+++ b/runtime/marshal_jsonpb.go
@@ -237,6 +237,10 @@ func decodeNonProtoField(d *json.Decoder, unmarshaler protojson.UnmarshalOptions
 			}
 			bk := result[0]
 			bv := reflect.New(rv.Type().Elem())
+			if v == nil {
+				null := json.RawMessage("null")
+				v = &null
+			}
 			if err := unmarshalJSONPb([]byte(*v), unmarshaler, bv.Interface()); err != nil {
 				return err
 			}

--- a/runtime/marshal_jsonpb_test.go
+++ b/runtime/marshal_jsonpb_test.go
@@ -648,6 +648,24 @@ var (
 	}
 )
 
+func TestJSONPbUnmarshalNullField(t *testing.T) {
+	var out map[string]interface{}
+
+	const json = `{"foo": null}`
+	marshaler := &runtime.JSONPb{}
+	if err := marshaler.Unmarshal([]byte(json), &out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	value, hasKey := out["foo"]
+	if !hasKey {
+		t.Fatalf("unmarshaled map did not have key 'foo'")
+	}
+	if value != nil {
+		t.Fatalf("unexpected value: %v", value)
+	}
+}
+
 func TestJSONPbMarshalResponseBodies(t *testing.T) {
 	marshaler := &runtime.JSONPb{}
 	for i, spec := range []struct {


### PR DESCRIPTION
#### References to other Issues or PRs
N/A

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?
Yes

#### Brief description of what is fixed or changed

Avoid dereferencing nil points when unmarshaling JSON. This might be the result of me doing something strange, but I'm using a custom JSON marshaler with gRPC-Gateway, where some fields (for example enums) end up as `null` in JSON if they are the zero value. When I then do a roundtrip JSON marshal/unmarshal the unmarshaler panics on a nil `*json.RawMessage`.

#### Other comments

I'm not sure if this needs a unit test, and in that case what that should look like. Any pointers are appreciated!
