### PR TITLE
protoc-gen-openapiv2: Fix schema types for `Value` and `Empty` well-known types

### DIFF
--- a/examples/internal/clients/abe/api/swagger.yaml
+++ b/examples/internal/clients/abe/api/swagger.yaml
@@ -1364,7 +1364,8 @@ paths:
       responses:
         200:
           description: "A successful response."
-          schema: {}
+          schema:
+            type: "object"
         403:
           description: "Returned when the user does not have permission to access\
             \ the resource."
@@ -1718,7 +1719,8 @@ paths:
       responses:
         200:
           description: "A successful response."
-          schema: {}
+          schema:
+            type: "object"
         403:
           description: "Returned when the user does not have permission to access\
             \ the resource."
@@ -1790,7 +1792,8 @@ paths:
       responses:
         200:
           description: "A successful response."
-          schema: {}
+          schema:
+            type: "object"
         403:
           description: "Returned when the user does not have permission to access\
             \ the resource."
@@ -2237,7 +2240,8 @@ paths:
       responses:
         200:
           description: "A successful response."
-          schema: {}
+          schema:
+            type: "object"
         403:
           description: "Returned when the user does not have permission to access\
             \ the resource."
@@ -2288,7 +2292,8 @@ paths:
       responses:
         200:
           description: "A successful response."
-          schema: {}
+          schema:
+            type: "object"
         403:
           description: "Returned when the user does not have permission to access\
             \ the resource."
@@ -2418,7 +2423,8 @@ paths:
       responses:
         200:
           description: "A successful response."
-          schema: {}
+          schema:
+            type: "object"
         403:
           description: "Returned when the user does not have permission to access\
             \ the resource."
@@ -2449,7 +2455,8 @@ paths:
       responses:
         200:
           description: "A successful response."
-          schema: {}
+          schema:
+            type: "object"
         403:
           description: "Returned when the user does not have permission to access\
             \ the resource."
@@ -2525,7 +2532,8 @@ paths:
       responses:
         200:
           description: "A successful response."
-          schema: {}
+          schema:
+            type: "object"
         403:
           description: "Returned when the user does not have permission to access\
             \ the resource."
@@ -2556,7 +2564,8 @@ paths:
       responses:
         200:
           description: "A successful response."
-          schema: {}
+          schema:
+            type: "object"
         403:
           description: "Returned when the user does not have permission to access\
             \ the resource."
@@ -2598,7 +2607,8 @@ paths:
       responses:
         200:
           description: "A successful response."
-          schema: {}
+          schema:
+            type: "object"
         403:
           description: "Returned when the user does not have permission to access\
             \ the resource."
@@ -2637,7 +2647,8 @@ paths:
       responses:
         200:
           description: "A successful response."
-          schema: {}
+          schema:
+            type: "object"
         403:
           description: "Returned when the user does not have permission to access\
             \ the resource."
@@ -2681,7 +2692,8 @@ paths:
       responses:
         200:
           description: "A successful response."
-          schema: {}
+          schema:
+            type: "object"
         403:
           description: "Returned when the user does not have permission to access\
             \ the resource."
@@ -2720,7 +2732,8 @@ paths:
       responses:
         200:
           description: "A successful response."
-          schema: {}
+          schema:
+            type: "object"
         403:
           description: "Returned when the user does not have permission to access\
             \ the resource."

--- a/examples/internal/clients/echo/api/swagger.yaml
+++ b/examples/internal/clients/echo/api/swagger.yaml
@@ -585,14 +585,12 @@ definitions:
       structField:
         type: "object"
         properties: {}
-      valueField:
-        type: "object"
-        properties: {}
+      valueField: {}
     description: "DynamicMessage represents a message which can have its structure\n\
       built dynamically using Struct and Values."
     example:
       structField: "{}"
-      valueField: "{}"
+      valueField: ""
   examplepbDynamicMessageUpdate:
     type: "object"
     properties:
@@ -603,7 +601,7 @@ definitions:
     example:
       body:
         structField: "{}"
-        valueField: "{}"
+        valueField: ""
       updateMask: "updateMask"
   examplepbEmbedded:
     type: "object"

--- a/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
+++ b/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
@@ -1202,6 +1202,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -1915,6 +1916,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -2055,6 +2057,7 @@
                   }
                 },
                 "oneofEmpty": {
+                  "type": "object",
                   "properties": {}
                 },
                 "oneofString": {
@@ -2225,6 +2228,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -2734,6 +2738,7 @@
                   }
                 },
                 "oneofEmpty": {
+                  "type": "object",
                   "properties": {}
                 },
                 "oneofString": {
@@ -3019,6 +3024,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -3160,6 +3166,7 @@
                   }
                 },
                 "oneofEmpty": {
+                  "type": "object",
                   "properties": {}
                 },
                 "oneofString": {
@@ -3284,6 +3291,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -3425,6 +3433,7 @@
                   }
                 },
                 "oneofEmpty": {
+                  "type": "object",
                   "properties": {}
                 },
                 "oneofString": {
@@ -3689,6 +3698,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -3734,6 +3744,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -3827,6 +3838,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -3888,6 +3900,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -3933,6 +3946,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -3994,6 +4008,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -4051,6 +4066,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -4194,6 +4210,7 @@
                       }
                     },
                     "oneofEmpty": {
+                      "type": "object",
                       "properties": {}
                     },
                     "oneofString": {
@@ -4326,6 +4343,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -4517,6 +4535,7 @@
           }
         },
         "oneofEmpty": {
+          "type": "object",
           "properties": {}
         },
         "oneofString": {

--- a/examples/internal/proto/examplepb/echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/echo_service.swagger.json
@@ -685,9 +685,7 @@
         "structField": {
           "type": "object"
         },
-        "valueField": {
-          "type": "object"
-        }
+        "valueField": {}
       },
       "description": "DynamicMessage represents a message which can have its structure\nbuilt dynamically using Struct and Values."
     },

--- a/examples/internal/proto/examplepb/generated_input.swagger.json
+++ b/examples/internal/proto/examplepb/generated_input.swagger.json
@@ -23,6 +23,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -189,6 +190,7 @@
           }
         },
         "oneofEmpty": {
+          "type": "object",
           "properties": {}
         },
         "oneofString": {

--- a/examples/internal/proto/examplepb/stream.swagger.json
+++ b/examples/internal/proto/examplepb/stream.swagger.json
@@ -54,6 +54,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -316,6 +317,7 @@
           }
         },
         "oneofEmpty": {
+          "type": "object",
           "properties": {}
         },
         "oneofString": {

--- a/examples/internal/proto/examplepb/wrappers.swagger.json
+++ b/examples/internal/proto/examplepb/wrappers.swagger.json
@@ -155,6 +155,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
+              "type": "object",
               "properties": {}
             }
           },
@@ -171,6 +172,7 @@
             "in": "body",
             "required": true,
             "schema": {
+              "type": "object",
               "properties": {}
             }
           }

--- a/protoc-gen-openapiv2/internal/genopenapi/BUILD.bazel
+++ b/protoc-gen-openapiv2/internal/genopenapi/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "@org_golang_google_protobuf//types/descriptorpb",
         "@org_golang_google_protobuf//types/known/anypb",
         "@org_golang_google_protobuf//types/known/durationpb",
+        "@org_golang_google_protobuf//types/known/emptypb",
         "@org_golang_google_protobuf//types/known/structpb",
         "@org_golang_google_protobuf//types/known/timestamppb",
         "@org_golang_google_protobuf//types/known/wrapperspb",

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -88,7 +88,9 @@ var wktSchemas = map[string]schemaCore{
 	".google.protobuf.BoolValue": {
 		Type: "boolean",
 	},
-	".google.protobuf.Empty": {},
+	".google.protobuf.Empty": {
+		Type: "object",
+	},
 	".google.protobuf.Struct": {
 		Type: "object",
 	},

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -92,9 +92,7 @@ var wktSchemas = map[string]schemaCore{
 	".google.protobuf.Struct": {
 		Type: "object",
 	},
-	".google.protobuf.Value": {
-		Type: "object",
-	},
+	".google.protobuf.Value": {},
 	".google.protobuf.ListValue": {
 		Type: "array",
 		Items: (*openapiItemsObject)(&schemaCore{

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -3732,9 +3732,7 @@ func TestSchemaOfField(t *testing.T) {
 			},
 			refs: make(refMap),
 			expected: openapiSchemaObject{
-				schemaCore: schemaCore{
-					Type: "object",
-				},
+				schemaCore: schemaCore{},
 			},
 		},
 		{

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -3503,6 +3504,22 @@ func TestSchemaOfField(t *testing.T) {
 		{
 			field: &descriptor.Field{
 				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
+					Name:     proto.String("empty_field"),
+					TypeName: proto.String(".google.protobuf.Empty"),
+					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+				},
+			},
+			refs: make(refMap),
+			expected: openapiSchemaObject{
+				schemaCore: schemaCore{
+					Type: "object",
+				},
+				Properties: &openapiSchemaObjectProperties{},
+			},
+		},
+		{
+			field: &descriptor.Field{
+				FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
 					Name:     proto.String("wrapped_field"),
 					TypeName: proto.String(".google.protobuf.FieldMask"),
 					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
@@ -4029,6 +4046,7 @@ func TestSchemaOfField(t *testing.T) {
 						GoPackage: proto.String("third_party/google"),
 					},
 					MessageType: []*descriptorpb.DescriptorProto{
+						protodesc.ToDescriptorProto((&emptypb.Empty{}).ProtoReflect().Descriptor()),
 						protodesc.ToDescriptorProto((&structpb.Struct{}).ProtoReflect().Descriptor()),
 						protodesc.ToDescriptorProto((&structpb.Value{}).ProtoReflect().Descriptor()),
 						protodesc.ToDescriptorProto((&structpb.ListValue{}).ProtoReflect().Descriptor()),

--- a/runtime/internal/examplepb/non_standard_names.swagger.json
+++ b/runtime/internal/examplepb/non_standard_names.swagger.json
@@ -130,9 +130,7 @@
         "structField": {
           "type": "object"
         },
-        "valueField": {
-          "type": "object"
-        }
+        "valueField": {}
       },
       "description": "NonStandardMessage has oddly named fields."
     },
@@ -186,9 +184,7 @@
         "StructField": {
           "type": "object"
         },
-        "ValueField": {
-          "type": "object"
-        }
+        "ValueField": {}
       },
       "description": "NonStandardMessageWithJSONNames maps odd field names to odd JSON names for maximum confusion."
     },


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #2718 

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

- Generate an empty schema `{}` for `google.protobuf.Value` fields (which [serialize to any JSON value](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#value)) 
  - currently this is incorrectly generated as `{ "type": "object" }`
- Generate an object schema `{ "type": "object", "properties": {} }` for `google.protobuf.Empty` (which [serialize to an empty JSON object `{}`](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#empty))
  - currently this is generated as `{ "properties": {} }`

#### Other comments

Ideally `Empty` would also have `"additionalProperties": false` but this can't be represented in the `openapiSchemaObject` struct, which defines that field to be of type `*openapiSchemaObject`.
