### PR TITLE
Decode path-encoded URL components

### DIFF
--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -39,6 +39,10 @@ When a message is added which happens to conflict with another message (e.g. by 
 
 The gRPC-Gateway is a generator that generates a Go implementation of a JSON/HTTP-gRPC reverse proxy based on annotations in your proto file, while the [grpc-httpjson-transcoding](https://github.com/grpc-ecosystem/grpc-httpjson-transcoding) library doesn't require the generation step, it uses protobuf descriptors as config. It can be used as a component of an existing proxy. Google Cloud Endpoints and the gRPC-JSON transcoder filter in Envoy are using this.
 
+<!-- TODO(v3): remove this note when default behavior matches Envoy/Cloud Endpoints -->
+**Behavior differences:**
+- By default, gRPC-Gateway does not escape path parameters in the same way. [This can be configured.](../mapping/customizing_your_gateway.md#Controlling-path-parameter-unescaping)
+
 ## What is the difference between the gRPC-Gateway and gRPC-web?
 
 ### Usage

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -286,7 +286,6 @@ func (s *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		pathParams, err := h.pat.MatchAndEscape(components, verb, s.unescapingMode)
 		if err != nil {
-			// malformed escape sequence
 			if err == ErrMalformedSequence {
 				_, outboundMarshaler := MarshalerForRequest(s, r)
 				s.routingErrorHandler(ctx, s, outboundMarshaler, w, r, http.StatusBadRequest)
@@ -306,7 +305,6 @@ func (s *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		for _, h := range handlers {
 			pathParams, err := h.pat.MatchAndEscape(components, verb, s.unescapingMode)
 			if err != nil {
-				// malformed escape sequence
 				if err == ErrMalformedSequence {
 					_, outboundMarshaler := MarshalerForRequest(s, r)
 					s.routingErrorHandler(ctx, s, outboundMarshaler, w, r, http.StatusBadRequest)

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -14,6 +14,31 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// UnescapingMode defines the behavior of grpc-gateway for URL escaping.
+type UnescapingMode int
+
+const (
+	// UnescapingModeLegacy is the default V2 behavior, which escapes the entire
+	// path string before doing any routing.
+	UnescapingModeLegacy UnescapingMode = iota
+
+	// EscapingTypeExceptReserved unescapes all path parameters except RFC 6570
+	// reserved characters.
+	UnescapingModeAllExceptReserved
+
+	// EscapingTypeExceptSlash unescapes URL path parameters except path
+	// seperators, which will be left as "%2F".
+	UnescapingModeAllExceptSlash
+
+	// URL path parameters will be fully decoded.
+	UnescapingModeAllCharacters
+
+	// UnescapingModeDefault is the default escaping type.
+	// TODO(v3): default this to UnescapingModeAllExceptReserved per grpc-httpjson-transcoding's
+	// reference implementation
+	UnescapingModeDefault = UnescapingModeLegacy
+)
+
 // A HandlerFunc handles a specific pair of path pattern and HTTP method.
 type HandlerFunc func(w http.ResponseWriter, r *http.Request, pathParams map[string]string)
 
@@ -31,6 +56,7 @@ type ServeMux struct {
 	streamErrorHandler        StreamErrorHandlerFunc
 	routingErrorHandler       RoutingErrorHandlerFunc
 	disablePathLengthFallback bool
+	unescapingMode            UnescapingMode
 }
 
 // ServeMuxOption is an option that can be given to a ServeMux on construction.
@@ -45,6 +71,14 @@ type ServeMuxOption func(*ServeMux)
 func WithForwardResponseOption(forwardResponseOption func(context.Context, http.ResponseWriter, proto.Message) error) ServeMuxOption {
 	return func(serveMux *ServeMux) {
 		serveMux.forwardResponseOptions = append(serveMux.forwardResponseOptions, forwardResponseOption)
+	}
+}
+
+// WithEscapingType sets the escaping type. See the definitions of UnescapingMode
+// for more information.
+func WithUnescapingMode(mode UnescapingMode) ServeMuxOption {
+	return func(serveMux *ServeMux) {
+		serveMux.unescapingMode = mode
 	}
 }
 
@@ -153,6 +187,7 @@ func NewServeMux(opts ...ServeMuxOption) *ServeMux {
 		errorHandler:           DefaultHTTPErrorHandler,
 		streamErrorHandler:     DefaultStreamErrorHandler,
 		routingErrorHandler:    DefaultRoutingErrorHandler,
+		unescapingMode:         UnescapingModeDefault,
 	}
 
 	for _, opt := range opts {
@@ -204,6 +239,11 @@ func (s *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// TODO(v3): remove UnescapingModeLegacy
+	if s.unescapingMode != UnescapingModeLegacy && r.URL.RawPath != "" {
+		path = r.URL.RawPath
+	}
+
 	components := strings.Split(path[1:], "/")
 
 	if override := r.Header.Get("X-HTTP-Method-Override"); override != "" && s.isPathLengthFallback(r) {
@@ -244,8 +284,13 @@ func (s *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			components[l-1], verb = lastComponent[:idx], lastComponent[idx+1:]
 		}
 
-		pathParams, err := h.pat.Match(components, verb)
+		pathParams, err := h.pat.MatchAndEscape(components, verb, s.unescapingMode)
 		if err != nil {
+			// malformed escape sequence
+			if err == ErrMalformedSequence {
+				_, outboundMarshaler := MarshalerForRequest(s, r)
+				s.routingErrorHandler(ctx, s, outboundMarshaler, w, r, http.StatusBadRequest)
+			}
 			continue
 		}
 		h.h(w, r, pathParams)
@@ -259,8 +304,13 @@ func (s *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		for _, h := range handlers {
-			pathParams, err := h.pat.Match(components, verb)
+			pathParams, err := h.pat.MatchAndEscape(components, verb, s.unescapingMode)
 			if err != nil {
+				// malformed escape sequence
+				if err == ErrMalformedSequence {
+					_, outboundMarshaler := MarshalerForRequest(s, r)
+					s.routingErrorHandler(ctx, s, outboundMarshaler, w, r, http.StatusBadRequest)
+				}
 				continue
 			}
 			// X-HTTP-Method-Override is optional. Always allow fallback to POST.

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -1,8 +1,8 @@
 package runtime
 
 import (
-	"errors"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/textproto"

--- a/runtime/pattern.go
+++ b/runtime/pattern.go
@@ -14,6 +14,8 @@ var (
 	ErrNotMatch = errors.New("not match to the path pattern")
 	// ErrInvalidPattern indicates that the given definition of Pattern is not valid.
 	ErrInvalidPattern = errors.New("invalid pattern")
+	// ErrMalformedSequence indicates that an escape sequence was malformed.
+	ErrMalformedSequence = errors.New("malformed escape sequence")
 )
 
 type op struct {
@@ -140,10 +142,11 @@ func MustPattern(p Pattern, err error) Pattern {
 	return p
 }
 
-// Match examines components if it matches to the Pattern.
-// If it matches, the function returns a mapping from field paths to their captured values.
-// If otherwise, the function returns an error.
-func (p Pattern) Match(components []string, verb string) (map[string]string, error) {
+// MatchAndEscape examines components if it matches to the Pattern. If it matches,
+// the function returns a mapping from field paths to their captured values while
+// applying the provided unescaping mode, returning an error if the URL encoding
+// is malformed. Otherwise, the function returns an error.
+func (p Pattern) MatchAndEscape(components []string, verb string, unescapingMode UnescapingMode) (map[string]string, error) {
 	if p.verb != verb {
 		if p.verb != "" {
 			return nil, ErrNotMatch
@@ -161,6 +164,8 @@ func (p Pattern) Match(components []string, verb string) (map[string]string, err
 	captured := make([]string, len(p.vars))
 	l := len(components)
 	for _, op := range p.ops {
+		var err error
+
 		switch op.code {
 		case utilities.OpNop:
 			continue
@@ -173,6 +178,10 @@ func (p Pattern) Match(components []string, verb string) (map[string]string, err
 				if lit := p.pool[op.operand]; c != lit {
 					return nil, ErrNotMatch
 				}
+			} else if op.code == utilities.OpPush {
+				if c, err = unescape(c, unescapingMode, false); err != nil {
+					return nil, ErrMalformedSequence
+				}
 			}
 			stack = append(stack, c)
 			pos++
@@ -182,7 +191,11 @@ func (p Pattern) Match(components []string, verb string) (map[string]string, err
 				return nil, ErrNotMatch
 			}
 			end -= p.tailLen
-			stack = append(stack, strings.Join(components[pos:end], "/"))
+			c := strings.Join(components[pos:end], "/")
+			if c, err = unescape(c, unescapingMode, true); err != nil {
+				return nil, ErrMalformedSequence
+			}
+			stack = append(stack, c)
 			pos = end
 		case utilities.OpConcatN:
 			n := op.operand
@@ -202,6 +215,15 @@ func (p Pattern) Match(components []string, verb string) (map[string]string, err
 		bindings[p.vars[i]] = val
 	}
 	return bindings, nil
+}
+
+// Match examines components if it matches to the Pattern.
+// If it matches, the function returns a mapping from field paths to their captured values.
+// If otherwise, the function returns an error.
+//
+// Deprecated: Use MatchAndEscape.
+func (p Pattern) Match(components []string, verb string) (map[string]string, error) {
+	return p.MatchAndEscape(components, verb, UnescapingModeDefault)
 }
 
 // Verb returns the verb part of the Pattern.
@@ -234,3 +256,122 @@ func (p Pattern) String() string {
 	}
 	return "/" + segs
 }
+
+/*
+ * The following code is adopted and modified from Go's standard library
+ * and carries the attached license.
+ *
+ *     Copyright 2009 The Go Authors. All rights reserved.
+ *     Use of this source code is governed by a BSD-style
+ *     license that can be found in the LICENSE file.
+ */
+
+// ishex returns whether or not the given byte is a valid hex character
+func ishex(c byte) bool {
+	switch {
+	case '0' <= c && c <= '9':
+		return true
+	case 'a' <= c && c <= 'f':
+		return true
+	case 'A' <= c && c <= 'F':
+		return true
+	}
+	return false
+}
+
+
+func isRFC6570Reserved(c byte) bool {
+	switch c {
+	case '!', '#', '$', '&', '\'', '(', ')', '*',
+		'+', ',', '/', ':', ';', '=', '?', '@', '[', ']':
+		return true
+	default:
+		return false
+	}
+}
+
+// unhex converts a hex point to the bit representation
+func unhex(c byte) byte {
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0'
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10
+	case 'A' <= c && c <= 'F':
+		return c - 'A' + 10
+	}
+	return 0
+}
+
+// shouldUnescapeWithMode returns true if the character is escapable with the
+// given mode
+func shouldUnescapeWithMode(c byte, mode UnescapingMode) bool {
+	switch mode {
+	case UnescapingModeAllExceptReserved:
+		if isRFC6570Reserved(c) {
+			return false
+		}
+	case UnescapingModeAllExceptSlash:
+		if c == '/' {
+			return false
+		}
+	case UnescapingModeAllCharacters:
+		return true
+	}
+	return true
+}
+
+// unescape unescapes a path string using the provided mode
+func unescape(s string, mode UnescapingMode, multisegment bool) (string, error) {
+	// TODO(v3): remove UnescapingModeLegacy
+	if mode == UnescapingModeLegacy {
+		return s, nil
+	}
+
+	if !multisegment {
+		mode = UnescapingModeAllCharacters
+	}
+
+	// Count %, check that they're well-formed.
+	n := 0
+	for i := 0; i < len(s); {
+		if s[i] == '%' {
+			n++
+			if i+2 >= len(s) || !ishex(s[i+1]) || !ishex(s[i+2]) {
+				s = s[i:]
+				if len(s) > 3 {
+					s = s[:3]
+				}
+
+				return "", ErrMalformedSequence
+			}
+			i += 3
+		} else {
+			i++
+		}
+	}
+
+	if n == 0 {
+		return s, nil
+	}
+
+	var t strings.Builder
+	t.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '%':
+			c := unhex(s[i+1])<<4 | unhex(s[i+2])
+			if shouldUnescapeWithMode(c, mode) {
+				t.WriteByte(c)
+				i += 2
+				continue
+			}
+			fallthrough
+		default:
+			t.WriteByte(s[i])
+		}
+	}
+
+	return t.String(), nil
+}
+

--- a/runtime/pattern.go
+++ b/runtime/pattern.go
@@ -149,10 +149,10 @@ func MustPattern(p Pattern, err error) Pattern {
 	return p
 }
 
-// MatchAndEscape examines components if it matches to the Pattern. If it matches,
-// the function returns a mapping from field paths to their captured values while
-// applying the provided unescaping mode, returning an error if the URL encoding
-// is malformed. Otherwise, the function returns an error.
+// MatchAndEscape examines components to determine if they match to a Pattern.
+// MatchAndEscape will return an error if no Patterns matched or if a pattern
+// matched but contained malformed escape sequences. If successful, the function
+// returns a mapping from field paths to their captured values.
 func (p Pattern) MatchAndEscape(components []string, verb string, unescapingMode UnescapingMode) (map[string]string, error) {
 	if p.verb != verb {
 		if p.verb != "" {
@@ -224,9 +224,10 @@ func (p Pattern) MatchAndEscape(components []string, verb string, unescapingMode
 	return bindings, nil
 }
 
-// Match examines components if it matches to the Pattern.
-// If it matches, the function returns a mapping from field paths to their captured values.
-// If otherwise, the function returns an error.
+// MatchAndEscape examines components to determine if they match to a Pattern.
+// It will never perform per-component unescaping (see: UnescapingModeLegacy).
+// MatchAndEscape will return an error if no Patterns matched. If successful,
+// the function returns a mapping from field paths to their captured values.
 //
 // Deprecated: Use MatchAndEscape.
 func (p Pattern) Match(components []string, verb string) (map[string]string, error) {
@@ -285,7 +286,6 @@ func ishex(c byte) bool {
 	}
 	return false
 }
-
 
 func isRFC6570Reserved(c byte) bool {
 	switch c {
@@ -381,4 +381,3 @@ func unescape(s string, mode UnescapingMode, multisegment bool) (string, error) 
 
 	return t.String(), nil
 }
-


### PR DESCRIPTION
This change causes pct-encoded characters passed via path parameters to
be correctly decoded as described in google.api.http (see: path template
syntax) and as implemented in grpc-http-json-transcoding.

A new configuration option is introduced, `WithDecodeMode()`, which
understands several modes. Backwards compatibility is maintained, with
the hope of UnescapingModeAllExceptReserved becoming the default mode in
V3.

#### References to other Issues or PRs

Fixes #660

Similiar to #2259, with a few significant differences: preserves backwards compatibility and strictly implements the spec describe in google.api.http and implemented in grpc-http-transcoding.

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

- Backwards compatibility is maintained via `UnescapingModeLegacy`, which short-circuits the path encoding flow.
- Strictly implements the spec as described in the google.api.http, if the template is multi-segment, %2F _should not_  decoded into `/`.
- Follows the reference implementation at [grpc-http-json-transcoding](https://github.com/grpc-ecosystem/grpc-httpjson-transcoding/blob/master/src/include/grpc_transcoding/path_matcher.h)
    - Provides multiple user-configurable decoding modes  (`UnescapingModeAllExceptReserved`, `UnescapingModeAllExceptSlash`, `UnescapingModeDefault`, and `UnescapingModeLegacy`)
    - Decoding occurs only for variable binding, routing does not use decoding.

#### Other comments

n/a