### PR TITLE
protoc-gen-openapiv2: Use the canonical camelCase converter for protobuf

### DIFF
--- a/internal/casing/LICENSE.md
+++ b/internal/casing/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2010 The Go Authors.  All rights reserved.
+Copyright 2010, 2019 The Go Authors.  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/internal/casing/README.md
+++ b/internal/casing/README.md
@@ -1,5 +1,7 @@
 # Case conversion
 
-This package contains a single function, copied from the
-`github.com/golang/protobuf/protoc-gen-go/generator` package. That
-modules LICENSE is referenced in its entirety in this package.
+This package contains two functions:
+- `Camel` copied from the `github.com/golang/protobuf/protoc-gen-go/generator` package.
+- `JSONCamelCase` copied from the `github.com/protocolbuffers/protobuf-go/internal/strs` package.
+
+Both these modules are licensed by The Go Authors, as reflected in this package's [LICENSE.md].

--- a/internal/casing/camel.go
+++ b/internal/casing/camel.go
@@ -50,6 +50,24 @@ func Camel(s string) string {
 	return string(t)
 }
 
+// JSONCamelCase converts a snake_case identifier to a camelCase identifier,
+// according to the protobuf JSON specification.
+func JSONCamelCase(s string) string {
+	var b []byte
+	var wasUnderscore bool
+	for i := 0; i < len(s); i++ { // proto identifiers are always ASCII
+		c := s[i]
+		if c != '_' {
+			if wasUnderscore && isASCIILower(c) {
+				c -= 'a' - 'A' // convert to uppercase
+			}
+			b = append(b, c)
+		}
+		wasUnderscore = c == '_'
+	}
+	return string(b)
+}
+
 // And now lots of helper functions.
 
 // Is c an ASCII lower-case letter?

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -1164,7 +1164,7 @@ func renderServices(services []*descriptor.Service, paths openapiPathsObject, re
 							bodyFieldName = bodyField.Name
 						}
 						// Align pathParams with body field path.
-						pathParams := subPathParams(bodyField.Name, b.PathParams)
+						pathParams := subPathParams(bodyFieldName, b.PathParams)
 						var err error
 						schema, err = renderFieldAsDefinition(bodyField.Target, reg, customRefs, pathParams)
 						if err != nil {

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -1164,7 +1164,7 @@ func renderServices(services []*descriptor.Service, paths openapiPathsObject, re
 							bodyFieldName = bodyField.Name
 						}
 						// Align pathParams with body field path.
-						pathParams := subPathParams(bodyFieldName, b.PathParams)
+						pathParams := subPathParams(bodyField.Name, b.PathParams)
 						var err error
 						schema, err = renderFieldAsDefinition(bodyField.Target, reg, customRefs, pathParams)
 						if err != nil {
@@ -2523,7 +2523,7 @@ func updateswaggerObjectFromJSONSchema(s *openapiSchemaObject, j *openapi_option
 	if reg.GetUseJSONNamesForFields() {
 		for i, r := range s.Required {
 			// TODO(oyvindwe): Look up field and use field.GetJsonName()?
-			s.Required[i] = doCamelCase(r)
+			s.Required[i] = casing.JSONCamelCase(r)
 		}
 	}
 	s.Enum = j.GetEnum()
@@ -2707,7 +2707,7 @@ func lowerCamelCase(fieldName string, fields []*descriptor.Field, msgs []*descri
 		fieldNames := strings.Split(fieldName, ".")
 		fieldNamesWithCamelCase := make([]string, 0)
 		for i := 0; i < len(fieldNames)-1; i++ {
-			fieldNamesWithCamelCase = append(fieldNamesWithCamelCase, doCamelCase(string(fieldNames[i])))
+			fieldNamesWithCamelCase = append(fieldNamesWithCamelCase, casing.JSONCamelCase(string(fieldNames[i])))
 		}
 		prefix := strings.Join(fieldNamesWithCamelCase, ".")
 		reservedJSONName := getReservedJSONName(fieldName, messageNameToFieldsToJSONName, fieldNameToType)
@@ -2715,15 +2715,7 @@ func lowerCamelCase(fieldName string, fields []*descriptor.Field, msgs []*descri
 			return prefix + "." + reservedJSONName
 		}
 	}
-	return doCamelCase(fieldName)
-}
-
-func doCamelCase(input string) string {
-	parameterString := casing.Camel(input)
-	builder := &strings.Builder{}
-	builder.WriteString(strings.ToLower(string(parameterString[0])))
-	builder.WriteString(parameterString[1:])
-	return builder.String()
+	return casing.JSONCamelCase(fieldName)
 }
 
 func getReservedJSONName(fieldName string, messageNameToFieldsToJSONName map[string]map[string]string, fieldNameToType map[string]string) string {


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #2363

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

Fixes the generation of camelCase names in generated OAS files from field names in proto files.

#### Other comments

Updated `internal/casing/LICENSE.md`.