### PR TITLE
Remove duplicated endraw statement for documentation generation

### DIFF
--- a/docs/docs/mapping/customizing_openapi_output.md
+++ b/docs/docs/mapping/customizing_openapi_output.md
@@ -316,7 +316,7 @@ Note: Annotations are only supported on Services, Methods, Fields and Enum Value
 `opt: visibility_restriction_selectors=PREVIEW` will result in:
 
 Input Example:
-```
+```proto
 service Echo {
     rpc EchoInternal(VisibilityRuleSimpleMessage) returns (VisibilityRuleSimpleMessage) {
         option (google.api.method_visibility).restriction = "INTERNAL";

--- a/docs/docs/mapping/customizing_openapi_output.md
+++ b/docs/docs/mapping/customizing_openapi_output.md
@@ -316,7 +316,7 @@ Note: Annotations are only supported on Services, Methods, Fields and Enum Value
 `opt: visibility_restriction_selectors=PREVIEW` will result in:
 
 Input Example:
-```proto3
+```
 service Echo {
     rpc EchoInternal(VisibilityRuleSimpleMessage) returns (VisibilityRuleSimpleMessage) {
         option (google.api.method_visibility).restriction = "INTERNAL";

--- a/docs/docs/mapping/customizing_openapi_output.md
+++ b/docs/docs/mapping/customizing_openapi_output.md
@@ -316,7 +316,7 @@ Note: Annotations are only supported on Services, Methods, Fields and Enum Value
 `opt: visibility_restriction_selectors=PREVIEW` will result in:
 
 Input Example:
-```proto
+```protobuf
 service Echo {
     rpc EchoInternal(VisibilityRuleSimpleMessage) returns (VisibilityRuleSimpleMessage) {
         option (google.api.method_visibility).restriction = "INTERNAL";

--- a/docs/docs/mapping/customizing_openapi_output.md
+++ b/docs/docs/mapping/customizing_openapi_output.md
@@ -283,7 +283,6 @@ Output json:
     ]
 },
 ```
-{% endraw %}
 
 ### Hiding fields, methods, services and enum values
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

https://github.com/grpc-ecosystem/grpc-gateway/pull/2578

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

This was accidentally left this in my last PR, breaking documentation generation.

https://github.com/grpc-ecosystem/grpc-gateway/pull/2578

Update `proto3` language type in codeblock to `Protobuf` to fix formatting issue. 

#### Other comments

