### PR TITLE
Fix buf plugin's library version

### DIFF
--- a/.github/plugins/protoc-gen-grpc-gateway/Dockerfile
+++ b/.github/plugins/protoc-gen-grpc-gateway/Dockerfile
@@ -13,7 +13,7 @@ ARG GO_PROTOBUF_RELEASE_VERSION
 ARG GO_GRPC_RELEASE_VERSION
 
 # Runtime dependencies
-LABEL "build.buf.plugins.runtime_library_versions.0.name"="github.com/grpc-ecosystem/grpc-gateway"
+LABEL "build.buf.plugins.runtime_library_versions.0.name"="github.com/grpc-ecosystem/grpc-gateway/v2"
 LABEL "build.buf.plugins.runtime_library_versions.0.version"="${RELEASE_VERSION}"
 LABEL "build.buf.plugins.runtime_library_versions.1.name"="google.golang.org/protobuf"
 LABEL "build.buf.plugins.runtime_library_versions.1.version"="${GO_PROTOBUF_RELEASE_VERSION}"


### PR DESCRIPTION
The buf `mod` currently returns a defunct version which cause go mod to complain.

See https://bufbuild.slack.com/archives/CRZ680FUH/p1658149356049699?thread_ts=1658096456.542309&cid=CRZ680FUH

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

#### Other comments
