### PR TITLE
Set fetch depth for renovate actions

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           token: ${{ secrets.GH_PUSH_TOKEN }}
       - uses: actions/cache@v3
         with:
@@ -58,6 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           token: ${{ secrets.GH_PUSH_TOKEN }}
       - run: make install
       - run: make clean


### PR DESCRIPTION
This should help avoid the issue where a force push deletes all the history for a PR. Thanks to Arthur from Github for debugging this for me!
