### PR TITLE
Fix proto push job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,11 +150,10 @@ jobs:
       - image: bufbuild/buf:1.1.0
     steps:
       - checkout
-      - run: echo "${BUF_API_TOKEN}" | buf registry login --username grpcgatewaybot --token-stdin
       # Limit pushes to protoc-gen-openapiv2 files. This is a total hack.
       # It excludes all the files that we don't want to publish, just for the push step.
       - run: echo -e "    - examples\n    - internal\n    - runtime" >> buf.yaml
-      - run: buf push --tag "$CIRCLE_SHA1"
+      - run: BUF_TOKEN="${BUF_API_TOKEN}" buf push --tag "$CIRCLE_SHA1"
   release:
     executor: build-env
     working_directory: /home/vscode/src/grpc-gateway


### PR DESCRIPTION
Apparently buf registry login now checks usernames, lets just use [BUF_TOKEN](https://docs.buf.build/bsr/authentication#authenticating-the-cli) instead