### PR TITLE
marshalNonProtoField slice of enums

### DIFF
--- a/runtime/marshal_jsonpb_test.go
+++ b/runtime/marshal_jsonpb_test.go
@@ -142,13 +142,31 @@ func TestJSONPbMarshalFields(t *testing.T) {
 		}
 	}
 
+	nums := []examplepb.NumericEnum{examplepb.NumericEnum_ZERO, examplepb.NumericEnum_ONE}
+
+	buf, err := m.Marshal(nums)
+	if err != nil {
+		t.Errorf("m.Marshal(%#v) failed with %v; want success", nums, err)
+	}
+	if got, want := string(buf), `[0,1]`; got != want {
+		t.Errorf("m.Marshal(%#v) = %q; want %q", nums, got, want)
+	}
+
 	m.UseEnumNumbers = false
-	buf, err := m.Marshal(examplepb.NumericEnum_ONE)
+	buf, err = m.Marshal(examplepb.NumericEnum_ONE)
 	if err != nil {
 		t.Errorf("m.Marshal(%#v) failed with %v; want success", examplepb.NumericEnum_ONE, err)
 	}
 	if got, want := string(buf), `"ONE"`; got != want {
 		t.Errorf("m.Marshal(%#v) = %q; want %q", examplepb.NumericEnum_ONE, got, want)
+	}
+
+	buf, err = m.Marshal(nums)
+	if err != nil {
+		t.Errorf("m.Marshal(%#v) failed with %v; want success", nums, err)
+	}
+	if got, want := string(buf), `["ZERO","ONE"]`; got != want {
+		t.Errorf("m.Marshal(%#v) = %q; want %q", nums, got, want)
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs
https://github.com/grpc-ecosystem/grpc-gateway/pull/2220

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

Fix: marshalNonProtoField a slice of enum does not obey `UseEnumNumbers` config.

#### Other comments
Merge https://github.com/grpc-ecosystem/grpc-gateway/pull/2220 to master