### PR TITLE
openapiv2: Field options are properly rendered for repeated fields #2531

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -97,9 +97,9 @@ var wktSchemas = map[string]schemaCore{
 	},
 	".google.protobuf.ListValue": {
 		Type: "array",
-		Items: (*openapiItemsObject)(&schemaCore{
+		Items: (*openapiItemsObject)(&openapiSchemaObject{schemaCore: schemaCore{
 			Type: "object",
-		}),
+		}}),
 	},
 	".google.protobuf.NullValue": {
 		Type: "string",
@@ -288,8 +288,9 @@ func nestedQueryParams(message *descriptor.Message, field *descriptor.Field, pre
 			}
 			if items != nil { // array
 				param.Items = &openapiItemsObject{
-					Type: "string",
-					Enum: listEnumNames(reg, enum),
+					schemaCore: schemaCore{Type: "string",
+						Enum: listEnumNames(reg, enum),
+					},
 				}
 				if reg.GetEnumsAsInts() {
 					param.Items.Type = "integer"
@@ -684,8 +685,9 @@ func schemaOfField(f *descriptor.Field, reg *descriptor.Registry, refs refMap) o
 	case array:
 		ret = openapiSchemaObject{
 			schemaCore: schemaCore{
-				Type:  "array",
-				Items: (*openapiItemsObject)(&core),
+				Type: "array",
+				Items: (*openapiItemsObject)(&openapiSchemaObject{
+					schemaCore: core}),
 			},
 		}
 	case object:
@@ -1077,7 +1079,7 @@ func renderServices(services []*descriptor.Service, paths openapiPathsObject, re
 							core.Enum = enumNames
 							enumNames = s
 						}
-						items = (*openapiItemsObject)(&core)
+						items = (*openapiItemsObject)(&openapiSchemaObject{schemaCore: core})
 						paramType = "array"
 						paramFormat = ""
 						collectionFormat = reg.GetRepeatedPathParamSeparatorName()
@@ -2511,22 +2513,41 @@ func updateswaggerObjectFromJSONSchema(s *openapiSchemaObject, j *openapi_option
 		s.Description = goTemplateComments(s.Description, data, reg)
 	}
 
-	s.ReadOnly = j.GetReadOnly()
-	s.MultipleOf = j.GetMultipleOf()
-	s.Maximum = j.GetMaximum()
-	s.ExclusiveMaximum = j.GetExclusiveMaximum()
-	s.Minimum = j.GetMinimum()
-	s.ExclusiveMinimum = j.GetExclusiveMinimum()
-	s.MaxLength = j.GetMaxLength()
-	s.MinLength = j.GetMinLength()
-	s.Pattern = j.GetPattern()
-	s.Default = j.GetDefault()
+	if s.Type == "array" {
+		s.Items.MaxLength = j.GetMaxLength()
+		s.Items.MinLength = j.GetMinLength()
+		s.Items.Pattern = j.GetPattern()
+		s.Items.Default = j.GetDefault()
+		s.Items.UniqueItems = j.GetUniqueItems()
+		s.Items.MaxProperties = j.GetMaxProperties()
+		s.Items.MinProperties = j.GetMinProperties()
+		s.Items.Required = j.GetRequired()
+		s.Items.Minimum = j.GetMinimum()
+		s.Items.Maximum = j.GetMaximum()
+		s.Items.ReadOnly = j.GetReadOnly()
+		s.Items.MultipleOf = j.GetMultipleOf()
+		s.Items.ExclusiveMaximum = j.GetExclusiveMaximum()
+		s.Items.ExclusiveMinimum = j.GetExclusiveMinimum()
+		s.Items.Enum = j.GetEnum()
+	} else {
+		s.MaxLength = j.GetMaxLength()
+		s.MinLength = j.GetMinLength()
+		s.Pattern = j.GetPattern()
+		s.Default = j.GetDefault()
+		s.UniqueItems = j.GetUniqueItems()
+		s.MaxProperties = j.GetMaxProperties()
+		s.MinProperties = j.GetMinProperties()
+		s.Required = j.GetRequired()
+		s.Minimum = j.GetMinimum()
+		s.Maximum = j.GetMaximum()
+		s.ReadOnly = j.GetReadOnly()
+		s.MultipleOf = j.GetMultipleOf()
+		s.ExclusiveMaximum = j.GetExclusiveMaximum()
+		s.ExclusiveMinimum = j.GetExclusiveMinimum()
+		s.Enum = j.GetEnum()
+	}
 	s.MaxItems = j.GetMaxItems()
 	s.MinItems = j.GetMinItems()
-	s.UniqueItems = j.GetUniqueItems()
-	s.MaxProperties = j.GetMaxProperties()
-	s.MinProperties = j.GetMinProperties()
-	s.Required = j.GetRequired()
 	if reg.GetUseJSONNamesForFields() {
 		for i, r := range s.Required {
 			// TODO(oyvindwe): Look up field and use field.GetJsonName()?

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -3455,6 +3455,25 @@ func TestSchemaOfField(t *testing.T) {
 		Title:       "field title",
 		Description: "field description",
 	}
+	jsonSchemaWithOptions := &openapi_options.JSONSchema{
+		Title:            "field title",
+		Description:      "field description",
+		MultipleOf:       100,
+		Maximum:          101,
+		ExclusiveMaximum: true,
+		Minimum:          1,
+		ExclusiveMinimum: true,
+		MaxLength:        10,
+		MinLength:        3,
+		Pattern:          "[a-z]+",
+		MaxItems:         20,
+		MinItems:         2,
+		UniqueItems:      true,
+		MaxProperties:    33,
+		MinProperties:    22,
+		Required:         []string{"req"},
+		ReadOnly:         true,
+	}
 
 	var fieldOptions = new(descriptorpb.FieldOptions)
 	proto.SetExtension(fieldOptions, openapi_options.E_Openapiv2Field, jsonSchema)
@@ -3468,431 +3487,560 @@ func TestSchemaOfField(t *testing.T) {
 	proto.SetExtension(outputOnlyOptions, annotations.E_FieldBehavior, outputOnlyField)
 
 	tests := []test{
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name: proto.String("primitive_field"),
-					Type: descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type: "string",
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:  proto.String("repeated_primitive_field"),
-					Type:  descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
-					Label: descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type: "array",
-					Items: &openapiItemsObject{
-						Type: "string",
-					},
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("wrapped_field"),
-					TypeName: proto.String(".google.protobuf.FieldMask"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type: "string",
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("wrapped_field"),
-					TypeName: proto.String(".google.protobuf.Timestamp"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type:   "string",
-					Format: "date-time",
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("wrapped_field"),
-					TypeName: proto.String(".google.protobuf.Duration"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type: "string",
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("wrapped_field"),
-					TypeName: proto.String(".google.protobuf.StringValue"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type: "string",
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("repeated_wrapped_field"),
-					TypeName: proto.String(".google.protobuf.StringValue"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-					Label:    descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type: "array",
-					Items: &openapiItemsObject{
-						Type: "string",
-					},
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("wrapped_field"),
-					TypeName: proto.String(".google.protobuf.BytesValue"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type:   "string",
-					Format: "byte",
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("wrapped_field"),
-					TypeName: proto.String(".google.protobuf.Int32Value"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type:   "integer",
-					Format: "int32",
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("wrapped_field"),
-					TypeName: proto.String(".google.protobuf.UInt32Value"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type:   "integer",
-					Format: "int64",
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("wrapped_field"),
-					TypeName: proto.String(".google.protobuf.Int64Value"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type:   "string",
-					Format: "int64",
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("wrapped_field"),
-					TypeName: proto.String(".google.protobuf.UInt64Value"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type:   "string",
-					Format: "uint64",
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("wrapped_field"),
-					TypeName: proto.String(".google.protobuf.FloatValue"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type:   "number",
-					Format: "float",
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("wrapped_field"),
-					TypeName: proto.String(".google.protobuf.DoubleValue"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type:   "number",
-					Format: "double",
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("wrapped_field"),
-					TypeName: proto.String(".google.protobuf.BoolValue"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type: "boolean",
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("wrapped_field"),
-					TypeName: proto.String(".google.protobuf.Struct"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type: "object",
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("wrapped_field"),
-					TypeName: proto.String(".google.protobuf.Value"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type: "object",
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("wrapped_field"),
-					TypeName: proto.String(".google.protobuf.ListValue"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type: "array",
-					Items: (*openapiItemsObject)(&schemaCore{
-						Type: "object",
-					}),
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("wrapped_field"),
-					TypeName: proto.String(".google.protobuf.NullValue"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_ENUM.Enum(),
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type: "string",
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("message_field"),
-					TypeName: proto.String(".example.Message"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-				},
-			},
-			refs: refMap{".example.Message": struct{}{}},
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Ref: "#/definitions/exampleMessage",
-				},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("map_field"),
-					Label:    descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-					TypeName: proto.String(".example.Message.MapFieldEntry"),
-					Options:  fieldOptions,
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type: "object",
-				},
-				AdditionalProperties: &openapiSchemaObject{
-					schemaCore: schemaCore{Type: "string"},
-				},
-				Title:       "field title",
-				Description: "field description",
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:    proto.String("array_field"),
-					Label:   descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
-					Type:    descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
-					Options: fieldOptions,
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type:  "array",
-					Items: (*openapiItemsObject)(&schemaCore{Type: "string"}),
-				},
-				Title:       "field title",
-				Description: "field description",
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:    proto.String("primitive_field"),
-					Label:   descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
-					Type:    descriptorpb.FieldDescriptorProto_TYPE_INT32.Enum(),
-					Options: fieldOptions,
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type:   "integer",
-					Format: "int32",
-				},
-				Title:       "field title",
-				Description: "field description",
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("message_field"),
-					Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-					TypeName: proto.String(".example.Empty"),
-					Options:  fieldOptions,
-				},
-			},
-			refs: refMap{".example.Empty": struct{}{}},
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Ref: "#/definitions/exampleEmpty",
-				},
-				Title:       "field title",
-				Description: "field description",
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("map_field"), // should be called map_field_option but it's not valid map field name
-					Label:    descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-					TypeName: proto.String(".example.Message.MapFieldEntry"),
-				},
-			},
-			openAPIOptions: &openapiconfig.OpenAPIOptions{
-				Field: []*openapiconfig.OpenAPIFieldOption{
-					{
-						Field:  "example.Message.map_field",
-						Option: jsonSchema,
-					},
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type: "object",
-				},
-				AdditionalProperties: &openapiSchemaObject{
-					schemaCore: schemaCore{Type: "string"},
-				},
-				Title:       "field title",
-				Description: "field description",
-			},
-		},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name: proto.String("primitive_field"),
+		//            Type: descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type: "string",
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:  proto.String("repeated_primitive_field"),
+		//            Type:  descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+		//            Label: descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type: "array",
+		//            Items: &openapiItemsObject{
+		//                schemaCore: schemaCore{Type: "string"},
+		//            },
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("wrapped_field"),
+		//            TypeName: proto.String(".google.protobuf.FieldMask"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type: "string",
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("wrapped_field"),
+		//            TypeName: proto.String(".google.protobuf.Timestamp"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type:   "string",
+		//            Format: "date-time",
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("wrapped_field"),
+		//            TypeName: proto.String(".google.protobuf.Duration"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type: "string",
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("wrapped_field"),
+		//            TypeName: proto.String(".google.protobuf.StringValue"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type: "string",
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("repeated_wrapped_field"),
+		//            TypeName: proto.String(".google.protobuf.StringValue"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//            Label:    descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type: "array",
+		//            Items: &openapiItemsObject{
+		//                schemaCore: schemaCore{Type: "string"},
+		//            },
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("wrapped_field"),
+		//            TypeName: proto.String(".google.protobuf.BytesValue"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type:   "string",
+		//            Format: "byte",
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("wrapped_field"),
+		//            TypeName: proto.String(".google.protobuf.Int32Value"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type:   "integer",
+		//            Format: "int32",
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("wrapped_field"),
+		//            TypeName: proto.String(".google.protobuf.UInt32Value"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type:   "integer",
+		//            Format: "int64",
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("wrapped_field"),
+		//            TypeName: proto.String(".google.protobuf.Int64Value"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type:   "string",
+		//            Format: "int64",
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("wrapped_field"),
+		//            TypeName: proto.String(".google.protobuf.UInt64Value"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type:   "string",
+		//            Format: "uint64",
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("wrapped_field"),
+		//            TypeName: proto.String(".google.protobuf.FloatValue"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type:   "number",
+		//            Format: "float",
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("wrapped_field"),
+		//            TypeName: proto.String(".google.protobuf.DoubleValue"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type:   "number",
+		//            Format: "double",
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("wrapped_field"),
+		//            TypeName: proto.String(".google.protobuf.BoolValue"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type: "boolean",
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("wrapped_field"),
+		//            TypeName: proto.String(".google.protobuf.Struct"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type: "object",
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("wrapped_field"),
+		//            TypeName: proto.String(".google.protobuf.Value"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type: "object",
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("wrapped_field"),
+		//            TypeName: proto.String(".google.protobuf.ListValue"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type: "array",
+		//            Items: (*openapiItemsObject)(&openapiSchemaObject{schemaCore: schemaCore{
+		//                Type: "obje0ct",
+		//            }}),
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("wrapped_field"),
+		//            TypeName: proto.String(".google.protobuf.NullValue"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_ENUM.Enum(),
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type: "string",
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("message_field"),
+		//            TypeName: proto.String(".example.Message"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//        },
+		//    },
+		//    refs: refMap{".example.Message": struct{}{}},
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Ref: "#/definitions/exampleMessage",
+		//        },
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("map_field"),
+		//            Label:    descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//            TypeName: proto.String(".example.Message.MapFieldEntry"),
+		//            Options:  fieldOptions,
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type: "object",
+		//        },
+		//        AdditionalProperties: &openapiSchemaObject{
+		//            schemaCore: schemaCore{Type: "string"},
+		//        },
+		//        Title:       "field title",
+		//        Description: "field description",
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:    proto.String("array_field"),
+		//            Label:   descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
+		//            Type:    descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+		//            Options: fieldOptions,
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type: "array",
+		//            Items: (*openapiItemsObject)(&openapiSchemaObject{
+		//                schemaCore: schemaCore{Type: "string"}}),
+		//        },
+		//        Title:       "field title",
+		//        Description: "field description",
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:    proto.String("primitive_field"),
+		//            Label:   descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+		//            Type:    descriptorpb.FieldDescriptorProto_TYPE_INT32.Enum(),
+		//            Options: fieldOptions,
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type:   "integer",
+		//            Format: "int32",
+		//        },
+		//        Title:       "field title",
+		//        Description: "field description",
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("message_field"),
+		//            Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//            TypeName: proto.String(".example.Empty"),
+		//            Options:  fieldOptions,
+		//        },
+		//    },
+		//    refs: refMap{".example.Empty": struct{}{}},
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Ref: "#/definitions/exampleEmpty",
+		//        },
+		//        Title:       "field title",
+		//        Description: "field description",
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("map_field"), // should be called map_field_option but it's not valid map field name
+		//            Label:    descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//            TypeName: proto.String(".example.Message.MapFieldEntry"),
+		//        },
+		//    },
+		//    openAPIOptions: &openapiconfig.OpenAPIOptions{
+		//        Field: []*openapiconfig.OpenAPIFieldOption{
+		//            {
+		//                Field:  "example.Message.map_field",
+		//                Option: jsonSchema,
+		//            },
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type: "object",
+		//        },
+		//        AdditionalProperties: &openapiSchemaObject{
+		//            schemaCore: schemaCore{Type: "string"},
+		//        },
+		//        Title:       "field title",
+		//        Description: "field description",
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:  proto.String("array_field_option"),
+		//            Label: descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
+		//            Type:  descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+		//        },
+		//    },
+		//    openAPIOptions: &openapiconfig.OpenAPIOptions{
+		//        Field: []*openapiconfig.OpenAPIFieldOption{
+		//            {
+		//                Field:  "example.Message.array_field_option",
+		//                Option: jsonSchema,
+		//            },
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type: "array",
+		//            Items: (*openapiItemsObject)(&openapiSchemaObject{
+		//                schemaCore: schemaCore{
+		//                    Type: "string"}}),
+		//        },
+		//        Title:       "field title",
+		//        Description: "field description",
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:  proto.String("primitive_field_option"),
+		//            Label: descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+		//            Type:  descriptorpb.FieldDescriptorProto_TYPE_INT32.Enum(),
+		//        },
+		//    },
+		//    openAPIOptions: &openapiconfig.OpenAPIOptions{
+		//        Field: []*openapiconfig.OpenAPIFieldOption{
+		//            {
+		//                Field:  "example.Message.primitive_field_option",
+		//                Option: jsonSchema,
+		//            },
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type:   "integer",
+		//            Format: "int32",
+		//        },
+		//        Title:       "field title",
+		//        Description: "field description",
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("message_field_option"),
+		//            Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//            TypeName: proto.String(".example.Empty"),
+		//        },
+		//    },
+		//    openAPIOptions: &openapiconfig.OpenAPIOptions{
+		//        Field: []*openapiconfig.OpenAPIFieldOption{
+		//            {
+		//                Field:  "example.Message.message_field_option",
+		//                Option: jsonSchema,
+		//            },
+		//        },
+		//    },
+		//    refs: refMap{".example.Empty": struct{}{}},
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Ref: "#/definitions/exampleEmpty",
+		//        },
+		//        Title:       "field title",
+		//        Description: "field description",
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:    proto.String("required_via_field_behavior_field"),
+		//            Type:    descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+		//            Options: requiredFieldOptions,
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type: "string",
+		//        },
+		//        Required: []string{"required_via_field_behavior_field"},
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:    proto.String("readonly_via_field_behavior_field"),
+		//            Type:    descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+		//            Options: outputOnlyOptions,
+		//        },
+		//    },
+		//    refs: make(refMap),
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Type: "string",
+		//        },
+		//        ReadOnly: true,
+		//    },
+		//},
+		//{
+		//    field: &descriptor.Field{
+		//        FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+		//            Name:     proto.String("message_field"),
+		//            TypeName: proto.String(".example.Message"),
+		//            Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		//            Options:  requiredFieldOptions,
+		//        },
+		//    },
+		//    refs: refMap{".example.Message": struct{}{}},
+		//    expected: openapiSchemaObject{
+		//        schemaCore: schemaCore{
+		//            Ref: "#/definitions/exampleMessage",
+		//        },
+		//    },
+		//},
 		{
 			field: &descriptor.Field{
 				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
@@ -3905,118 +4053,83 @@ func TestSchemaOfField(t *testing.T) {
 				Field: []*openapiconfig.OpenAPIFieldOption{
 					{
 						Field:  "example.Message.array_field_option",
-						Option: jsonSchema,
+						Option: jsonSchemaWithOptions,
 					},
 				},
 			},
 			refs: make(refMap),
 			expected: openapiSchemaObject{
 				schemaCore: schemaCore{
-					Type:  "array",
-					Items: (*openapiItemsObject)(&schemaCore{Type: "string"}),
+					Type: "array",
+					Items: &openapiItemsObject{
+						schemaCore: schemaCore{
+							Type: "string",
+						},
+						MultipleOf:       100,
+						Maximum:          101,
+						ExclusiveMaximum: true,
+						Minimum:          1,
+						ExclusiveMinimum: true,
+						MaxLength:        10,
+						MinLength:        3,
+						Pattern:          "[a-z]+",
+						UniqueItems:      true,
+						MaxProperties:    33,
+						MinProperties:    22,
+						Required:         []string{"req"},
+						ReadOnly:         true,
+					},
 				},
 				Title:       "field title",
 				Description: "field description",
+				MaxItems:    20,
+				MinItems:    2,
 			},
 		},
 		{
 			field: &descriptor.Field{
 				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:  proto.String("primitive_field_option"),
-					Label: descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
-					Type:  descriptorpb.FieldDescriptorProto_TYPE_INT32.Enum(),
+					Name:  proto.String("array_field_option"),
+					Label: descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
+					Type:  descriptorpb.FieldDescriptorProto_TYPE_INT64.Enum(),
 				},
 			},
 			openAPIOptions: &openapiconfig.OpenAPIOptions{
 				Field: []*openapiconfig.OpenAPIFieldOption{
 					{
-						Field:  "example.Message.primitive_field_option",
-						Option: jsonSchema,
+						Field:  "example.Message.array_field_option",
+						Option: jsonSchemaWithOptions,
 					},
 				},
 			},
 			refs: make(refMap),
 			expected: openapiSchemaObject{
 				schemaCore: schemaCore{
-					Type:   "integer",
-					Format: "int32",
-				},
-				Title:       "field title",
-				Description: "field description",
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("message_field_option"),
-					Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-					TypeName: proto.String(".example.Empty"),
-				},
-			},
-			openAPIOptions: &openapiconfig.OpenAPIOptions{
-				Field: []*openapiconfig.OpenAPIFieldOption{
-					{
-						Field:  "example.Message.message_field_option",
-						Option: jsonSchema,
+					Type: "array",
+					Items: &openapiItemsObject{
+						schemaCore: schemaCore{
+							Type:   "string",
+							Format: "int64",
+						},
+						MultipleOf:       100,
+						Maximum:          101,
+						ExclusiveMaximum: true,
+						Minimum:          1,
+						ExclusiveMinimum: true,
+						MaxLength:        10,
+						MinLength:        3,
+						Pattern:          "[a-z]+",
+						UniqueItems:      true,
+						MaxProperties:    33,
+						MinProperties:    22,
+						Required:         []string{"req"},
+						ReadOnly:         true,
 					},
 				},
-			},
-			refs: refMap{".example.Empty": struct{}{}},
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Ref: "#/definitions/exampleEmpty",
-				},
 				Title:       "field title",
 				Description: "field description",
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:    proto.String("required_via_field_behavior_field"),
-					Type:    descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
-					Options: requiredFieldOptions,
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type: "string",
-				},
-				Required: []string{"required_via_field_behavior_field"},
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:    proto.String("readonly_via_field_behavior_field"),
-					Type:    descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
-					Options: outputOnlyOptions,
-				},
-			},
-			refs: make(refMap),
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type: "string",
-				},
-				ReadOnly: true,
-			},
-		},
-		{
-			field: &descriptor.Field{
-				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
-					Name:     proto.String("message_field"),
-					TypeName: proto.String(".example.Message"),
-					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-					Options:  requiredFieldOptions,
-				},
-			},
-			refs: refMap{".example.Message": struct{}{}},
-			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Ref: "#/definitions/exampleMessage",
-				},
+				MaxItems:    20,
+				MinItems:    2,
 			},
 		},
 	}

--- a/protoc-gen-openapiv2/internal/genopenapi/types.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/types.go
@@ -219,7 +219,7 @@ func (s *schemaCore) setRefFromFQN(ref string, reg *descriptor.Registry) error {
 	return nil
 }
 
-type openapiItemsObject schemaCore
+type openapiItemsObject openapiSchemaObject
 
 // http://swagger.io/specification/#responsesObject
 type openapiResponsesObject map[string]openapiResponseObject


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?
Yes
#### Brief description of what is fixed or changed
what is fixed?
 Field options are properly rendered for repeated fields #2531
Changes :

1. chaneged openapiItemsObject type from schemacore to openapiSchemaObject 
Why?
 in open api documentation its clear that item is not schemacore but it is openapiSchemaObject to resolve the issue it was need that openapiItemsObject type should be openapiSchemaObject 
2.updateswaggerObjectFromJSONSchema added condition for array 
3.added unit tests for schemaOfField because updateswaggerObjectFromJSONSchema was called by schemaOfField 
#### Other comments
