### PR TITLE
 Add optional_nullable option (default: off) to mark Proto3 Optional fields as x-nullable

### DIFF
--- a/internal/descriptor/registry.go
+++ b/internal/descriptor/registry.go
@@ -87,8 +87,8 @@ type Registry struct {
 	// has no HttpRule annotation.
 	warnOnUnboundMethods bool
 
-	// optionalNullable specifies whether Proto3 Optional fields should be marked as x-nullable.
-	optionalNullable bool
+	// proto3OptionalNullable specifies whether Proto3 Optional fields should be marked as x-nullable.
+	proto3OptionalNullable bool
 
 	// fileOptions is a mapping of file name to additional OpenAPI file options
 	fileOptions map[string]*options.Swagger
@@ -571,14 +571,14 @@ func (r *Registry) GetOmitPackageDoc() bool {
 	return r.omitPackageDoc
 }
 
-// SetOptionalNullable set optionalNullable
-func (r *Registry) SetOptionalNullable(optionalNullable bool) {
-	r.optionalNullable = optionalNullable
+// SetProto3OptionalNullable set proto3OtionalNullable
+func (r *Registry) SetProto3OptionalNullable(proto3OtionalNullable bool) {
+	r.proto3OptionalNullable = proto3OtionalNullable
 }
 
-// GetOptionalNullable returns optionalNullable
-func (r *Registry) GetOptionalNullable() bool {
-	return r.optionalNullable
+// GetProto3OptionalNullable returns proto3OtionalNullable
+func (r *Registry) GetProto3OptionalNullable() bool {
+	return r.proto3OptionalNullable
 }
 
 // RegisterOpenAPIOptions registers OpenAPI options

--- a/internal/descriptor/registry.go
+++ b/internal/descriptor/registry.go
@@ -87,6 +87,9 @@ type Registry struct {
 	// has no HttpRule annotation.
 	warnOnUnboundMethods bool
 
+	// optionalNullable specifies whether Proto3 Optional fields should be marked as x-nullable.
+	optionalNullable bool
+
 	// fileOptions is a mapping of file name to additional OpenAPI file options
 	fileOptions map[string]*options.Swagger
 
@@ -566,6 +569,16 @@ func (r *Registry) SetOmitPackageDoc(omit bool) {
 // GetOmitPackageDoc returns whether a package comment will be omitted from the generated code
 func (r *Registry) GetOmitPackageDoc() bool {
 	return r.omitPackageDoc
+}
+
+// SetOptionalNullable set optionalNullable
+func (r *Registry) SetOptionalNullable(optionalNullable bool) {
+	r.optionalNullable = optionalNullable
+}
+
+// GetOptionalNullable returns optionalNullable
+func (r *Registry) GetOptionalNullable() bool {
+	return r.optionalNullable
 }
 
 // RegisterOpenAPIOptions registers OpenAPI options

--- a/protoc-gen-openapiv2/defs.bzl
+++ b/protoc-gen-openapiv2/defs.bzl
@@ -62,6 +62,7 @@ def _run_proto_gen_openapi(
         disable_default_errors,
         enums_as_ints,
         simple_operation_ids,
+        optional_nullable,
         openapi_configuration,
         generate_unbound_methods):
     args = actions.args()
@@ -106,6 +107,9 @@ def _run_proto_gen_openapi(
 
     if enums_as_ints:
         args.add("--openapiv2_opt", "enums_as_ints=true")
+
+    if optional_nullable:
+        args.add("--openapiv2_opt", "optional_nullable=true")
 
     args.add("--openapiv2_opt", "repeated_path_param_separator=%s" % repeated_path_param_separator)
 
@@ -201,6 +205,7 @@ def _proto_gen_openapi_impl(ctx):
                     disable_default_errors = ctx.attr.disable_default_errors,
                     enums_as_ints = ctx.attr.enums_as_ints,
                     simple_operation_ids = ctx.attr.simple_operation_ids,
+                    optional_nullable = ctx.attr.optional_nullable,
                     openapi_configuration = ctx.file.openapi_configuration,
                     generate_unbound_methods = ctx.attr.generate_unbound_methods,
                 ),
@@ -278,6 +283,11 @@ protoc_gen_openapiv2 = rule(
             doc = "whether to remove the service prefix in the operationID" +
                   " generation. Can introduce duplicate operationIDs, use with caution.",
         ),
+        "optional_nullable": attr.bool(
+            default = False,
+            mandatory = False,
+            doc = "whether Proto3 Optional fields should be marked as x-nullable",
+        )
         "openapi_configuration": attr.label(
             allow_single_file = True,
             mandatory = False,

--- a/protoc-gen-openapiv2/defs.bzl
+++ b/protoc-gen-openapiv2/defs.bzl
@@ -62,7 +62,7 @@ def _run_proto_gen_openapi(
         disable_default_errors,
         enums_as_ints,
         simple_operation_ids,
-        optional_nullable,
+        proto3_optional_nullable,
         openapi_configuration,
         generate_unbound_methods):
     args = actions.args()
@@ -108,8 +108,8 @@ def _run_proto_gen_openapi(
     if enums_as_ints:
         args.add("--openapiv2_opt", "enums_as_ints=true")
 
-    if optional_nullable:
-        args.add("--openapiv2_opt", "optional_nullable=true")
+    if proto3_optional_nullable:
+        args.add("--openapiv2_opt", "proto3_optional_nullable=true")
 
     args.add("--openapiv2_opt", "repeated_path_param_separator=%s" % repeated_path_param_separator)
 
@@ -205,7 +205,7 @@ def _proto_gen_openapi_impl(ctx):
                     disable_default_errors = ctx.attr.disable_default_errors,
                     enums_as_ints = ctx.attr.enums_as_ints,
                     simple_operation_ids = ctx.attr.simple_operation_ids,
-                    optional_nullable = ctx.attr.optional_nullable,
+                    proto3_optional_nullable = ctx.attr.proto3_optional_nullable,
                     openapi_configuration = ctx.file.openapi_configuration,
                     generate_unbound_methods = ctx.attr.generate_unbound_methods,
                 ),
@@ -283,11 +283,11 @@ protoc_gen_openapiv2 = rule(
             doc = "whether to remove the service prefix in the operationID" +
                   " generation. Can introduce duplicate operationIDs, use with caution.",
         ),
-        "optional_nullable": attr.bool(
+        "proto3_optional_nullable": attr.bool(
             default = False,
             mandatory = False,
             doc = "whether Proto3 Optional fields should be marked as x-nullable",
-        )
+        ),
         "openapi_configuration": attr.label(
             allow_single_file = True,
             mandatory = False,

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -582,7 +582,7 @@ func schemaOfField(f *descriptor.Field, reg *descriptor.Registry, refs refMap) o
 		updateSwaggerObjectFromFieldBehavior(&ret, j, f)
 	}
 
-	if reg.GetOptionalNullable() && f.Proto3Optional != nil && *f.Proto3Optional {
+	if reg.GetProto3OptionalNullable() && f.GetProto3Optional() {
 		ret.Nullable = true
 	}
 

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -410,6 +410,7 @@ func renderMessageAsDefinition(msg *descriptor.Message, reg *descriptor.Registry
 		schema.MaxProperties = protoSchema.MaxProperties
 		schema.MinProperties = protoSchema.MinProperties
 		schema.Required = protoSchema.Required
+		schema.Nullable = protoSchema.Nullable
 		if protoSchema.schemaCore.Type != "" || protoSchema.schemaCore.Ref != "" {
 			schema.schemaCore = protoSchema.schemaCore
 		}
@@ -579,6 +580,10 @@ func schemaOfField(f *descriptor.Field, reg *descriptor.Registry, refs refMap) o
 
 	if j, err := getFieldBehaviorOption(reg, f); err == nil {
 		updateSwaggerObjectFromFieldBehavior(&ret, j, f)
+	}
+
+	if reg.GetOptionalNullable() && f.Proto3Optional != nil && *f.Proto3Optional {
+		ret.Nullable = true
 	}
 
 	return ret

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -410,7 +410,7 @@ func renderMessageAsDefinition(msg *descriptor.Message, reg *descriptor.Registry
 		schema.MaxProperties = protoSchema.MaxProperties
 		schema.MinProperties = protoSchema.MinProperties
 		schema.Required = protoSchema.Required
-		schema.Nullable = protoSchema.Nullable
+		schema.XNullable = protoSchema.XNullable
 		if protoSchema.schemaCore.Type != "" || protoSchema.schemaCore.Ref != "" {
 			schema.schemaCore = protoSchema.schemaCore
 		}
@@ -583,7 +583,7 @@ func schemaOfField(f *descriptor.Field, reg *descriptor.Registry, refs refMap) o
 	}
 
 	if reg.GetProto3OptionalNullable() && f.GetProto3Optional() {
-		ret.Nullable = true
+		ret.XNullable = true
 	}
 
 	return ret

--- a/protoc-gen-openapiv2/internal/genopenapi/types.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/types.go
@@ -150,13 +150,18 @@ type openapiParameterObject struct {
 }
 
 // core part of schema, which is common to itemsObject and schemaObject.
-// http://swagger.io/specification/#itemsObject
+// http://swagger.io/specification/v2/#itemsObject
+// The OAS3 spec (https://swagger.io/specification/#schemaObject) defines the
+// `nullable` field as part of a Schema Object. This behavior has been
+// "back-ported" to OAS2 as the Specification Extension `x-nullable`, and is
+// supported by generation tools such as swagger-codegen and go-swagger.
+// For protoc-gen-openapiv3, we'd want to add `nullable` instead.
 type schemaCore struct {
-	Type     string          `json:"type,omitempty"`
-	Format   string          `json:"format,omitempty"`
-	Ref      string          `json:"$ref,omitempty"`
-	Nullable bool            `json:"x-nullable,omitempty"`
-	Example  json.RawMessage `json:"example,omitempty"`
+	Type      string          `json:"type,omitempty"`
+	Format    string          `json:"format,omitempty"`
+	Ref       string          `json:"$ref,omitempty"`
+	XNullable bool            `json:"x-nullable,omitempty"`
+	Example   json.RawMessage `json:"example,omitempty"`
 
 	Items *openapiItemsObject `json:"items,omitempty"`
 

--- a/protoc-gen-openapiv2/internal/genopenapi/types.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/types.go
@@ -152,10 +152,11 @@ type openapiParameterObject struct {
 // core part of schema, which is common to itemsObject and schemaObject.
 // http://swagger.io/specification/#itemsObject
 type schemaCore struct {
-	Type    string          `json:"type,omitempty"`
-	Format  string          `json:"format,omitempty"`
-	Ref     string          `json:"$ref,omitempty"`
-	Example json.RawMessage `json:"example,omitempty"`
+	Type     string          `json:"type,omitempty"`
+	Format   string          `json:"format,omitempty"`
+	Ref      string          `json:"$ref,omitempty"`
+	Nullable bool            `json:"x-nullable,omitempty"`
+	Example  json.RawMessage `json:"example,omitempty"`
 
 	Items *openapiItemsObject `json:"items,omitempty"`
 

--- a/protoc-gen-openapiv2/main.go
+++ b/protoc-gen-openapiv2/main.go
@@ -31,6 +31,7 @@ var (
 	disableDefaultErrors       = flag.Bool("disable_default_errors", false, "if set, disables generation of default errors. This is useful if you have defined custom error handling")
 	enumsAsInts                = flag.Bool("enums_as_ints", false, "whether to render enum values as integers, as opposed to string values")
 	simpleOperationIDs         = flag.Bool("simple_operation_ids", false, "whether to remove the service prefix in the operationID generation. Can introduce duplicate operationIDs, use with caution.")
+	optionalNullable           = flag.Bool("optional_nullable", false, "whether Proto3 Optional fields should be marked as x-nullable")
 	openAPIConfiguration       = flag.String("openapi_configuration", "", "path to file which describes the OpenAPI Configuration in YAML format")
 	generateUnboundMethods     = flag.Bool("generate_unbound_methods", false, "generate swagger metadata even for RPC methods that have no HttpRule annotation")
 	recursiveDepth             = flag.Int("recursive-depth", 1000, "maximum recursion count allowed for a field type")
@@ -89,6 +90,7 @@ func main() {
 	reg.SetEnumsAsInts(*enumsAsInts)
 	reg.SetDisableDefaultErrors(*disableDefaultErrors)
 	reg.SetSimpleOperationIDs(*simpleOperationIDs)
+	reg.SetOptionalNullable(*optionalNullable)
 	reg.SetGenerateUnboundMethods(*generateUnboundMethods)
 	reg.SetRecursiveDepth(*recursiveDepth)
 	if err := reg.SetRepeatedPathParamSeparator(*repeatedPathParamSeparator); err != nil {

--- a/protoc-gen-openapiv2/main.go
+++ b/protoc-gen-openapiv2/main.go
@@ -31,7 +31,7 @@ var (
 	disableDefaultErrors       = flag.Bool("disable_default_errors", false, "if set, disables generation of default errors. This is useful if you have defined custom error handling")
 	enumsAsInts                = flag.Bool("enums_as_ints", false, "whether to render enum values as integers, as opposed to string values")
 	simpleOperationIDs         = flag.Bool("simple_operation_ids", false, "whether to remove the service prefix in the operationID generation. Can introduce duplicate operationIDs, use with caution.")
-	optionalNullable           = flag.Bool("optional_nullable", false, "whether Proto3 Optional fields should be marked as x-nullable")
+	proto3OptionalNullable     = flag.Bool("proto3_optional_nullable", false, "whether Proto3 Optional fields should be marked as x-nullable")
 	openAPIConfiguration       = flag.String("openapi_configuration", "", "path to file which describes the OpenAPI Configuration in YAML format")
 	generateUnboundMethods     = flag.Bool("generate_unbound_methods", false, "generate swagger metadata even for RPC methods that have no HttpRule annotation")
 	recursiveDepth             = flag.Int("recursive-depth", 1000, "maximum recursion count allowed for a field type")
@@ -90,7 +90,7 @@ func main() {
 	reg.SetEnumsAsInts(*enumsAsInts)
 	reg.SetDisableDefaultErrors(*disableDefaultErrors)
 	reg.SetSimpleOperationIDs(*simpleOperationIDs)
-	reg.SetOptionalNullable(*optionalNullable)
+	reg.SetProto3OptionalNullable(*proto3OptionalNullable)
 	reg.SetGenerateUnboundMethods(*generateUnboundMethods)
 	reg.SetRecursiveDepth(*recursiveDepth)
 	if err := reg.SetRepeatedPathParamSeparator(*repeatedPathParamSeparator); err != nil {


### PR DESCRIPTION
See #669 for more background.

This change adds an optional (default: off) `proto3_optional_nullable` flag to `protoc-gen-openapiv2` that will mark Proto3 fields marked with the `optional` label as `x-nullable`. The OAS specification calls this out as `nullable`, but this behavior has been "back-ported" to OAS2 using the System Extension `x-nullable`.

The effect of the Proto3 Optional flag on the GRPC is exactly this—it sets primitive types to pointers. It's certainly open to debate why we have Proto2 `optional`, the `optional` field descriptor, and Proto3 `optional`, but fundamentally Proto3 Optional is designed to solve the "true presence" issue as discussed in #669, at least IMHO. Whereas the other options never felt specific to this nullable behavior. Proto3 optional field presence discussion is [here](https://github.com/protocolbuffers/protobuf/blob/master/docs/field_presence.md).

It could be a valid approach to make this behavior the default, but for now it felt best to me to retain backwards compatibility until the semantics are well understood.

Potentially:
Fixes #669

Adds:
 * `proto3_optional_nullable` command line flag.
 * If `proto3_optional_nullable` is set, and the proto field has `proto3optional` set, the schema XNullable state is set to true, which emits the OAPI `x-nullable` tag.

Comments and feedback welcome! @johanbrandhorst 
