### PR TITLE
Update devcontainer and build env

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,34 +1,53 @@
 FROM golang:1.17.0
 
-# Warm apt cache and install dependencies
-# bzip2 is required by the node_tests (to extract its dependencies).
-# patch is required by bazel tests
+ENV NVM_DIR="/usr/local/share/nvm"
+ENV NVM_SYMLINK_CURRENT=true \
+    PATH=${NVM_DIR}/current/bin:${PATH}
+
+ARG VSCODE_SCRIPTS_VERSION="v0.193.0"
+ARG NODE_VERSION="10"
+# Run some common installation scripts for a nicer dev environment. In order:
+# Used to create non-root user and update system packages
+# https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
+# We use this to install Go tools used by gopls
+# https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/go.md
+# We use this to install Node
+# https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 RUN apt-get update && \
-    apt-get install -y wget unzip \
-    openjdk-11-jre \
-    bzip2 \
-    patch
+    wget "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/${VSCODE_SCRIPTS_VERSION}/script-library/common-debian.sh" && \
+    chmod +x ./common-debian.sh && \
+    ./common-debian.sh false vscode automatic automatic true false && \
+    wget "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/${VSCODE_SCRIPTS_VERSION}/script-library/go-debian.sh" && \
+    chmod +x ./go-debian.sh && \
+    ./go-debian.sh none /usr/local/go /go vscode false true && \
+    wget "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/${VSCODE_SCRIPTS_VERSION}/script-library/node-debian.sh" && \
+    chmod +x ./node-debian.sh && \
+    ./node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" vscode true && \
+    rm common-debian.sh go-debian.sh node-debian.sh && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+        wget \
+        unzip \
+        openjdk-11-jre \
+        bzip2 \
+        patch && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install swagger-codegen
 ENV SWAGGER_CODEGEN_VERSION=2.4.8
 RUN wget https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/${SWAGGER_CODEGEN_VERSION}/swagger-codegen-cli-${SWAGGER_CODEGEN_VERSION}.jar \
-    -O /usr/local/bin/swagger-codegen-cli.jar
-
-# Wrap the jar for swagger-codgen
-RUN echo -e '#!/bin/bash\njava -jar /usr/local/bin/swagger-codegen-cli.jar "$@"' > /usr/local/bin/swagger-codegen && \
+    -O /usr/local/bin/swagger-codegen-cli.jar && \
+    echo -e '#!/bin/bash\njava -jar /usr/local/bin/swagger-codegen-cli.jar "$@"' > /usr/local/bin/swagger-codegen && \
 	chmod +x /usr/local/bin/swagger-codegen
 
-# Install node, used by NVM
-ENV NODE_VERSION=v10.16.3
-ENV NVM_VERSION=v0.35.0
-RUN wget -qO- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
-
 # Install Bazelisk as bazel to manage Bazel
-RUN go get github.com/bazelbuild/bazelisk && \
+RUN go install github.com/bazelbuild/bazelisk@latest && \
     mv $(which bazelisk) /usr/local/bin/bazel
 
-# Clean up
-RUN apt-get autoremove -y && \
-    apt-get remove -y wget \
-    unzip && \
-    rm -rf /var/lib/apt/lists/*
+# Install buildifier for bazel formatting
+RUN go install github.com/bazelbuild/buildtools/buildifier@latest
+
+# Give vscode ownership of GOPATH
+RUN chown -R vscode: /go
+
+USER vscode

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -5,4 +5,4 @@ Contained within is the CI test setup for the Gateway. It runs on Circle CI.
 ### Whats up with the Dockerfile?
 
 The `Dockerfile` in this folder is used as the build environment when regenerating the files (see CONTRIBUTING.md).
-The canonical repository for this Dockerfile is `docker.pkg.github.com/grpc-ecosystem/grpc-gateway/build-env`.
+The canonical repository for this Dockerfile is `ghcr.io/grpc-ecosystem/grpc-gateway/build-env`.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ executors:
       password1: "3ec86b2e5a431be2d72c"
       GLOG_logtostderr: "1"
     docker:
-      - image: docker.pkg.github.com/grpc-ecosystem/grpc-gateway/build-env:1.16
+      - image: docker.pkg.github.com/grpc-ecosystem/grpc-gateway/build-env:1.17
         auth:
           username: gateway-ci-user
           password: ${password0}${password1}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ commands:
     steps:
       - run: |
           cat > .bazelrc \<< EOF
-          startup --output_base /root/.cache/_grpc_gateway_bazel
+          startup --output_base /home/vscode/.cache/_grpc_gateway_bazel
           build --test_output errors
           build --features race
           # Workaround https://github.com/bazelbuild/bazel/issues/3645
@@ -109,7 +109,7 @@ jobs:
       - save_cache:
           key: v3-bazel-cache-{{ checksum "repositories.bzl" }}
           paths:
-            - /root/.cache/_grpc_gateway_bazel
+            - /home/vscode/.cache/_grpc_gateway_bazel
   gorelease:
     executor: build-env
     working_directory: /home/vscode/src/grpc-gateway

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,6 @@ jobs:
       - checkout
       - run: go mod vendor
       - run: >
-          . $HOME/.nvm/nvm.sh &&
           cd examples/internal/browser &&
           npm install gulp-cli &&
           npm install &&

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,8 +85,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v2-bazel-cache-{{ checksum "repositories.bzl" }}
-            - v2-bazel-cache-
+            - v3-bazel-cache-{{ checksum "repositories.bzl" }}
+            - v3-bazel-cache-
       - configure_bazel
       - run:
           name: Check that Bazel BUILD files are up-to-date
@@ -107,7 +107,7 @@ jobs:
           name: Run tests with Bazel
           command: bazel test //...
       - save_cache:
-          key: v2-bazel-cache-{{ checksum "repositories.bzl" }}
+          key: v3-bazel-cache-{{ checksum "repositories.bzl" }}
           paths:
             - /root/.cache/_grpc_gateway_bazel
   gorelease:
@@ -151,8 +151,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v2-bazel-cache-{{ checksum "repositories.bzl" }}
-            - v2-bazel-cache-
+            - v3-bazel-cache-{{ checksum "repositories.bzl" }}
+            - v3-bazel-cache-
       - configure_bazel
       - run:
           name: Update repositories.bzl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,20 +49,20 @@ executors:
 jobs:
   build:
     executor: build-env
-    working_directory: /src/grpc-gateway
+    working_directory: /home/vscode/src/grpc-gateway
     steps:
       - checkout
       - run: go build ./...
   test:
     executor: build-env
-    working_directory: /src/grpc-gateway
+    working_directory: /home/vscode/src/grpc-gateway
     steps:
       - checkout
       - run: go test -race -coverprofile=coverage.txt ./...
       - run: bash <(curl -s https://codecov.io/bash)
   node_test:
     executor: build-env
-    working_directory: /src/grpc-gateway
+    working_directory: /home/vscode/src/grpc-gateway
     steps:
       - checkout
       - run: go mod vendor
@@ -73,14 +73,14 @@ jobs:
           ./node_modules/.bin/gulp
   generate:
     executor: build-env
-    working_directory: /src/grpc-gateway
+    working_directory: /home/vscode/src/grpc-gateway
     steps:
       - checkout
       - generate
       - run: git diff --exit-code
   bazel:
     executor: build-env
-    working_directory: /src/grpc-gateway
+    working_directory: /home/vscode/src/grpc-gateway
     steps:
       - checkout
       - restore_cache:
@@ -112,7 +112,7 @@ jobs:
             - /root/.cache/_grpc_gateway_bazel
   gorelease:
     executor: build-env
-    working_directory: /src/grpc-gateway
+    working_directory: /home/vscode/src/grpc-gateway
     steps:
       - checkout
       - run:
@@ -139,14 +139,14 @@ jobs:
       - run: buf push --tag "$CIRCLE_SHA1"
   release:
     executor: build-env
-    working_directory: /src/grpc-gateway
+    working_directory: /home/vscode/src/grpc-gateway
     steps:
       - checkout
       - run: go mod vendor
       - run: curl -sL https://git.io/goreleaser | bash
   update-repositoriesbzl:
     executor: build-env
-    working_directory: /src/grpc-gateway
+    working_directory: /home/vscode/src/grpc-gateway
     steps:
       - checkout
       - restore_cache:
@@ -161,7 +161,7 @@ jobs:
       - renovate_git_amend_push
   regenerate:
     executor: build-env
-    working_directory: /src/grpc-gateway
+    working_directory: /home/vscode/src/grpc-gateway
     steps:
       - checkout
       - generate

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,8 +4,7 @@
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"editor.formatOnSave": true,
-		"terminal.integrated.shell.linux": "/bin/bash",
-		"go.useGoProxyToCheckForToolUpdates": true,
+		"go.toolsManagement.autoUpdate": true,
 		"go.useLanguageServer": true,
 		"go.gopath": "/go",
 		"go.goroot": "/usr/local/go",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,22 +1,25 @@
+// For format details, see https://aka.ms/devcontainer.json.
 {
-	"dockerFile": "../.circleci/Dockerfile",
-	"overrideCommand": true,
-	// Set *default* container specific settings.json values on container create.
+	"name": "Go",
+	"build": {
+		"dockerfile": "../Dockerfile",
+		"args": {
+			"NODE_VERSION": "10"
+		}
+	},
 	"settings": {
 		"editor.formatOnSave": true,
-		"go.toolsManagement.autoUpdate": true,
+		"go.toolsManagement.checkForUpdates": "local",
 		"go.useLanguageServer": true,
 		"go.gopath": "/go",
 		"go.goroot": "/usr/local/go",
-		"go.toolsGopath": "/go/bin",
 		"bazel.buildifierExecutable": "/go/bin/buildifier",
 		"bazel.buildifierFixOnFormat": true,
 		"bazel.enableCodeLens": true,
 	},
-	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"golang.Go",
 		"bazelbuild.vscode-bazel",
 	],
-	"postCreateCommand": "cd $(mktemp -d) && GO111MODULE=on go get golang.org/x/tools/gopls@latest github.com/bazelbuild/buildtools/buildifier@latest && cd -",
+	"remoteUser": "vscode"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,5 @@
 # How to contribute
 
-Thank you for your contribution to gRPC-Gateway.
-Here's the recommended process of contribution.
-
-1. `go get github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway`
-1. `cd $GOPATH/src/github.com/grpc-ecosystem/grpc-gateway`
-1. hack, hack, hack...
-1. Make sure that your change follows best practices in Go
-   - [Effective Go](https://golang.org/doc/effective_go.html)
-   - [Go Code Review Comments](https://golang.org/wiki/CodeReviewComments)
-1. Make sure that `go test ./...` passes.
-1. Sign [a Contributor License Agreement](https://cla.developers.google.com/clas)
-1. Open a pull request in GitHub
-
-When you work on a larger contribution, it is also recommended that you get in touch
-with us through the issue tracker.
-
 ## Code reviews
 
 All submissions, including submissions by project members, require review.
@@ -27,9 +11,8 @@ All submissions, including submissions by project members, require review.
 It should be as simple as this (run from the root of the repository):
 
 ```bash
-docker run -v $(pwd):/src/grpc-gateway --rm docker.pkg.github.com/grpc-ecosystem/grpc-gateway/build-env:1.16 \
-    /bin/bash -c 'cd /src/grpc-gateway && \
-        make install && \
+docker run -v $(pwd):/grpc-gateway -w /grpc-gateway --rm ghcr.io/grpc-ecosystem/grpc-gateway/build-env:1.16 \
+    /bin/bash -c 'make install && \
         make clean && \
         make generate'
 docker run -itv $(pwd):/grpc-gateway -w /grpc-gateway --entrypoint /bin/bash --rm \

--- a/Makefile
+++ b/Makefile
@@ -81,14 +81,10 @@ $(GENERATE_UNBOUND_METHODS_EXAMPLE_SRCS): $(GENERATE_UNBOUND_METHODS_EXAMPLE_SPE
 	@rm -f $(EXAMPLE_CLIENT_DIR)/generateunboundmethods/README.md \
 		$(EXAMPLE_CLIENT_DIR)/generateunboundmethods/git_push.sh
 
-TMP_INSTALL_DIR := $(shell mktemp -d)
 install:
-	@mkdir -p ${TMP_INSTALL_DIR}
-	cd ${TMP_INSTALL_DIR} && go get \
-		google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0 \
-		google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1 \
-		github.com/bufbuild/buf/cmd/buf@v0.51.1
-	@rmdir ${TMP_INSTALL_DIR}
+	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0
+	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1
+	go install github.com/bufbuild/buf/cmd/buf@v0.51.1
 
 	go install \
 		./protoc-gen-openapiv2 \

--- a/protoc-gen-grpc-gateway/Dockerfile
+++ b/protoc-gen-grpc-gateway/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.17.0 as builder
+
+ARG RELEASE_VERSION
+
+# Buf plugins must be built for linux/amd64
+ENV GOOS=linux GOARCH=amd64 CGO_ENABLED=0
+RUN go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@${RELEASE_VERSION}
+
+FROM scratch
+
+COPY --from=builder /go/bin/protoc-gen-grpc-gateway /usr/local/bin/protoc-gen-grpc-gateway
+
+ENTRYPOINT ["/usr/local/bin/protoc-gen-grpc-gateway"]

--- a/protoc-gen-openapiv2/Dockerfile
+++ b/protoc-gen-openapiv2/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.17.0 as builder
+
+ARG RELEASE_VERSION
+
+# Buf plugins must be built for linux/amd64
+ENV GOOS=linux GOARCH=amd64 CGO_ENABLED=0
+RUN go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@${RELEASE_VERSION}
+
+FROM scratch
+
+COPY --from=builder /go/bin/protoc-gen-openapiv2 /usr/local/bin/protoc-gen-openapiv2
+
+ENTRYPOINT ["/usr/local/bin/protoc-gen-openapiv2"]


### PR DESCRIPTION
The devcontainer was using the build-env, which was strictly not designed to be a nice environment to develop in. Now that Codespaces are generally available, we should make this development environment better for contributors, and it doesn't hurt the CI in any way (I hope).