### PR TITLE
feature/custom HTTP health check endpoint

### DIFF
--- a/docs/docs/operations/health_check.md
+++ b/docs/docs/operations/health_check.md
@@ -54,3 +54,7 @@ to `/healthz` will result in the following:
 If you've implemented multiple services in your server you can target specific services with the `?service=<service>`
 query parameter. This will then be added to the `health.HealthCheckRequest` in the `Service` property. With that you can
 write your own logic to handle that in the health checking methods.
+
+Analogously, to register an `{/endpoint/path}` endpoint in your `ServeMux` with a user-defined endpoint path, you can use
+the `ServeMuxOption` `WithHealthEndpointAt`, which accepts a connection to your registered gRPC server
+together with a custom `endpointPath string` parameter.

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -205,24 +205,24 @@ func WithDisablePathLengthFallback() ServeMuxOption {
 	}
 }
 
-// WithHealthzEndpoint returns a ServeMuxOption that will add a /healthz endpoint to the created ServeMux.
+// WithHealthEndpointAt returns a ServeMuxOption that will add an {endpointPath} endpoint to the created ServeMux.
 // When called the handler will forward the request to the upstream grpc service health check (defined in the
 // gRPC Health Checking Protocol).
+//
 // See here https://grpc-ecosystem.github.io/grpc-gateway/docs/operations/health_check/ for more information on how
 // to setup the protocol in the grpc server.
+//
 // If you define a service as query parameter, this will also be forwarded as service in the HealthCheckRequest.
-func WithHealthzEndpoint(healthCheckClient grpc_health_v1.HealthClient) ServeMuxOption {
+func WithHealthEndpointAt(healthCheckClient grpc_health_v1.HealthClient, endpointPath string) ServeMuxOption {
 	return func(s *ServeMux) {
 		// error can be ignored since pattern is definitely valid
 		_ = s.HandlePath(
-			http.MethodGet, "/healthz", func(w http.ResponseWriter, r *http.Request, _ map[string]string,
+			http.MethodGet, endpointPath, func(w http.ResponseWriter, r *http.Request, _ map[string]string,
 			) {
 				_, outboundMarshaler := MarshalerForRequest(s, r)
 
-				serviceQueryParam := r.URL.Query().Get("service")
-
 				resp, err := healthCheckClient.Check(r.Context(), &grpc_health_v1.HealthCheckRequest{
-					Service: serviceQueryParam,
+					Service: r.URL.Query().Get("service"),
 				})
 				if err != nil {
 					s.errorHandler(r.Context(), s, outboundMarshaler, w, r, err)
@@ -245,6 +245,13 @@ func WithHealthzEndpoint(healthCheckClient grpc_health_v1.HealthClient) ServeMux
 				_ = outboundMarshaler.NewEncoder(w).Encode(resp)
 			})
 	}
+}
+
+// WithHealthzEndpoint returns a ServeMuxOption that will add a /healthz endpoint to the created ServeMux.
+//
+// See WithHealthEndpointAt for the general implementation.
+func WithHealthzEndpoint(healthCheckClient grpc_health_v1.HealthClient) ServeMuxOption {
+	return WithHealthEndpointAt(healthCheckClient, "/healthz")
 }
 
 // NewServeMux returns a new ServeMux whose internal mapping is empty.

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -205,7 +205,7 @@ func WithDisablePathLengthFallback() ServeMuxOption {
 	}
 }
 
-// WithHealthEndpointAt returns a ServeMuxOption that will add an {endpointPath} endpoint to the created ServeMux.
+// WithHealthEndpointAt returns a ServeMuxOption that will add an endpoint to the created ServeMux at the path specified by endpointPath.
 // When called the handler will forward the request to the upstream grpc service health check (defined in the
 // gRPC Health Checking Protocol).
 //


### PR DESCRIPTION
# Custom HTTP health check endpoint

FYI @johanbrandhorst @brumhard I'd love a review of yours. I tried to go for the simplest option here, but any criticism is most welcome :muscle: 

### References to other Issues or PRs

- Fixes #2572 
- Minor improvements over the work of @brumhard :
  - https://github.com/grpc-ecosystem/grpc-gateway/issues/2302
  - https://github.com/grpc-ecosystem/grpc-gateway/pull/2319

### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes. @googlebot I signed it!

### Brief description of what is fixed or changed

- Add `WithHealthEndpointAt` server mux option to specify a custom endpoint path by means of an additional input parameter
- Implementation is entirely based on and replaces https://github.com/grpc-ecosystem/grpc-gateway/pull/2319
- The former option `WithHealthzEndpoint` uses `WithHealthEndpointAt` saturating the `endpointPath` parameter with `/healthz` (slash included), so that retro-compatibility is guaranteed
- The newly added test `TestWithHealthEndpointAt_consistentWithHealthz` uses the same test cases as the existing one, but simply makes sure that two mux routers created with the same endpoint path `/healthz` (one as option parameter via the general option, and the other by construction) return the same status code. I limited myself to this because the correctness of the output status should be already guaranteed by the existing `TestWithHealthzEndpoint_codes`
- A few words in `health_check.md`

### Other comments

As discussed in #2572 , functional options to customize `WithHealthzEndpoint` might have been a valid alternative to a new function. Since I didn't find any other parameters that might be worth generalizing within a config, I stuck to the cheapest alternative with a single argument to customize.