### PR TITLE
Incorrect mapping from grpc code to http code for canceled request.

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -38,7 +38,7 @@ func HTTPStatusFromCode(code codes.Code) int {
 	case codes.OK:
 		return http.StatusOK
 	case codes.Canceled:
-		return http.StatusRequestTimeout
+		return 499
 	case codes.Unknown:
 		return http.StatusInternalServerError
 	case codes.InvalidArgument:


### PR DESCRIPTION
Fixes #2707 

#### Brief description of what is fixed or changed
Incorrect mapping from grpc code to http code for canceled request.

The reference for error mapping in HTTPStatusFromCode is followed from:
https://github.com/googleapis/googleapis/blob/942691f8dcf3e521be35d909de9bba3239feb471/google/rpc/code.proto#L40
And the reference claims that http code mapping for CANCELED grpc code is 499 (Client Closed Request), and not 408 (StatusRequestTimeout).

This MR changes this mapping. 

Note: HTTP error code 499 const is not supported by go http pkg, hence I have used the integer literal.

