### PR TITLE
fix(tutorials): remove usage of `WithBlock` in examples

### DIFF
--- a/docs/docs/tutorials/adding_annotations.md
+++ b/docs/docs/tutorials/adding_annotations.md
@@ -163,7 +163,6 @@ func main() {
 	conn, err := grpc.DialContext(
 		context.Background(),
 		"0.0.0.0:8080",
-		grpc.WithBlock(),
 		grpc.WithInsecure(),
 	)
 	if err != nil {


### PR DESCRIPTION
close #2425 