### PR TITLE
Tag support in comments

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -4181,6 +4181,38 @@ func TestUpdateOpenAPIDataFromComments(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			descr:                "multi line comment with tag",
+			openapiSwaggerObject: &openapiOperationObject{},
+			expectedOpenAPIObject: &openapiOperationObject{
+				Summary:     "First line",
+				Description: "Second line",
+				Tags:        []string{"tag1"},
+			},
+			comments:      "First line\n\nSecond line\n\nTag: tag1",
+			expectedError: nil,
+		},
+		{
+			descr:                "multi line comment with multiple tags",
+			openapiSwaggerObject: &openapiOperationObject{},
+			expectedOpenAPIObject: &openapiOperationObject{
+				Summary:     "First line",
+				Description: "Second line",
+				Tags:        []string{"tag1", "tag2"},
+			},
+			comments:      "First line\n\nSecond line\n\nTag: tag1, tag2",
+			expectedError: nil,
+		},
+		{
+			descr:                "multi line comment with empty tag",
+			openapiSwaggerObject: &openapiOperationObject{},
+			expectedOpenAPIObject: &openapiOperationObject{
+				Summary:     "First line",
+				Description: "Second line",
+			},
+			comments:      "First line\n\nSecond line\n\nTag:",
+			expectedError: nil,
+		},
+		{
 			descr:                 "multi line comment with summary no dot",
 			openapiSwaggerObject:  &schemaCore{},
 			expectedOpenAPIObject: &schemaCore{},


### PR DESCRIPTION


#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)? 👍 

#### Brief description of what is fixed or changed
Not sure if others would support this, but this enables you to add in OpenAPI tags in comments currently you have to add them as an annotation which is a bit cluttering. 

```proto
  // Gets a thing
  //
  // Retrieves a single legal entity by its ID
  //
  // Tags: Thing
  rpc GetThing(GetThingRequest) returns (Thing) {
    option (google.api.http) = {
      get: "/api/thing/{thing_id}"
    };
  }
```
vs
```proto
  // Gets a thing
  //
  // Retrieves a single legal entity by its ID
  rpc GetThing(GetThingRequest) returns (Thing) {
    option (google.api.http) = {
      get: "/api/thing/{thing_id}"
    };
    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
      tags: "Thing"
    };
  }
```

#### Other comments
