### PR TITLE
fix: Set Content-Type from marshaler on stream error

### DIFF
--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -202,10 +202,12 @@ func handleForwardResponseOptions(ctx context.Context, w http.ResponseWriter, re
 
 func handleForwardResponseStreamError(ctx context.Context, wroteHeader bool, marshaler Marshaler, w http.ResponseWriter, req *http.Request, mux *ServeMux, err error) {
 	st := mux.streamErrorHandler(ctx, err)
+	msg := errorChunk(st)
 	if !wroteHeader {
+		w.Header().Set("Content-Type", marshaler.ContentType(msg))
 		w.WriteHeader(HTTPStatusFromCode(st.Code()))
 	}
-	buf, merr := marshaler.Marshal(errorChunk(st))
+	buf, merr := marshaler.Marshal(msg)
 	if merr != nil {
 		grpclog.Infof("Failed to marshal an error: %v", merr)
 		return

--- a/runtime/handler_test.go
+++ b/runtime/handler_test.go
@@ -109,6 +109,9 @@ func TestForwardResponseStream(t *testing.T) {
 				t.Errorf("Failed to read response body with %v", err)
 			}
 			w.Body.Close()
+			if len(body) > 0 && w.Header.Get("Content-Type") != "application/json" {
+				t.Errorf("Content-Type %s want application/json", w.Header.Get("Content-Type"))
+			}
 
 			var want []byte
 			for i, msg := range tt.msgs {
@@ -239,6 +242,9 @@ func TestForwardResponseStreamCustomMarshaler(t *testing.T) {
 				t.Errorf("Failed to read response body with %v", err)
 			}
 			w.Body.Close()
+			if len(body) > 0 && w.Header.Get("Content-Type") != "Custom-Content-Type" {
+				t.Errorf("Content-Type %s want Custom-Content-Type", w.Header.Get("Content-Type"))
+			}
 
 			var want []byte
 			for _, msg := range tt.msgs {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

--

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

The marshaler was used to marshal the body of a stream error, but the content type was not used, leaving it as `text/plain; charset=utf-8`. This uses the content type as defined by the marshaler if the headers have not already been written.

#### Other comments

--