### PR TITLE
Use Bytes from convert.go to unmarshal byte value

### DIFF
--- a/runtime/query.go
+++ b/runtime/query.go
@@ -1,7 +1,6 @@
 package runtime
 
 import (
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/url"
@@ -234,7 +233,7 @@ func parseField(fieldDescriptor protoreflect.FieldDescriptor, value string) (pro
 	case protoreflect.StringKind:
 		return protoreflect.ValueOfString(value), nil
 	case protoreflect.BytesKind:
-		v, err := base64.URLEncoding.DecodeString(value)
+		v, err := Bytes(value)
 		if err != nil {
 			return protoreflect.Value{}, err
 		}
@@ -312,7 +311,7 @@ func parseMessage(msgDescriptor protoreflect.MessageDescriptor, value string) (p
 	case "google.protobuf.StringValue":
 		msg = &wrapperspb.StringValue{Value: value}
 	case "google.protobuf.BytesValue":
-		v, err := base64.URLEncoding.DecodeString(value)
+		v, err := Bytes(value)
 		if err != nil {
 			return protoreflect.Value{}, err
 		}


### PR DESCRIPTION
#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?
Yes 
#### Brief description of what is fixed or changed
`bytes` field in path can use `base64.StdEncoding` form also. 

In #1978 , the way how `bytes` field in path is unmarshalled is changed to `base64.URLEncoding`. However, the `bytes` field is marshalled using `base64.StdEncoding` in json. If both these encodings are accepted as a path components, user may use result in json output as path parameter directly.

#### Other comments
