### PR TITLE
build: upgrade `go` directive in `go.mod` to 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grpc-ecosystem/grpc-gateway/v2
 
-go 1.14
+go 1.17
 
 require (
 	github.com/antihax/optional v1.0.0
@@ -13,4 +13,13 @@ require (
 	google.golang.org/grpc v1.42.0
 	google.golang.org/protobuf v1.27.1
 	sigs.k8s.io/yaml v1.3.0
+)
+
+require (
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )


### PR DESCRIPTION
#### References to other Issues or PRs

N/A

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

Upgrading the `go` directive in `go.mod` file by running `go mod tidy -go=1.17` to enable [module graph pruning](https://golang.org/ref/mod#graph-pruning) and [lazy module loading](https://golang.org/ref/mod#lazy-loading).

#### Other comments

This does not prevent users with earlier Go versions from successfully building packages from this module.