### PR TITLE
Send trailers only when `TE: trailers` is set

### DIFF
--- a/examples/internal/integration/integration_test.go
+++ b/examples/internal/integration/integration_test.go
@@ -289,7 +289,6 @@ func testEchoBody(t *testing.T, port int, apiPrefix string, useTrailers bool) {
 
 	apiURL := fmt.Sprintf("http://localhost:%d/%s/example/echo_body", port, apiPrefix)
 
-	client := &http.Client{}
 	req, err := http.NewRequest("POST", apiURL, bytes.NewReader(payload))
 	if err != nil {
 		t.Errorf("http.NewRequest() failed with %v; want success", err)
@@ -298,7 +297,8 @@ func testEchoBody(t *testing.T, port int, apiPrefix string, useTrailers bool) {
 	if useTrailers {
 		req.Header.Set("TE", "trailers")
 	}
-	resp, err := client.Do(req)
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Errorf("client.Do(%v) failed with %v; want success", req, err)
 		return
@@ -619,7 +619,6 @@ func testABEBulkCreate(t *testing.T, port int, useTrailers bool) {
 	}(w)
 	apiURL := fmt.Sprintf("http://localhost:%d/v1/example/a_bit_of_everything/bulk", port)
 
-	client := &http.Client{}
 	req, err := http.NewRequest("POST", apiURL, r)
 	if err != nil {
 		t.Errorf("http.NewRequest() failed with %v; want success", err)
@@ -631,7 +630,7 @@ func testABEBulkCreate(t *testing.T, port int, useTrailers bool) {
 		req.Header.Set("TE", "trailers")
 	}
 
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Errorf("client.Do(%v) failed with %v; want success", req, err)
 		return
@@ -1035,7 +1034,6 @@ func testABELookupNotFound(t *testing.T, port int, useTrailers bool) {
 	uuid := "not_exist"
 	apiURL = fmt.Sprintf("%s/%s", apiURL, uuid)
 
-	client := &http.Client{}
 	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
 		t.Errorf("http.NewRequest() failed with %v; want success", err)
@@ -1046,7 +1044,7 @@ func testABELookupNotFound(t *testing.T, port int, useTrailers bool) {
 		req.Header.Set("TE", "trailers")
 	}
 
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Errorf("client.Do(%v) failed with %v; want success", req, err)
 		return

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -131,10 +130,9 @@ func DefaultHTTPErrorHandler(ctx context.Context, mux *ServeMux, marshaler Marsh
 	// is acceptable, as described in Section 4.3, a server SHOULD NOT
 	// generate trailer fields that it believes are necessary for the user
 	// agent to receive.
-	var wantsTrailers bool
+	doForwardTrailers := requestAcceptsTrailers(r)
 
-	if te := r.Header.Get("TE"); strings.Contains(strings.ToLower(te), "trailers") {
-		wantsTrailers = true
+	if doForwardTrailers {
 		handleForwardResponseTrailerHeader(w, md)
 		w.Header().Set("Transfer-Encoding", "chunked")
 	}
@@ -149,7 +147,7 @@ func DefaultHTTPErrorHandler(ctx context.Context, mux *ServeMux, marshaler Marsh
 		grpclog.Infof("Failed to write response: %v", err)
 	}
 
-	if wantsTrailers {
+	if doForwardTrailers {
 		handleForwardResponseTrailer(w, md)
 	}
 }

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/textproto"
+	"strings"
 
 	"google.golang.org/genproto/googleapis/api/httpbody"
 	"google.golang.org/grpc/codes"
@@ -136,7 +137,20 @@ func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marsha
 		grpclog.Infof("Failed to extract ServerMetadata from context")
 	}
 
-	handleForwardResponseServerMetadata(w, mux, md)
+	// RFC 7230 https://tools.ietf.org/html/rfc7230#section-4.1.2
+	// Unless the request includes a TE header field indicating "trailers"
+	// is acceptable, as described in Section 4.3, a server SHOULD NOT
+	// generate trailer fields that it believes are necessary for the user
+	// agent to receive.
+	var wantsTrailers bool
+
+	if te := req.Header.Get("TE"); strings.Contains(strings.ToLower(te), "trailers") {
+		wantsTrailers = true
+		handleForwardResponseServerMetadata(w, mux, md)
+		handleForwardResponseTrailerHeader(w, md)
+		w.Header().Set("Transfer-Encoding", "chunked")
+	}
+
 	handleForwardResponseTrailerHeader(w, md)
 
 	contentType := marshaler.ContentType(resp)
@@ -163,7 +177,9 @@ func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marsha
 		grpclog.Infof("Failed to write response: %v", err)
 	}
 
-	handleForwardResponseTrailer(w, md)
+	if wantsTrailers {
+		handleForwardResponseTrailer(w, md)
+	}
 }
 
 func handleForwardResponseOptions(ctx context.Context, w http.ResponseWriter, resp proto.Message, opts []func(context.Context, http.ResponseWriter, proto.Message) error) error {

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -137,6 +137,8 @@ func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marsha
 		grpclog.Infof("Failed to extract ServerMetadata from context")
 	}
 
+	handleForwardResponseServerMetadata(w, mux, md)
+
 	// RFC 7230 https://tools.ietf.org/html/rfc7230#section-4.1.2
 	// Unless the request includes a TE header field indicating "trailers"
 	// is acceptable, as described in Section 4.3, a server SHOULD NOT
@@ -146,7 +148,6 @@ func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marsha
 
 	if te := req.Header.Get("TE"); strings.Contains(strings.ToLower(te), "trailers") {
 		wantsTrailers = true
-		handleForwardResponseServerMetadata(w, mux, md)
 		handleForwardResponseTrailerHeader(w, md)
 		w.Header().Set("Transfer-Encoding", "chunked")
 	}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs
Fixes #1709

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?
Yes.

#### Brief description of what is fixed or changed

Sends trailers back only when client specifies `TE: trailers`. 

#### Other comments

I borrowed the code from `errors.go` from https://github.com/grpc-ecosystem/grpc-gateway/pull/1499 as well as the approach to the tests.
I was thinking about increasing the reuse but did not figure out anything elegant. Will gladly adjust.

