### PR TITLE
Fix typo in openapiv2.proto example

### DIFF
--- a/protoc-gen-openapiv2/options/openapiv2.pb.go
+++ b/protoc-gen-openapiv2/options/openapiv2.pb.go
@@ -1354,7 +1354,7 @@ func (x *Schema) GetExample() string {
 //    // Id represents the message identifier.
 //    string id = 1; [
 //        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-//          {description: "The unique identifier of the simple message."
+//          description: "The unique identifier of the simple message."
 //        }];
 //  }
 //

--- a/protoc-gen-openapiv2/options/openapiv2.proto
+++ b/protoc-gen-openapiv2/options/openapiv2.proto
@@ -411,7 +411,7 @@ message Schema {
 //    // Id represents the message identifier.
 //    string id = 1; [
 //        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-//          {description: "The unique identifier of the simple message."
+//          description: "The unique identifier of the simple message."
 //        }];
 //  }
 //


### PR DESCRIPTION
#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

Fixed a typo in one of the examples in `openapiv2.proto`.
