### PR TITLE
fix: Content-Type and Grpc-Metadata-Content-Type headers with the health endpoint

### DIFF
--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -229,6 +229,9 @@ func WithHealthEndpointAt(healthCheckClient grpc_health_v1.HealthClient, endpoin
 					return
 				}
 
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Grpc-Metadata-Content-Type", "application/grpc")
+
 				if resp.GetStatus() != grpc_health_v1.HealthCheckResponse_SERVING {
 					var err error
 					switch resp.GetStatus() {


### PR DESCRIPTION
Fixes #2611

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)? Yes

#### Brief description of what is fixed or changed
Manually set the `Content-Type` and `Grpc-Metadata-Content-Type` headers to `application/json` and `application/grpc` respectively.
I also added a test to check the headers of the `healthCheckTests` set.


#### Other comments
Since we stay in the [WithHealthEndpointAt()](https://github.com/grpc-ecosystem/grpc-gateway/blob/d8e890717a850f4bcc23f192fb567176d7f92e1b/runtime/mux.go#L216) method and we use the [outgoing marshaler](https://github.com/grpc-ecosystem/grpc-gateway/blob/d8e890717a850f4bcc23f192fb567176d7f92e1b/runtime/mux.go#L222) directly in it, we can't take advantage of the Content-Type deduction (except in the [errorHandler](https://github.com/grpc-ecosystem/grpc-gateway/blob/d8e890717a850f4bcc23f192fb567176d7f92e1b/runtime/mux.go#L241)). In my opinion it is easier in this case to directly add the headers [before](https://github.com/grpc-ecosystem/grpc-gateway/blob/d8e890717a850f4bcc23f192fb567176d7f92e1b/runtime/mux.go#L231) writing the response writer. 

CC @brumhard @antonioiubatti93