### PR TITLE
Log zero property as warning instead of error

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -975,7 +975,7 @@ func renderServices(services []*descriptor.Service, paths openapiPathsObject, re
 							if len(bodyExcludedFields) != 0 {
 								schema = renderMessageAsDefinition(meth.RequestType, reg, customRefs, bodyExcludedFields)
 								if schema.Properties == nil || len(*schema.Properties) == 0 {
-									glog.Errorf("created a body with 0 properties in the message, this might be unintended: %s", *meth.RequestType)
+									glog.Warningf("created a body with 0 properties in the message, this might be unintended: %s", *meth.RequestType)
 								}
 							} else {
 								err := schema.setRefFromFQN(meth.RequestType.FQMN(), reg)


### PR DESCRIPTION

#### References to other Issues or PRs

Originally discussed from https://github.com/grpc-ecosystem/grpc-gateway/pull/2078#discussion_r726698849

Related to https://github.com/grpc-ecosystem/grpc-gateway/pull/2078

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

I read it, and run docker commands. No additional changes.

#### Brief description of what is fixed or changed

For prudent design, warning may be more appropriate than error I think.

It could be more tolerant if want to express the state that fields can be added to the body not right now, It's just "empty" instead of "void" like below.

```proto
service Greeting {
  rpc Hello(HelloRequest) returns (HelloResponse) {
    option (google.api.http) = {
      post: "/v1/users/{user_id}/hello"
      body: "*"
    };
  }
}

message HelloRequest {
  string user_id = 1;
}
```
