### PR TITLE
fix(runtime): fix path parsing to use URL.EscapedPath() instead of Path and unescape individual components

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang/glog v0.0.0-20210429001901-424d2337a529
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6
+	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/rogpeppe/fastuuid v1.2.0
 	golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914
 	google.golang.org/genproto v0.0.0-20210728212813-7823e685a01f

--- a/runtime/mux_test.go
+++ b/runtime/mux_test.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strconv"
 	"testing"
 
+	"github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/httprule"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
 )
@@ -464,5 +466,69 @@ func TestServeMux_HandlePath(t *testing.T) {
 				t.Errorf("The route %v with method %v and path %v should be invalid", tt.name, tt.method, tt.path)
 			}
 		})
+	}
+}
+
+// TestSlashEncoding ensures that slashes are supported as part of path when encoded
+func TestSlashEncoding(t *testing.T) {
+	for _, spec := range []struct {
+		method     string
+		template   string
+		reqPath    string
+		respStatus int
+		pathParams map[string]string
+	}{
+		{
+			method:     "GET",
+			template:   "/v1/users/{name}/profile",
+			reqPath:    "/v1/users/some%2Fuser/profile",
+			respStatus: http.StatusOK,
+			pathParams: map[string]string{"name": "some/user"},
+		},
+		{
+			method:     "GET",
+			template:   "/v1/users/{name}",
+			reqPath:    "/v1/users/some%2Fuser",
+			respStatus: http.StatusOK,
+			pathParams: map[string]string{"name": "some/user"},
+		},
+		{
+			method:     "GET",
+			template:   "/v1/users/{name}/profile",
+			reqPath:    "/v1/users/some/user/profile",
+			respStatus: http.StatusNotFound,
+		},
+		{
+			method:     "GET",
+			template:   "/v1/users/{name}",
+			reqPath:    "/v1/users/some/user",
+			respStatus: http.StatusNotFound,
+		},
+	} {
+		mux := runtime.NewServeMux()
+		compiled, err := httprule.Parse(spec.template)
+		if err != nil {
+			t.Fatalf("httprule.Parse(%s) failed with %v; want success", spec.template, err)
+		}
+		template := compiled.Compile()
+		pat, err := runtime.NewPattern(1, template.OpCodes, template.Pool, template.Verb)
+		if err != nil {
+			t.Fatalf("runtime.NewPattern(1, %#v, %#v, %q) failed with %v; want success", template.OpCodes, template.Pool, template.Verb, err)
+		}
+		mux.Handle(spec.method, pat, func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+			if !reflect.DeepEqual(pathParams, spec.pathParams) {
+				t.Errorf("pathParams got: %v, want: %v", pathParams, spec.pathParams)
+			}
+		})
+		url := fmt.Sprintf("http://host.example%s", spec.reqPath)
+		r, err := http.NewRequest(spec.method, url, bytes.NewReader(nil))
+		if err != nil {
+			t.Fatalf("http.NewRequest(%q, %q, nil) failed with %v; want success", spec.method, url, err)
+		}
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, r)
+		if got, want := w.Code, spec.respStatus; got != want {
+			t.Errorf("w.Code = %d; want %d; req=%v", got, want, r)
+		}
 	}
 }


### PR DESCRIPTION
Basically, we want to route for instance http://example.com/resources/some%2Fpath/something from this HTTP annotation :

    get: /resources/{key}/something

We want the  key field in gRPC to be able to contain 0 or many slashes


#### References to other Issues or PRs

https://github.com/grpc-ecosystem/grpc-gateway/pull/660

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

#### Other comments
