### PR TITLE
Remove ubuntu1604 from presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,29 +4,19 @@ platforms:
     build_flags:
     - "--build_tag_filters=-nolinux"
     build_targets:
-    - "..."
+    - "//..."
     test_flags:
     - "--features=race"
     - "--test_tag_filters=-nolinux"
     test_targets:
-    - "..."
-  ubuntu1604:
-    build_flags:
-    - "--build_tag_filters=-nolinux"
-    build_targets:
-    - "..."
-    test_flags:
-    - "--features=race"
-    - "--test_tag_filters=-nolinux"
-    test_targets:
-    - "..."
+    - "//..."
   macos:
     build_flags:
     - "--build_tag_filters=-nomacos"
     build_targets:
-    - "..."
+    - "//..."
     test_flags:
     - "--features=race"
     - "--test_tag_filters=-nomacos"
     test_targets:
-    - "..."
+    - "//..."


### PR DESCRIPTION
Ubuntu 16.04 is end-of-life, we're going to remove it from Bazel CI.

If you like you can add testing on `ubuntu2004` platform which we also support.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?
Yes.

#### Brief description of what is fixed or changed
Compatibility fixes for Bazel CI infrastructure changes.
