### PR TITLE
Supporting a scenario where proto_library is being used withour srcs...

### DIFF
--- a/protoc-gen-openapiv2/defs.bzl
+++ b/protoc-gen-openapiv2/defs.bzl
@@ -27,12 +27,12 @@ def _direct_source_infos(proto_info, provided_sources = []):
 
     source_root = proto_info.proto_source_root
     if "." == source_root:
-        return [struct(file = src, import_path = src.path) for src in proto_info.direct_sources]
+        return [struct(file = src, import_path = src.path) for src in proto_info.check_deps_sources.to_list()]
 
     offset = len(source_root) + 1  # + '/'.
 
     infos = []
-    for src in proto_info.direct_sources:
+    for src in proto_info.check_deps_sources.to_list():
         # TODO(yannic): Remove this hack when we drop support for Bazel < 1.0.
         local_offset = offset
         if src.root.path and not source_root.startswith(src.root.path):


### PR DESCRIPTION
#### References to other Issues or PRs ####
Fixes #2208

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?
Yes

#### Brief description of what is fixed or changed
Instead of using `proto_source_root`, `check_deps_sources.to_list()`, which return the source if exists, and if not - support the other scenario of a `proto_library` without srcs and only deps.