### PR TITLE
docs: specify invalid cases for FieldMask

### DIFF
--- a/docs/docs/mapping/patch_feature.md
+++ b/docs/docs/mapping/patch_feature.md
@@ -9,7 +9,7 @@ parent: Mapping
 
 The HTTP PATCH method allows a resource to be partially updated.
 
-If a binding is mapped to patch and the request message has exactly one FieldMask message in it, additional code is rendered for the gateway handler that will populate the FieldMask based on the request body.
+If a binding is mapped to patch and the request message has exactly one FieldMask message in it, additional code is rendered for the gateway handler that will populate the FieldMask based on the request body. FieldMask is treated as a regular field by the gateway if the request method is not PATCH, or if the HttpRule body is `"*"`
 
 There are two scenarios:
 


### PR DESCRIPTION
Specify that FieldMask is treated as a regular field in the scenario where the gateway' HTTP method is not PATCH, or if Body is `"*"`.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

N/A

#### Brief description of what is fixed or changed

Clarifies the invalid cases for the `FieldMask` field.

#### Other comments

Initially when trying this field, I was using the PUT method instead of the PATCH method, and I was unsure why it wasn't working. The docs do indeed mention that this is a feature for PATCH methods, however, it still did not click to me that it was _exclusively_ for PATCH requests. Mentioning this can be helpful for  those in the future who might make the same (incorrect) assumption I did.