### PR TITLE
fix(integ-test): timeout test is now consistent

### DIFF
--- a/examples/internal/server/a_bit_of_everything.go
+++ b/examples/internal/server/a_bit_of_everything.go
@@ -308,7 +308,7 @@ func (s *_ABitOfEverythingServer) NoBindings(ctx context.Context, msg *durationp
 
 func (s *_ABitOfEverythingServer) Timeout(ctx context.Context, msg *emptypb.Empty) (*emptypb.Empty, error) {
 	<-ctx.Done()
-	return nil, ctx.Err()
+	return nil, status.FromContextError(ctx.Err()).Err()
 }
 
 func (s *_ABitOfEverythingServer) ErrorWithDetails(ctx context.Context, msg *emptypb.Empty) (*emptypb.Empty, error) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs
Fixes #1527
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)? yes

#### Brief description of what is fixed or changed
The timeout test on the server side returned a regular error and not a grpc error. replaced this error with a grpc error using `grpc/status`. 

The problem caused by a race condition in the grpc client of the gateway not returning an error before the server made a response. 
(![Race condition of the grpc client ](https://github.com/grpc/grpc-go/blob/1ddab338690a578975747239ad4ecd2ae63b1965/clientconn.go#L567))


#### Other comments
By making the the server return a grpc error its not truly checks a timeout. the other option is to put a sleep after the context is done to make sure the client have enough time to return a timeout . so the question is if the second option is preferred? (sleep in tests are not best practice thats why its not in this pr) 