### PR TITLE
Replace all deprecated ioutil with io and os

### DIFF
--- a/examples/internal/clients/abe/api_a_bit_of_everything_service.go
+++ b/examples/internal/clients/abe/api_a_bit_of_everything_service.go
@@ -12,7 +12,7 @@ package abe
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -91,7 +91,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCheckExternal
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -247,7 +247,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCheckExternal
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -577,7 +577,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCheckGetQuery
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -907,7 +907,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCheckNestedEn
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -1230,7 +1230,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCheckPostQuer
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -1384,7 +1384,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCheckStatus(c
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -1669,7 +1669,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCreate(ctx co
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -1826,7 +1826,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCreateBody(ct
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -1995,7 +1995,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceCreateBook(ct
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -2154,7 +2154,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceDeepPathEcho(
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -2310,7 +2310,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceDelete(ctx co
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -2464,7 +2464,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceErrorWithDeta
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -2623,7 +2623,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceGetMessageWit
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -2945,7 +2945,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceGetQuery(ctx 
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -3179,7 +3179,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceGetRepeatedQu
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -3335,7 +3335,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceLookup(ctx co
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -3489,7 +3489,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceOverwriteResp
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -3648,7 +3648,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServicePostWithEmpty
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -3802,7 +3802,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceTimeout(ctx c
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -3961,7 +3961,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdate(ctx co
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -4135,7 +4135,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateBook(ct
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -4304,7 +4304,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV2(ctx 
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -4473,7 +4473,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV22(ctx
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -4632,7 +4632,7 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV23(ctx
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err

--- a/examples/internal/clients/abe/api_camel_case_service_name.go
+++ b/examples/internal/clients/abe/api_camel_case_service_name.go
@@ -12,7 +12,7 @@ package abe
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -87,7 +87,7 @@ func (a *CamelCaseServiceNameApiService) CamelCaseServiceNameEmpty(ctx context.C
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err

--- a/examples/internal/clients/abe/api_echo_rpc.go
+++ b/examples/internal/clients/abe/api_echo_rpc.go
@@ -12,7 +12,7 @@ package abe
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -92,7 +92,7 @@ func (a *EchoRpcApiService) ABitOfEverythingServiceEcho(ctx context.Context, val
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -261,7 +261,7 @@ func (a *EchoRpcApiService) ABitOfEverythingServiceEcho2(ctx context.Context, bo
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -437,7 +437,7 @@ func (a *EchoRpcApiService) ABitOfEverythingServiceEcho3(ctx context.Context, lo
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err

--- a/examples/internal/clients/echo/api_echo_service.go
+++ b/examples/internal/clients/echo/api_echo_service.go
@@ -11,7 +11,7 @@ package echo
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -123,7 +123,7 @@ func (a *EchoServiceApiService) EchoServiceEcho(ctx context.Context, id string, 
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -265,7 +265,7 @@ func (a *EchoServiceApiService) EchoServiceEcho2(ctx context.Context, id string,
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -404,7 +404,7 @@ func (a *EchoServiceApiService) EchoServiceEcho3(ctx context.Context, id string,
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -538,7 +538,7 @@ func (a *EchoServiceApiService) EchoServiceEcho4(ctx context.Context, id string,
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -678,7 +678,7 @@ func (a *EchoServiceApiService) EchoServiceEcho5(ctx context.Context, noNote str
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -778,7 +778,7 @@ func (a *EchoServiceApiService) EchoServiceEchoBody(ctx context.Context, body Ex
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -925,7 +925,7 @@ func (a *EchoServiceApiService) EchoServiceEchoDelete(ctx context.Context, local
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -1035,7 +1035,7 @@ func (a *EchoServiceApiService) EchoServiceEchoPatch(ctx context.Context, body E
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -1182,7 +1182,7 @@ func (a *EchoServiceApiService) EchoServiceEchoUnauthorized(ctx context.Context,
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err

--- a/examples/internal/clients/generateunboundmethods/api_generate_unbound_methods_echo_service.go
+++ b/examples/internal/clients/generateunboundmethods/api_generate_unbound_methods_echo_service.go
@@ -11,7 +11,7 @@ package generateunboundmethods
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -77,7 +77,7 @@ func (a *GenerateUnboundMethodsEchoServiceApiService) GenerateUnboundMethodsEcho
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -177,7 +177,7 @@ func (a *GenerateUnboundMethodsEchoServiceApiService) GenerateUnboundMethodsEcho
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -277,7 +277,7 @@ func (a *GenerateUnboundMethodsEchoServiceApiService) GenerateUnboundMethodsEcho
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err

--- a/examples/internal/clients/responsebody/api_response_body_service.go
+++ b/examples/internal/clients/responsebody/api_response_body_service.go
@@ -11,11 +11,11 @@ package responsebody
 
 import (
 	"context"
-	"io/ioutil"
+	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
-	"fmt"
 )
 
 // Linger please
@@ -76,7 +76,7 @@ func (a *ResponseBodyServiceApiService) ResponseBodyServiceGetResponseBody(ctx c
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -175,7 +175,7 @@ func (a *ResponseBodyServiceApiService) ResponseBodyServiceGetResponseBodyStream
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -274,7 +274,7 @@ func (a *ResponseBodyServiceApiService) ResponseBodyServiceListResponseBodies(ct
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -373,7 +373,7 @@ func (a *ResponseBodyServiceApiService) ResponseBodyServiceListResponseStrings(c
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err

--- a/examples/internal/clients/unannotatedecho/api_unannotated_echo_service.go
+++ b/examples/internal/clients/unannotatedecho/api_unannotated_echo_service.go
@@ -12,7 +12,7 @@ package unannotatedecho
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -139,7 +139,7 @@ func (a *UnannotatedEchoServiceApiService) UnannotatedEchoServiceEcho(ctx contex
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -332,7 +332,7 @@ func (a *UnannotatedEchoServiceApiService) UnannotatedEchoServiceEcho2(ctx conte
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -478,7 +478,7 @@ func (a *UnannotatedEchoServiceApiService) UnannotatedEchoServiceEchoBody(ctx co
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
@@ -662,7 +662,7 @@ func (a *UnannotatedEchoServiceApiService) UnannotatedEchoServiceEchoDelete(ctx 
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err

--- a/examples/internal/integration/integration_test.go
+++ b/examples/internal/integration/integration_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -68,9 +67,9 @@ func TestEchoUnauthorized(t *testing.T) {
 		return
 	}
 	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 	msg := new(statuspb.Status)
@@ -122,9 +121,9 @@ func TestEchoPatch(t *testing.T) {
 		return
 	}
 	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 
@@ -188,9 +187,9 @@ func testEcho(t *testing.T, port int, apiPrefix string, contentType string) {
 		return
 	}
 	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 
@@ -221,9 +220,9 @@ func testEchoOneof(t *testing.T, port int, apiPrefix string, contentType string)
 		return
 	}
 	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 
@@ -254,9 +253,9 @@ func testEchoOneof1(t *testing.T, port int, apiPrefix string, contentType string
 		return
 	}
 	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 
@@ -287,9 +286,9 @@ func testEchoOneof2(t *testing.T, port int, apiPrefix string, contentType string
 		return
 	}
 	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 
@@ -336,9 +335,9 @@ func testEchoBody(t *testing.T, port int, apiPrefix string, useTrailers bool) {
 		return
 	}
 	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 
@@ -430,9 +429,9 @@ func testABECreate(t *testing.T, port int) {
 		return
 	}
 	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 
@@ -540,9 +539,9 @@ func testABECreateBody(t *testing.T, port int) {
 		return
 	}
 	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 
@@ -669,9 +668,9 @@ func testABEBulkCreate(t *testing.T, port int, useTrailers bool) {
 	}
 
 	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 
@@ -752,9 +751,9 @@ func testABEBulkCreateWithError(t *testing.T, port int) {
 		return
 	}
 	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 
@@ -779,9 +778,9 @@ func testABELookup(t *testing.T, port int) {
 		return
 	}
 	defer cresp.Body.Close()
-	buf, err := ioutil.ReadAll(cresp.Body)
+	buf, err := io.ReadAll(cresp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(cresp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(cresp.Body) failed with %v; want success", err)
 		return
 	}
 	if got, want := cresp.StatusCode, http.StatusOK; got != want {
@@ -804,9 +803,9 @@ func testABELookup(t *testing.T, port int) {
 	}
 	defer resp.Body.Close()
 
-	buf, err = ioutil.ReadAll(resp.Body)
+	buf, err = io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 
@@ -853,7 +852,7 @@ func TestABEPatch(t *testing.T) {
 		t.Fatalf("failed to issue PATCH request: %v", err)
 	}
 	if got, want := patchResp.StatusCode, http.StatusOK; got != want {
-		if body, err := ioutil.ReadAll(patchResp.Body); err != nil {
+		if body, err := io.ReadAll(patchResp.Body); err != nil {
 			t.Errorf("patchResp body couldn't be read: %v", err)
 		} else {
 			t.Errorf("patchResp.StatusCode= %d; want %d resp: %v", got, want, string(body))
@@ -986,7 +985,7 @@ func TestABEPatchBody(t *testing.T) {
 				t.Fatalf("failed to issue PATCH request: %v", err)
 			}
 			if got, want := patchResp.StatusCode, http.StatusOK; got != want {
-				if body, err := ioutil.ReadAll(patchResp.Body); err != nil {
+				if body, err := io.ReadAll(patchResp.Body); err != nil {
 					t.Errorf("patchResp body couldn't be read: %v", err)
 				} else {
 					t.Errorf("patchResp.StatusCode= %d; want %d resp: %v", got, want, string(body))
@@ -1021,7 +1020,7 @@ func postABE(t *testing.T, port int, abe *examplepb.ABitOfEverything) (uuid stri
 		t.Fatalf("http.Post(%q) failed with %v; want success", apiURL, err)
 		return
 	}
-	body, err := ioutil.ReadAll(postResp.Body)
+	body, err := io.ReadAll(postResp.Body)
 	if err != nil {
 		t.Fatalf("postResp body couldn't be read: %v", err)
 	}
@@ -1050,7 +1049,7 @@ func getABE(t *testing.T, port int, uuid string) *examplepb.ABitOfEverything {
 		t.Fatalf("getResp.StatusCode= %d, want %d. resp: %v", got, want, getResp)
 	}
 	var getRestatuspbody examplepb.ABitOfEverything
-	body, err := ioutil.ReadAll(getResp.Body)
+	body, err := io.ReadAll(getResp.Body)
 	if err != nil {
 		t.Fatalf("getResp body couldn't be read: %v", err)
 	}
@@ -1083,9 +1082,9 @@ func testABELookupNotFound(t *testing.T, port int, useTrailers bool) {
 	}
 	defer resp.Body.Close()
 
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 
@@ -1369,9 +1368,9 @@ func testAdditionalBindings(t *testing.T, port int) {
 		}
 
 		defer resp.Body.Close()
-		buf, err := ioutil.ReadAll(resp.Body)
+		buf, err := io.ReadAll(resp.Body)
 		if err != nil {
-			t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success; i=%d", err, i)
+			t.Errorf("io.ReadAll(resp.Body) failed with %v; want success; i=%d", err, i)
 			return
 		}
 		if got, want := resp.StatusCode, http.StatusOK; got != want {
@@ -1488,9 +1487,9 @@ func testABERepeated(t *testing.T, port int) {
 		return
 	}
 	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 
@@ -1568,9 +1567,9 @@ func TestUnknownPath(t *testing.T) {
 		return
 	}
 	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 
@@ -1593,9 +1592,9 @@ func TestNotImplemented(t *testing.T) {
 		return
 	}
 	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 	if got, want := resp.StatusCode, http.StatusNotImplemented; got != want {
@@ -1617,9 +1616,9 @@ func TestInvalidArgument(t *testing.T) {
 		return
 	}
 	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 
@@ -1662,9 +1661,9 @@ func testResponseBody(t *testing.T, port int) {
 			}
 
 			defer resp.Body.Close()
-			buf, err := ioutil.ReadAll(resp.Body)
+			buf, err := io.ReadAll(resp.Body)
 			if err != nil {
-				t.Fatalf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+				t.Fatalf("io.ReadAll(resp.Body) failed with %v; want success", err)
 			}
 
 			if got, want := resp.StatusCode, tt.wantStatus; got != want {
@@ -1742,9 +1741,9 @@ func testResponseBodies(t *testing.T, port int) {
 		return
 	}
 	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 		return
 	}
 
@@ -1799,9 +1798,9 @@ func testResponseStrings(t *testing.T, port int) {
 			return
 		}
 		defer resp.Body.Close()
-		buf, err := ioutil.ReadAll(resp.Body)
+		buf, err := io.ReadAll(resp.Body)
 		if err != nil {
-			t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+			t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 			return
 		}
 
@@ -1830,9 +1829,9 @@ func testResponseStrings(t *testing.T, port int) {
 			return
 		}
 		defer resp.Body.Close()
-		buf, err := ioutil.ReadAll(resp.Body)
+		buf, err := io.ReadAll(resp.Body)
 		if err != nil {
-			t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+			t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 			return
 		}
 
@@ -1861,9 +1860,9 @@ func testResponseStrings(t *testing.T, port int) {
 			return
 		}
 		defer resp.Body.Close()
-		buf, err := ioutil.ReadAll(resp.Body)
+		buf, err := io.ReadAll(resp.Body)
 		if err != nil {
-			t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+			t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 			return
 		}
 
@@ -1999,9 +1998,9 @@ func testRequestQueryParams(t *testing.T, port int) {
 			}
 			defer resp.Body.Close()
 
-			buf, err := ioutil.ReadAll(resp.Body)
+			buf, err := io.ReadAll(resp.Body)
 			if err != nil {
-				t.Errorf("ioutil.ReadAll(resp.Body) failed with %v; want success", err)
+				t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
 				return
 			}
 
@@ -2230,7 +2229,7 @@ func testNonStandardNames(t *testing.T, port int, method string, jsonBody string
 		t.Fatalf("failed to issue PATCH request: %v", err)
 	}
 
-	body, err := ioutil.ReadAll(patchResp.Body)
+	body, err := io.ReadAll(patchResp.Body)
 	if err != nil {
 		t.Errorf("patchResp body couldn't be read: %v", err)
 	}

--- a/internal/codegenerator/parse_req.go
+++ b/internal/codegenerator/parse_req.go
@@ -2,16 +2,14 @@ package codegenerator
 
 import (
 	"fmt"
-	"io"
-	"io/ioutil"
-
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/pluginpb"
+	"io"
 )
 
 // ParseRequest parses a code generator request from a proto Message.
 func ParseRequest(r io.Reader) (*pluginpb.CodeGeneratorRequest, error) {
-	input, err := ioutil.ReadAll(r)
+	input, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read code generator request: %v", err)
 	}

--- a/internal/descriptor/grpc_api_configuration.go
+++ b/internal/descriptor/grpc_api_configuration.go
@@ -2,7 +2,7 @@ package descriptor
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor/apiconfig"
@@ -57,7 +57,7 @@ func registerHTTPRulesFromGrpcAPIService(registry *Registry, service *apiconfig.
 // Note that for the purposes of the gateway generator we only consider a subset of all
 // available features google supports in their service descriptions.
 func (r *Registry) LoadGrpcAPIServiceFromYAML(yamlFile string) error {
-	yamlFileContents, err := ioutil.ReadFile(yamlFile)
+	yamlFileContents, err := os.ReadFile(yamlFile)
 	if err != nil {
 		return fmt.Errorf("failed to read gRPC API Configuration description from '%v': %v", yamlFile, err)
 	}

--- a/internal/descriptor/openapi_configuration.go
+++ b/internal/descriptor/openapi_configuration.go
@@ -2,7 +2,7 @@ package descriptor
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor/openapiconfig"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -44,7 +44,7 @@ func registerOpenAPIOptions(registry *Registry, openAPIConfig *openapiconfig.Ope
 // and registers the OpenAPI options the given registry.
 // This must be done after loading the proto file.
 func (r *Registry) LoadOpenAPIConfigFromYAML(yamlFile string) error {
-	yamlFileContents, err := ioutil.ReadFile(yamlFile)
+	yamlFileContents, err := os.ReadFile(yamlFile)
 	if err != nil {
 		return fmt.Errorf("failed to read gRPC API Configuration description from '%v': %v", yamlFile, err)
 	}

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net/textproto"
 	"os"
@@ -1882,7 +1881,7 @@ func goTemplateComments(comment string, data interface{}, reg *descriptor.Regist
 	tpl, err := template.New("").Funcs(template.FuncMap{
 		// Allows importing documentation from a file
 		"import": func(name string) string {
-			file, err := ioutil.ReadFile(name)
+			file, err := os.ReadFile(name)
 			if err != nil {
 				return err.Error()
 			}

--- a/runtime/handler_test.go
+++ b/runtime/handler_test.go
@@ -3,7 +3,6 @@ package runtime_test
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -104,7 +103,7 @@ func TestForwardResponseStream(t *testing.T) {
 			if h := w.Header.Get("Transfer-Encoding"); h != "chunked" {
 				t.Errorf("ForwardResponseStream missing header chunked")
 			}
-			body, err := ioutil.ReadAll(w.Body)
+			body, err := io.ReadAll(w.Body)
 			if err != nil {
 				t.Errorf("Failed to read response body with %v", err)
 			}
@@ -237,7 +236,7 @@ func TestForwardResponseStreamCustomMarshaler(t *testing.T) {
 			if h := w.Header.Get("Transfer-Encoding"); h != "chunked" {
 				t.Errorf("ForwardResponseStream missing header chunked")
 			}
-			body, err := ioutil.ReadAll(w.Body)
+			body, err := io.ReadAll(w.Body)
 			if err != nil {
 				t.Errorf("Failed to read response body with %v", err)
 			}
@@ -301,7 +300,7 @@ func TestForwardResponseMessage(t *testing.T) {
 			if h := w.Header.Get("Content-Type"); h != tt.contentType {
 				t.Errorf("Content-Type %v want %v", h, tt.contentType)
 			}
-			body, err := ioutil.ReadAll(w.Body)
+			body, err := io.ReadAll(w.Body)
 			if err != nil {
 				t.Errorf("Failed to read response body with %v", err)
 			}

--- a/runtime/marshal_proto.go
+++ b/runtime/marshal_proto.go
@@ -4,8 +4,6 @@ import (
 	"io"
 
 	"errors"
-	"io/ioutil"
-
 	"google.golang.org/protobuf/proto"
 )
 
@@ -38,7 +36,7 @@ func (*ProtoMarshaller) Unmarshal(data []byte, value interface{}) error {
 // NewDecoder returns a Decoder which reads proto stream from "reader".
 func (marshaller *ProtoMarshaller) NewDecoder(reader io.Reader) Decoder {
 	return DecoderFunc(func(value interface{}) error {
-		buffer, err := ioutil.ReadAll(reader)
+		buffer, err := io.ReadAll(reader)
 		if err != nil {
 			return err
 		}

--- a/utilities/readerfactory.go
+++ b/utilities/readerfactory.go
@@ -3,13 +3,12 @@ package utilities
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 )
 
 // IOReaderFactory takes in an io.Reader and returns a function that will allow you to create a new reader that begins
 // at the start of the stream
 func IOReaderFactory(r io.Reader) (func() io.Reader, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The io/ioutil package is deprecated in golang 1.16, please see [go1.16#ioutil](https://go.dev/doc/go1.16#ioutil). Although it is not removed yet, it'd be better to replace all the deprecated io/iouitl with io and os; and it's exactly this PR tries to resolve. 