### PR TITLE
Include Package in Service Tags when Option is Enabled

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -870,11 +870,16 @@ func partsToRegexpMap(parts []string) map[string]string {
 	return regExps
 }
 
-func renderServiceTags(services []*descriptor.Service) []openapiTagObject {
+func renderServiceTags(services []*descriptor.Service, reg *descriptor.Registry) []openapiTagObject {
 	var tags []openapiTagObject
 	for _, svc := range services {
+		tagName := svc.GetName()
+		if pkg := svc.File.GetPackage(); pkg != "" && reg.IsIncludePackageInTags() {
+			tagName = pkg + "." + tagName
+		}
+
 		tag := openapiTagObject{
-			Name: *svc.Name,
+			Name: tagName,
 		}
 		if proto.HasExtension(svc.Options, openapi_options.E_Openapiv2Tag) {
 			ext := proto.GetExtension(svc.Options, openapi_options.E_Openapiv2Tag)
@@ -1394,7 +1399,7 @@ func applyTemplate(p param) (*openapiSwaggerObject, error) {
 	if err := renderServices(p.Services, s.Paths, p.reg, requestResponseRefs, customRefs, p.Messages); err != nil {
 		panic(err)
 	}
-	s.Tags = append(s.Tags, renderServiceTags(p.Services)...)
+	s.Tags = append(s.Tags, renderServiceTags(p.Services, p.reg)...)
 
 	messages := messageMap{}
 	streamingMessages := messageMap{}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Nope

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Absolutely Yes

#### Brief description of what is fixed or changed

Proto service name isn't generated by full package when `include_package_in_tags` is true.

And it should be, because as the comment said `If set and the package directive is shown in the proto file, the package name will be prepended to the service name`

#### Other comments

before
```
{
  "swagger": "2.0",
  "info": {
    "title": "foo.example",
  },
  "tags": [
    {
      "name": "ExampleService"
    }
  ],
}
```

after
```

  "swagger": "2.0",
  "info": {
    "title": "foo.example",
  },
  "tags": [
    {
      // service tags will be generated in full package (prepended) if `include_package_in_tags` is true
      "name": "foo.example.ExampleService"
    }
  ],
}
```