### PR TITLE
Change renovate branch trigger

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - renovate/master-*
+      - renovate/*
 permissions:
   contents: read
 name: renovate


### PR DESCRIPTION
Ever since we disabled renovate on v1, the branch names have changed. This means the job has not been running. Update the branch names on which this job runs.