### PR TITLE
Export `defaultQueryParser` struct for custom query parsers

### DIFF
--- a/docs/docs/development/grpc-gateway_v2_migration_guide.md
+++ b/docs/docs/development/grpc-gateway_v2_migration_guide.md
@@ -162,3 +162,7 @@ There is no workaround for this, as we considered it a correct interpretation of
 ## Error handling configuration has been overhauled
 
 `runtime.HTTPError`, `runtime.OtherErrorHandler`, `runtime.GlobalHTTPErrorHandler`, `runtime.WithProtoErrorHandler` are all gone. Error handling is rewritten around the use of gRPCs Status types. If you wish to configure how the gateway handles errors, please use `runtime.WithErrorHandler` and `runtime.WithStreamErrorHandler`. To handle routing errors (similar to the removed `runtime.OtherErrorHandler`) please use `runtime.WithRoutingErrorHandler`.
+
+## Default query parameter parsing behaviour change
+
+The default behaviour for query parameter parsing has changed to return an `InvalidArgument` (`400 Bad Request`) error when more than one of the same matching query parameters is parsed. Previously, it would log but not return an error, using the first query parameter that matched and ignoring any others. See [the original issue](https://github.com/grpc-ecosystem/grpc-gateway/issues/2632) for more information.

--- a/runtime/query.go
+++ b/runtime/query.go
@@ -24,7 +24,7 @@ import (
 
 var valuesKeyRegexp = regexp.MustCompile(`^(.*)\[(.*)\]$`)
 
-var currentQueryParser QueryParameterParser = &defaultQueryParser{}
+var currentQueryParser QueryParameterParser = &DefaultQueryParser{}
 
 // QueryParameterParser defines interface for all query parameter parsers
 type QueryParameterParser interface {
@@ -37,11 +37,15 @@ func PopulateQueryParameters(msg proto.Message, values url.Values, filter *utili
 	return currentQueryParser.Parse(msg, values, filter)
 }
 
-type defaultQueryParser struct{}
+// DefaultQueryParser is a QueryParameterParser which implements the default
+// query parameters parsing behavior.
+//
+// See https://github.com/grpc-ecosystem/grpc-gateway/issues/2632 for more context.
+type DefaultQueryParser struct{}
 
 // Parse populates "values" into "msg".
 // A value is ignored if its key starts with one of the elements in "filter".
-func (*defaultQueryParser) Parse(msg proto.Message, values url.Values, filter *utilities.DoubleArray) error {
+func (*DefaultQueryParser) Parse(msg proto.Message, values url.Values, filter *utilities.DoubleArray) error {
 	for key, values := range values {
 		match := valuesKeyRegexp.FindStringSubmatch(key)
 		if len(match) == 3 {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

Fixes #2632

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

- Updated the v2 migration guide to reflect that the default query parameter parsing behavior has changed.
- Exported the `defaultQueryParser` struct so custom query parsers can wrap it and pass to `SetQueryParameterParser`

#### Other comments
