### PR TITLE
Use custom token secret for pushes

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,8 +14,6 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v3
 
@@ -41,7 +39,7 @@ jobs:
           if output=$(git status --porcelain) && [ ! -z "$output" ]; then
             git config user.name "Renovate Bot"
             git config user.email "bot@renovateapp.com"
-            git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/grpc-ecosystem/grpc-gateway.git
+            git remote set-url origin https://x-access-token:${{ secrets.GH_PUSH_TOKEN }}@github.com/grpc-ecosystem/grpc-gateway.git
             git commit --amend --no-edit
             git push --force-with-lease origin ${{ github.ref_name }}
           fi
@@ -53,8 +51,6 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     needs:
       # Run after update_repositoriesbzl to avoid
       # git conflicts
@@ -70,7 +66,7 @@ jobs:
           if output=$(git status --porcelain) && [ ! -z "$output" ]; then
             git config user.name "Renovate Bot"
             git config user.email "bot@renovateapp.com"
-            git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/grpc-ecosystem/grpc-gateway.git
+            git remote set-url origin https://x-access-token:${{ secrets.GH_PUSH_TOKEN }}@github.com/grpc-ecosystem/grpc-gateway.git
             git commit --amend --no-edit
             git push --force-with-lease origin ${{ github.ref_name }}
           fi

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,7 +6,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 # Define before rules_proto, otherwise we receive the version of com_google_protobuf from there
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "6cec96cd159aae33aa519a4ec7114b6433e13289bec7acd160bacebdcb3cad85",
+    sha256 = "a295dd3b9551d3e2749a9969583dea110c6cdcc39d02088f7c7bb1100077e081",
     strip_prefix = "protobuf-3.21.1",
     urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.21.1.tar.gz"],
 )


### PR DESCRIPTION
Renovate PRs have been getting auto-closed and I suspect it's because we're using the jobs own token to push to the repository. Use a custom token instead and hope that fixes the issue.

This token belongs to @grpcgatewaybot 