### PR TITLE
fix: typo of binary file update

### DIFF
--- a/docs/docs/mapping/binary_file_uploads.md
+++ b/docs/docs/mapping/binary_file_uploads.md
@@ -32,14 +32,14 @@ mux.HandlePath("POST", "/v1/files", handleBinaryFileUpload)
 And then in your handler you can do something like:
 
 ```go
-func handleBinaryFileUpload(w http.ResponseWriter, rq *http.Request, params map[string]string) {
+func handleBinaryFileUpload(w http.ResponseWriter, r *http.Request, params map[string]string) {
 	err := r.ParseForm()
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to parse form: %s", err.Error()), http.StatusBadRequest)
 		return
 	}
 
-	f, header, err := rq.FormFile("attachment")
+	f, header, err := r.FormFile("attachment")
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to get file 'attachment': %s", err.Error()), http.StatusBadRequest)
 		return


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs
None
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?
Yes
#### Brief description of what is fixed or changed
I fixed typo in Binary file uploads example.
L36 use variable "r" but provided *http.Request is named "rq", so just integrated all *http.Request name as "r" that is generally used.
#### Other comments
