### PR TITLE
fix: path template to valid openapi v2 parameters

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -10,11 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor"
-	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor/openapiconfig"
-	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule"
-	openapi_options "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/genproto/protobuf/field_mask"
 	"google.golang.org/protobuf/proto"
@@ -25,6 +20,12 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	"google.golang.org/protobuf/types/pluginpb"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor/openapiconfig"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule"
+	openapi_options "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 )
 
 var marshaler = &runtime.JSONPb{}
@@ -2616,7 +2617,7 @@ func TestApplyTemplateRequestWithBodyQueryParameters(t *testing.T) {
 								PathTmpl: httprule.Template{
 									Version:  1,
 									OpCodes:  []int{0, 0},
-									Template: "/v1/{parent=publishers/*}/books",
+									Template: "/v1/publishers/{parent}/books",
 								},
 								PathParams: []descriptor.Parameter{
 									{
@@ -2660,10 +2661,10 @@ func TestApplyTemplateRequestWithBodyQueryParameters(t *testing.T) {
 		return
 	}
 
-	if _, ok := result.Paths["/v1/{parent=publishers/*}/books"].Post.Responses["200"]; !ok {
-		t.Errorf("applyTemplate(%#v).%s = expected 200 response to be defined", file, `result.Paths["/v1/{parent=publishers/*}/books"].Post.Responses["200"]`)
+	if _, ok := result.Paths["/v1/publishers/{parent}/books"].Post.Responses["200"]; !ok {
+		t.Errorf("applyTemplate(%#v).%s = expected 200 response to be defined", file, `result.Paths["/v1/publishers/{parent}/books"].Post.Responses["200"]`)
 	} else {
-		if want, got, name := 3, len(result.Paths["/v1/{parent=publishers/*}/books"].Post.Parameters), `len(result.Paths["/v1/{parent=publishers/*}/books"].Post.Parameters)`; !reflect.DeepEqual(got, want) {
+		if want, got, name := 3, len(result.Paths["/v1/publishers/{parent}/books"].Post.Parameters), `len(result.Paths["/v1/publishers/{parent}/books"].Post.Parameters)`; !reflect.DeepEqual(got, want) {
 			t.Errorf("applyTemplate(%#v).%s = %d want to be %d", file, name, got, want)
 		}
 
@@ -2673,16 +2674,16 @@ func TestApplyTemplateRequestWithBodyQueryParameters(t *testing.T) {
 			Required bool
 		}
 
-		p0 := result.Paths["/v1/{parent=publishers/*}/books"].Post.Parameters[0]
-		if want, got, name := (param{"parent", "path", true}), (param{p0.Name, p0.In, p0.Required}), `result.Paths["/v1/{parent=publishers/*}/books"].Post.Parameters[0]`; !reflect.DeepEqual(got, want) {
+		p0 := result.Paths["/v1/publishers/{parent}/books"].Post.Parameters[0]
+		if want, got, name := (param{"parent", "path", true}), (param{p0.Name, p0.In, p0.Required}), `result.Paths["/v1/publishers/{parent}/books"].Post.Parameters[0]`; !reflect.DeepEqual(got, want) {
 			t.Errorf("applyTemplate(%#v).%s = %v want to be %v", file, name, got, want)
 		}
-		p1 := result.Paths["/v1/{parent=publishers/*}/books"].Post.Parameters[1]
-		if want, got, name := (param{"body", "body", true}), (param{p1.Name, p1.In, p1.Required}), `result.Paths["/v1/{parent=publishers/*}/books"].Post.Parameters[1]`; !reflect.DeepEqual(got, want) {
+		p1 := result.Paths["/v1/publishers/{parent}/books"].Post.Parameters[1]
+		if want, got, name := (param{"body", "body", true}), (param{p1.Name, p1.In, p1.Required}), `result.Paths["/v1/publishers/{parent}/books"].Post.Parameters[1]`; !reflect.DeepEqual(got, want) {
 			t.Errorf("applyTemplate(%#v).%s = %v want to be %v", file, name, got, want)
 		}
-		p2 := result.Paths["/v1/{parent=publishers/*}/books"].Post.Parameters[2]
-		if want, got, name := (param{"book_id", "query", false}), (param{p2.Name, p2.In, p2.Required}), `result.Paths["/v1/{parent=publishers/*}/books"].Post.Parameters[1]`; !reflect.DeepEqual(got, want) {
+		p2 := result.Paths["/v1/publishers/{parent}/books"].Post.Parameters[2]
+		if want, got, name := (param{"book_id", "query", false}), (param{p2.Name, p2.In, p2.Required}), `result.Paths["/v1/publishers/{parent}/books"].Post.Parameters[1]`; !reflect.DeepEqual(got, want) {
 			t.Errorf("applyTemplate(%#v).%s = %v want to be %v", file, name, got, want)
 		}
 	}
@@ -2798,20 +2799,20 @@ func TestTemplateToOpenAPIPath(t *testing.T) {
 	}{
 		{"/test", "/test"},
 		{"/{test}", "/{test}"},
-		{"/{test=prefix/*}", "/{test}"},
-		{"/{test=prefix/that/has/multiple/parts/to/it/*}", "/{test}"},
+		{"/{test=prefix/*}", "/prefix/{test}"},
+		{"/{test=prefix/that/has/multiple/parts/to/it/*}", "/prefix/that/has/multiple/parts/to/it/{test}"},
 		{"/{test1}/{test2}", "/{test1}/{test2}"},
 		{"/{test1}/{test2}/", "/{test1}/{test2}/"},
-		{"/{name=prefix/*}", "/{name=prefix/*}"},
-		{"/{name=prefix1/*/prefix2/*}", "/{name=prefix1/*/prefix2/*}"},
-		{"/{user.name=prefix/*}", "/{user.name=prefix/*}"},
-		{"/{user.name=prefix1/*/prefix2/*}", "/{user.name=prefix1/*/prefix2/*}"},
-		{"/{parent=prefix/*}/children", "/{parent=prefix/*}/children"},
-		{"/{name=prefix/*}:customMethod", "/{name=prefix/*}:customMethod"},
-		{"/{name=prefix1/*/prefix2/*}:customMethod", "/{name=prefix1/*/prefix2/*}:customMethod"},
-		{"/{user.name=prefix/*}:customMethod", "/{user.name=prefix/*}:customMethod"},
-		{"/{user.name=prefix1/*/prefix2/*}:customMethod", "/{user.name=prefix1/*/prefix2/*}:customMethod"},
-		{"/{parent=prefix/*}/children:customMethod", "/{parent=prefix/*}/children:customMethod"},
+		{"/{name=prefix/*}", "/prefix/{name}"},
+		{"/{name=prefix1/*/prefix2/*}", "/prefix1/{name.prefix1}/prefix2/{name.prefix2}"},
+		{"/{user.name=prefix/*}", "/prefix/{user.name}"},
+		{"/{user.name=prefix1/*/prefix2/*}", "/prefix1/{user.name.prefix1}/prefix2/{user.name.prefix2}"},
+		{"/{parent=prefix/*}/children", "/prefix/{parent}/children"},
+		{"/{name=prefix/*}:customMethod", "/prefix/{name}:customMethod"},
+		{"/{name=prefix1/*/prefix2/*}:customMethod", "/prefix1/{name.prefix1}/prefix2/{name.prefix2}:customMethod"},
+		{"/{user.name=prefix/*}:customMethod", "/prefix/{user.name}:customMethod"},
+		{"/{user.name=prefix1/*/prefix2/*}:customMethod", "/prefix1/{user.name.prefix1}/prefix2/{user.name.prefix2}:customMethod"},
+		{"/{parent=prefix/*}/children:customMethod", "/prefix/{parent}/children:customMethod"},
 	}
 	reg := descriptor.NewRegistry()
 	reg.SetUseJSONNamesForFields(false)
@@ -2915,8 +2916,8 @@ func TestFQMNtoOpenAPIName(t *testing.T) {
 	}{
 		{"/test", "/test"},
 		{"/{test}", "/{test}"},
-		{"/{test=prefix/*}", "/{test}"},
-		{"/{test=prefix/that/has/multiple/parts/to/it/*}", "/{test}"},
+		{"/{test=prefix/*}", "/prefix/{test}"},
+		{"/{test=prefix/that/has/multiple/parts/to/it/*}", "/prefix/that/has/multiple/parts/to/it/{test}"},
 		{"/{test1}/{test2}", "/{test1}/{test2}"},
 		{"/{test1}/{test2}/", "/{test1}/{test2}/"},
 	}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
 Fixes #2084

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

yes

#### Brief description of what is fixed or changed

Still very much a draft, but the idea is to support some basic path templates as described in the referenced issue - by re-writing the path to be valid openapi v2 syntax and adding separate parameters if needed.

I intend to handle plural nouns in the path to make things nicer - e.g. `name=/orgs/*/projects/*` creates parameters `org` and `project` and path `/orgs/{org}/projects/{project}`.

#### Other comments

The code that I changed seemed quite complex in the sense that it may have been written to handle some cases that were not covered in unit tests and that I wasn't aware of. We just need to be careful about not breaking anyone with this change like it happened in the past when others tried to fix similar issues.