### PR TITLE
Log warning if HeaderMatcherFunc passes malformed HTTP headers to grpc server

### DIFF
--- a/examples/internal/cmd/example-gateway-server/BUILD.bazel
+++ b/examples/internal/cmd/example-gateway-server/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//examples/internal/gateway",
-        "//runtime",
         "@com_github_golang_glog//:glog",
     ],
 )

--- a/examples/internal/cmd/example-gateway-server/BUILD.bazel
+++ b/examples/internal/cmd/example-gateway-server/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//examples/internal/gateway",
+        "//runtime",
         "@com_github_golang_glog//:glog",
     ],
 )

--- a/runtime/BUILD.bazel
+++ b/runtime/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
         "marshal_jsonpb_test.go",
         "marshal_proto_test.go",
         "marshaler_registry_test.go",
+        "mux_internal_test.go",
         "mux_test.go",
         "pattern_test.go",
         "query_test.go",

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -41,6 +41,13 @@ var (
 	DefaultContextTimeout = 0 * time.Second
 )
 
+// malformedHTTPHeaders are headers would be considered malformed and be rejected by grpc server
+// Connection: https://github.com/grpc/grpc-go/pull/4803
+var malformedHTTPHeaders = map[string]struct{}{
+	"Connection": {},
+	"connection": {},
+}
+
 type (
 	rpcMethodKey       struct{}
 	httpPathPatternKey struct{}
@@ -306,6 +313,13 @@ func isPermanentHTTPHeader(hdr string) bool {
 		return true
 	}
 	return false
+}
+
+// isMalformedHTTPHeaders checks whether hdr belongs to the list of
+// "malformed headers" and would be rejected by grpc server
+func isMalformedHTTPHeaders(hdr string) bool {
+	_, isMalFormed := malformedHTTPHeaders[hdr]
+	return isMalFormed
 }
 
 // RPCMethod returns the method string for the server context. The returned

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -41,10 +41,9 @@ var (
 	DefaultContextTimeout = 0 * time.Second
 )
 
-// malformedHTTPHeaders are headers would be considered malformed and be rejected by grpc server
-// Connection: https://github.com/grpc/grpc-go/pull/4803
+// malformedHTTPHeaders lists the headers that the gRPC server may reject outright as malformed.
+// See https://github.com/grpc/grpc-go/pull/4803#issuecomment-986093310 for more context.
 var malformedHTTPHeaders = map[string]struct{}{
-	"Connection": {},
 	"connection": {},
 }
 
@@ -315,11 +314,11 @@ func isPermanentHTTPHeader(hdr string) bool {
 	return false
 }
 
-// isMalformedHTTPHeaders checks whether hdr belongs to the list of
-// "malformed headers" and would be rejected by grpc server
-func isMalformedHTTPHeaders(hdr string) bool {
-	_, isMalFormed := malformedHTTPHeaders[hdr]
-	return isMalFormed
+// isMalformedHTTPHeader checks whether header belongs to the list of
+// "malformed headers" and would be rejected by the gRPC server.
+func isMalformedHTTPHeader(header string) bool {
+	_, isMalformed := malformedHTTPHeaders[strings.ToLower(header)]
+	return isMalformed
 }
 
 // RPCMethod returns the method string for the server context. The returned

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -114,7 +114,6 @@ func DefaultHeaderMatcher(key string) (string, bool) {
 // This matcher will be called with each header in http.Request. If matcher returns true, that header will be
 // passed to gRPC context. To transform the header before passing to gRPC context, matcher should return modified header.
 func WithIncomingHeaderMatcher(fn HeaderMatcherFunc) ServeMuxOption {
-
 	for _, hdr := range fn.forwardingMalformedHdr() {
 		grpclog.Warningf("malformed HTTP header %s would be sent to grpc server", hdr)
 	}
@@ -124,19 +123,19 @@ func WithIncomingHeaderMatcher(fn HeaderMatcherFunc) ServeMuxOption {
 	}
 }
 
-// forwardingMalformedHdr returns malformed headers that would be forward to grpc server
-func (fn HeaderMatcherFunc) forwardingMalformedHdr() []string {
+// matchedMalformedHeaders returns the malformed headers that would be forwarded to gRPC server.
+func (fn HeaderMatcherFunc) matchedMalformedHeaders() []string {
 	if fn == nil {
 		return nil
 	}
-	hdrs := make([]string, 0)
-	for hdr := range malformedHTTPHeaders {
-		out, accept := fn(hdr)
-		if accept && isMalformedHTTPHeaders(out) {
-			hdrs = append(hdrs, out)
+	headers := make([]string, 0)
+	for header := range malformedHTTPHeaders {
+		out, accept := fn(header)
+		if accept && isMalformedHTTPHeader(out) {
+			headers = append(headers, out)
 		}
 	}
-	return hdrs
+	return headers
 }
 
 // WithOutgoingHeaderMatcher returns a ServeMuxOption representing a headerMatcher for outgoing response from gateway.

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -114,8 +114,8 @@ func DefaultHeaderMatcher(key string) (string, bool) {
 // This matcher will be called with each header in http.Request. If matcher returns true, that header will be
 // passed to gRPC context. To transform the header before passing to gRPC context, matcher should return modified header.
 func WithIncomingHeaderMatcher(fn HeaderMatcherFunc) ServeMuxOption {
-	for _, hdr := range fn.forwardingMalformedHdr() {
-		grpclog.Warningf("malformed HTTP header %s would be sent to grpc server", hdr)
+	for _, header := range fn.forwardingMalformedHdr() {
+		grpclog.Warningf("The configured forwarding filter would allow %q to be sent to the gRPC server, which will likely cause errors. See https://github.com/grpc/grpc-go/pull/4803#issuecomment-986093310 for more information.", header)
 	}
 
 	return func(mux *ServeMux) {

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"google.golang.org/grpc/grpclog"
 	"net/http"
 	"net/textproto"
 	"strings"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -114,7 +114,7 @@ func DefaultHeaderMatcher(key string) (string, bool) {
 // This matcher will be called with each header in http.Request. If matcher returns true, that header will be
 // passed to gRPC context. To transform the header before passing to gRPC context, matcher should return modified header.
 func WithIncomingHeaderMatcher(fn HeaderMatcherFunc) ServeMuxOption {
-	for _, header := range fn.forwardingMalformedHdr() {
+	for _, header := range fn.matchedMalformedHeaders() {
 		grpclog.Warningf("The configured forwarding filter would allow %q to be sent to the gRPC server, which will likely cause errors. See https://github.com/grpc/grpc-go/pull/4803#issuecomment-986093310 for more information.", header)
 	}
 

--- a/runtime/mux_internal_test.go
+++ b/runtime/mux_internal_test.go
@@ -1,0 +1,58 @@
+package runtime
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestWithIncomingHeaderMatcher_matchedMalformedHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		matcher HeaderMatcherFunc
+		want    []string
+	}{
+		{
+			"nil matcher returns nothing",
+			nil,
+			nil,
+		},
+		{
+			"default matcher returns nothing",
+			DefaultHeaderMatcher,
+			nil,
+		},
+		{
+			"passthrough matcher returns all malformed headers",
+			func(s string) (string, bool) {
+				return s, true
+			},
+			[]string{"connection"},
+		},
+	}
+
+	sliceEqual := func(a, b []string) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		sort.Slice(a, func(i, j int) bool {
+			return a[i] < a[j]
+		})
+		sort.Slice(b, func(i, j int) bool {
+			return a[i] < a[j]
+		})
+		for idx := range a {
+			if a[idx] != b[idx] {
+				return false
+			}
+		}
+		return true
+	}
+
+	for _, tt := range tests {
+		out := tt.matcher.matchedMalformedHeaders()
+		if !sliceEqual(tt.want, out) {
+			t.Errorf("matchedMalformedHeaders not match; Want %v; got %v",
+				tt.want, out)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Solves #2447 

Log warning if the custom header matcher function returns "malformed" headers that would be rejected be grpc server.    
It will help others who is using passthrough HeaderMatcherFunc avoid breaking their server after they updating to grpc-gateway 2.7.x.

To re-produce this warning, use a custom HeaderMatcherFunc like following in example-gateway-server/main.go:
```go
func main() {
	flag.Parse()
	defer glog.Flush()

	ctx := context.Background()
	opts := gateway.Options{
		Addr: ":8080",
		GRPCServer: gateway.Endpoint{
			Network: *network,
			Addr:    *endpoint,
		},
		OpenAPIDir: *openAPIDir,
		Mux: []runtime.ServeMuxOption{
			// a custom passthroughs HeaderMatcher
			runtime.WithIncomingHeaderMatcher(func(key string) (string, bool) {return key, true}),
		},
	}
	if err := gateway.Run(ctx, opts); err != nil {
		glog.Fatal(err)
	}
}
```

I suppose this pr should be backport to 2.6.x or earlier.

And i suggest that we can provide a passthrough HeaderMatcherFunc, which passes the valid headers to grpc metadata as-is. It could help backward compatibility because devs can transform from http restful api to grpc without updating their headers.



