### PR TITLE
Revert "support grpc.ClientConnInterface in RegisterXXXHandler (#2398)"

### DIFF
--- a/examples/internal/gateway/gateway.go
+++ b/examples/internal/gateway/gateway.go
@@ -18,7 +18,7 @@ func newGateway(ctx context.Context, conn *grpc.ClientConn, opts []gwruntime.Ser
 
 	mux := gwruntime.NewServeMux(opts...)
 
-	for _, f := range []func(context.Context, *gwruntime.ServeMux, grpc.ClientConnInterface) error{
+	for _, f := range []func(context.Context, *gwruntime.ServeMux, *grpc.ClientConn) error{
 		examplepb.RegisterEchoServiceHandler,
 		standalone.RegisterUnannotatedEchoServiceHandler,
 		examplepb.RegisterStreamServiceHandler,

--- a/examples/internal/helloworld/helloworld.pb.gw.go
+++ b/examples/internal/helloworld/helloworld.pb.gw.go
@@ -997,7 +997,7 @@ func RegisterGreeterHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeM
 
 // RegisterGreeterHandler registers the http handlers for service Greeter to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterGreeterHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterGreeterHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterGreeterHandlerClient(ctx, mux, NewGreeterClient(conn))
 }
 

--- a/examples/internal/proto/examplepb/a_bit_of_everything.pb.gw.go
+++ b/examples/internal/proto/examplepb/a_bit_of_everything.pb.gw.go
@@ -3028,7 +3028,7 @@ func RegisterABitOfEverythingServiceHandlerFromEndpoint(ctx context.Context, mux
 
 // RegisterABitOfEverythingServiceHandler registers the http handlers for service ABitOfEverythingService to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterABitOfEverythingServiceHandlerClient(ctx, mux, NewABitOfEverythingServiceClient(conn))
 }
 
@@ -3721,7 +3721,7 @@ func RegisterCamelCaseServiceNameHandlerFromEndpoint(ctx context.Context, mux *r
 
 // RegisterCamelCaseServiceNameHandler registers the http handlers for service CamelCaseServiceName to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterCamelCaseServiceNameHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterCamelCaseServiceNameHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterCamelCaseServiceNameHandlerClient(ctx, mux, NewCamelCaseServiceNameClient(conn))
 }
 

--- a/examples/internal/proto/examplepb/echo_service.pb.gw.go
+++ b/examples/internal/proto/examplepb/echo_service.pb.gw.go
@@ -916,7 +916,7 @@ func RegisterEchoServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.Se
 
 // RegisterEchoServiceHandler registers the http handlers for service EchoService to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterEchoServiceHandlerClient(ctx, mux, NewEchoServiceClient(conn))
 }
 

--- a/examples/internal/proto/examplepb/flow_combination.pb.gw.go
+++ b/examples/internal/proto/examplepb/flow_combination.pb.gw.go
@@ -1852,7 +1852,7 @@ func RegisterFlowCombinationHandlerFromEndpoint(ctx context.Context, mux *runtim
 
 // RegisterFlowCombinationHandler registers the http handlers for service FlowCombination to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterFlowCombinationHandlerClient(ctx, mux, NewFlowCombinationClient(conn))
 }
 

--- a/examples/internal/proto/examplepb/generate_unbound_methods.pb.gw.go
+++ b/examples/internal/proto/examplepb/generate_unbound_methods.pb.gw.go
@@ -238,7 +238,7 @@ func RegisterGenerateUnboundMethodsEchoServiceHandlerFromEndpoint(ctx context.Co
 
 // RegisterGenerateUnboundMethodsEchoServiceHandler registers the http handlers for service GenerateUnboundMethodsEchoService to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterGenerateUnboundMethodsEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterGenerateUnboundMethodsEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterGenerateUnboundMethodsEchoServiceHandlerClient(ctx, mux, NewGenerateUnboundMethodsEchoServiceClient(conn))
 }
 

--- a/examples/internal/proto/examplepb/non_standard_names.pb.gw.go
+++ b/examples/internal/proto/examplepb/non_standard_names.pb.gw.go
@@ -245,7 +245,7 @@ func RegisterNonStandardServiceHandlerFromEndpoint(ctx context.Context, mux *run
 
 // RegisterNonStandardServiceHandler registers the http handlers for service NonStandardService to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterNonStandardServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterNonStandardServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterNonStandardServiceHandlerClient(ctx, mux, NewNonStandardServiceClient(conn))
 }
 

--- a/examples/internal/proto/examplepb/openapi_merge_a.pb.gw.go
+++ b/examples/internal/proto/examplepb/openapi_merge_a.pb.gw.go
@@ -304,7 +304,7 @@ func RegisterServiceAHandlerFromEndpoint(ctx context.Context, mux *runtime.Serve
 
 // RegisterServiceAHandler registers the http handlers for service ServiceA to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterServiceAHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterServiceAHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterServiceAHandlerClient(ctx, mux, NewServiceAClient(conn))
 }
 
@@ -397,7 +397,7 @@ func RegisterServiceCHandlerFromEndpoint(ctx context.Context, mux *runtime.Serve
 
 // RegisterServiceCHandler registers the http handlers for service ServiceC to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterServiceCHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterServiceCHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterServiceCHandlerClient(ctx, mux, NewServiceCClient(conn))
 }
 

--- a/examples/internal/proto/examplepb/openapi_merge_b.pb.gw.go
+++ b/examples/internal/proto/examplepb/openapi_merge_b.pb.gw.go
@@ -181,7 +181,7 @@ func RegisterServiceBHandlerFromEndpoint(ctx context.Context, mux *runtime.Serve
 
 // RegisterServiceBHandler registers the http handlers for service ServiceB to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterServiceBHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterServiceBHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterServiceBHandlerClient(ctx, mux, NewServiceBClient(conn))
 }
 

--- a/examples/internal/proto/examplepb/response_body_service.pb.gw.go
+++ b/examples/internal/proto/examplepb/response_body_service.pb.gw.go
@@ -333,7 +333,7 @@ func RegisterResponseBodyServiceHandlerFromEndpoint(ctx context.Context, mux *ru
 
 // RegisterResponseBodyServiceHandler registers the http handlers for service ResponseBodyService to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterResponseBodyServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterResponseBodyServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterResponseBodyServiceHandlerClient(ctx, mux, NewResponseBodyServiceClient(conn))
 }
 

--- a/examples/internal/proto/examplepb/stream.pb.gw.go
+++ b/examples/internal/proto/examplepb/stream.pb.gw.go
@@ -218,7 +218,7 @@ func RegisterStreamServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.
 
 // RegisterStreamServiceHandler registers the http handlers for service StreamService to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterStreamServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterStreamServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterStreamServiceHandlerClient(ctx, mux, NewStreamServiceClient(conn))
 }
 

--- a/examples/internal/proto/examplepb/unannotated_echo_service.pb.gw.go
+++ b/examples/internal/proto/examplepb/unannotated_echo_service.pb.gw.go
@@ -389,7 +389,7 @@ func RegisterUnannotatedEchoServiceHandlerFromEndpoint(ctx context.Context, mux 
 
 // RegisterUnannotatedEchoServiceHandler registers the http handlers for service UnannotatedEchoService to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterUnannotatedEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterUnannotatedEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterUnannotatedEchoServiceHandlerClient(ctx, mux, NewUnannotatedEchoServiceClient(conn))
 }
 

--- a/examples/internal/proto/examplepb/use_go_template.pb.gw.go
+++ b/examples/internal/proto/examplepb/use_go_template.pb.gw.go
@@ -181,7 +181,7 @@ func RegisterLoginServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.S
 
 // RegisterLoginServiceHandler registers the http handlers for service LoginService to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterLoginServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterLoginServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterLoginServiceHandlerClient(ctx, mux, NewLoginServiceClient(conn))
 }
 

--- a/examples/internal/proto/examplepb/wrappers.pb.gw.go
+++ b/examples/internal/proto/examplepb/wrappers.pb.gw.go
@@ -696,7 +696,7 @@ func RegisterWrappersServiceHandlerFromEndpoint(ctx context.Context, mux *runtim
 
 // RegisterWrappersServiceHandler registers the http handlers for service WrappersService to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterWrappersServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterWrappersServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterWrappersServiceHandlerClient(ctx, mux, NewWrappersServiceClient(conn))
 }
 

--- a/examples/internal/proto/standalone/unannotated_echo_service.pb.gw.go
+++ b/examples/internal/proto/standalone/unannotated_echo_service.pb.gw.go
@@ -769,7 +769,7 @@ func RegisterUnannotatedEchoServiceHandlerFromEndpoint(ctx context.Context, mux 
 
 // RegisterUnannotatedEchoServiceHandler registers the http handlers for service UnannotatedEchoService to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterUnannotatedEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterUnannotatedEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterUnannotatedEchoServiceHandlerClient(ctx, mux, extExamplepb.NewUnannotatedEchoServiceClient(conn))
 }
 

--- a/protoc-gen-grpc-gateway/internal/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/internal/gengateway/template.go
@@ -655,7 +655,7 @@ func Register{{$svc.GetName}}{{$.RegisterFuncSuffix}}FromEndpoint(ctx context.Co
 
 // Register{{$svc.GetName}}{{$.RegisterFuncSuffix}} registers the http handlers for service {{$svc.GetName}} to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func Register{{$svc.GetName}}{{$.RegisterFuncSuffix}}(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func Register{{$svc.GetName}}{{$.RegisterFuncSuffix}}(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return Register{{$svc.GetName}}{{$.RegisterFuncSuffix}}Client(ctx, mux, {{$svc.ClientConstructorName}}(conn))
 }
 

--- a/protoc-gen-grpc-gateway/internal/gengateway/template_test.go
+++ b/protoc-gen-grpc-gateway/internal/gengateway/template_test.go
@@ -248,7 +248,7 @@ func TestApplyTemplateRequestWithoutClientStreaming(t *testing.T) {
 		if want := `protoReq.GetNested().Int32, err = runtime.Int32P(val)`; !strings.Contains(got, want) {
 			t.Errorf("applyTemplate(%#v) = %s; want to contain %s", file, got, want)
 		}
-		if want := `func RegisterExampleServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {`; !strings.Contains(got, want) {
+		if want := `func RegisterExampleServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {`; !strings.Contains(got, want) {
 			t.Errorf("applyTemplate(%#v) = %s; want to contain %s", file, got, want)
 		}
 		if want := `pattern_ExampleService_Echo_0 = runtime.MustPattern(runtime.NewPattern(1, []int{0, 0}, []string(nil), ""))`; !strings.Contains(got, want) {
@@ -403,7 +403,7 @@ func TestApplyTemplateRequestWithClientStreaming(t *testing.T) {
 		if want := spec.sigWant; !strings.Contains(got, want) {
 			t.Errorf("applyTemplate(%#v) = %s; want to contain %s", file, got, want)
 		}
-		if want := `func RegisterExampleServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {`; !strings.Contains(got, want) {
+		if want := `func RegisterExampleServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {`; !strings.Contains(got, want) {
 			t.Errorf("applyTemplate(%#v) = %s; want to contain %s", file, got, want)
 		}
 		if want := `pattern_ExampleService_Echo_0 = runtime.MustPattern(runtime.NewPattern(1, []int{0, 0}, []string(nil), ""))`; !strings.Contains(got, want) {


### PR DESCRIPTION
This reverts commit 8857147978c9e9c9835bdbe441337ffce8a2a806.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

Fixes #2442 

Breaks #2398 

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

Reverts the change which uses an interface instead of a concrete type, as that is a breaking change for at least one user (us).

#### Other comments
