### PR TITLE
fix: adding root '/' path in custom route handler

### DIFF
--- a/internal/httprule/compile.go
+++ b/internal/httprule/compile.go
@@ -96,6 +96,10 @@ func (t template) Compile() Template {
 		if op.str == "" {
 			ops = append(ops, op.num)
 		} else {
+			// eof segment literal represents the "/" path pattern
+			if op.str == eof {
+				op.str = ""
+			}
 			if _, ok := consts[op.str]; !ok {
 				consts[op.str] = len(pool)
 				pool = append(pool, op.str)

--- a/internal/httprule/compile_test.go
+++ b/internal/httprule/compile_test.go
@@ -23,6 +23,13 @@ func TestCompile(t *testing.T) {
 		{},
 		{
 			segs: []segment{
+				literal(eof),
+			},
+			ops:  []int{int(utilities.OpLitPush), 0},
+			pool: []string{""},
+		},
+		{
+			segs: []segment{
 				wildcard{},
 			},
 			ops: []int{int(utilities.OpPush), operandFiller},

--- a/internal/httprule/parse.go
+++ b/internal/httprule/parse.go
@@ -118,6 +118,10 @@ type parser struct {
 
 // topLevelSegments is the target of this parser.
 func (p *parser) topLevelSegments() ([]segment, error) {
+	if _, err := p.accept(typeEOF); err == nil {
+		p.tokens = p.tokens[:0]
+		return []segment{literal(eof)}, nil
+	}
 	segs, err := p.segments()
 	if err != nil {
 		return nil, err

--- a/internal/httprule/parse_test.go
+++ b/internal/httprule/parse_test.go
@@ -141,6 +141,20 @@ func TestParseSegments(t *testing.T) {
 		want   []segment
 	}{
 		{
+			tokens: []string{eof},
+			want: []segment{
+				literal(eof),
+			},
+		},
+		{
+			// Note: this case will never arise as tokenize() will never return such a sequence of tokens
+			// and even if it does it will be treated as [eof]
+			tokens: []string{eof, "v1", eof},
+			want: []segment{
+				literal(eof),
+			},
+		},
+		{
 			tokens: []string{"v1", eof},
 			want: []segment{
 				literal("v1"),
@@ -307,10 +321,6 @@ func TestParseSegmentsWithErrors(t *testing.T) {
 		{
 			// invalid percent-encoding
 			tokens: []string{"a%2z", eof},
-		},
-		{
-			// empty segments
-			tokens: []string{eof},
 		},
 		{
 			// unterminated variable

--- a/runtime/mux_test.go
+++ b/runtime/mux_test.go
@@ -419,6 +419,12 @@ var defaultRouteMatcherTests = []struct {
 	valid  bool
 }{
 	{
+		"Test route /",
+		"GET",
+		"/",
+		true,
+	},
+	{
 		"Simple Endpoint",
 		"GET",
 		"/v1/{bucket}/do:action",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

Fixes #1909 

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

As the root route does not have any path, the parser was trying to parse the following tokens: `[eof]`, which was causing an error in `parser.topLevelSegments`. Therefore, I added a condition for `eof` in it and returns an `eof` segment, which is checked in `template.Compile` to obtain the desired result.


#### Other comments

A more direct approach would be the one in #1916 but I think this approach would be better. 
Open for suggestions.
