### PR TITLE
embedding UnimplementedGreeterServer to creating_main.go.md server struct

### DIFF
--- a/docs/docs/tutorials/creating_main.go.md
+++ b/docs/docs/tutorials/creating_main.go.md
@@ -22,7 +22,9 @@ import (
 	helloworldpb "github.com/myuser/myrepo/proto/helloworld"
 )
 
-type server struct{}
+type server struct{
+	helloworldpb.UnimplementedGreeterServer
+}
 
 func NewServer() *server {
 	return &server{}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

To deal with the following errors that occur when compiling:

```
# command-line-arguments
./main.go:29:40: cannot use &server{} (type *server) as type protocol_buffers_note.GreeterServer in argument to protocol_buffers_note.RegisterGreeterServer:
        *server does not implement protocol_buffers_note.GreeterServer (missing protocol_buffers_note.mustEmbedUnimplementedGreeterServer method)
```

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

#### Other comments
