### PR TITLE
fix: yaml indent [#2645]

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/format.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/format.go
@@ -31,7 +31,10 @@ func (f Format) Validate() error {
 func (f Format) NewEncoder(w io.Writer) (ContentEncoder, error) {
 	switch f {
 	case FormatYAML:
-		return yaml.NewEncoder(w), nil
+		enc := yaml.NewEncoder(w)
+		enc.SetIndent(2)
+
+		return enc, nil
 	case FormatJSON:
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

Fixes #2745

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

There is an indent bug in the YAML library. Changing indentation to 2 spaces as it was before in the second version fixes this issue.

#### Other comments

```proto
syntax = "proto3";
package repro;
option go_package = "repro/foobar";

import "google/api/annotations.proto";

service Repro {
    rpc GetRollup(RollupRequest) returns (RollupResponse) {
        option (google.api.http) = {
	        get: "/rollup"
        };
    }
}

message RollupRequest {
    RollupType type = 1;
}

message RollupResponse {}

enum RollupType {
    UNKNOWN_ROLLUP = 0;

    // Apples are good
    APPLE = 1;
    BANANA = 2;

    // Carrots are mediocre
    CARROT = 3;
}
```

Produces:
```yaml
/* ... */
description: |2-
   - APPLE: Apples are good
   - CARROT: Carrots are **mediocre**
/* ... */
```

Full file:

```yaml
swagger: "2.0"
info:
  title: exampleproto/v1/exampleproto.proto
  version: version not set
tags:
  - name: Repro
consumes:
  - application/json
produces:
  - application/json
paths:
  /rollup:
    get:
      operationId: Repro_GetRollup
      responses:
        "200":
          description: A successful response.
          schema:
            $ref: '#/definitions/reproRollupResponse'
        default:
          description: An unexpected error response.
          schema:
            $ref: '#/definitions/rpcStatus'
      parameters:
        - name: type
          description: |2-
             - APPLE: Apples are good
             - CARROT: Carrots are mediocre
          in: query
          required: false
          type: string
          enum:
            - UNKNOWN_ROLLUP
            - APPLE
            - BANANA
            - CARROT
          default: UNKNOWN_ROLLUP
      tags:
        - Repro
definitions:
  protobufAny:
    type: object
    properties:
      '@type':
        type: string
    additionalProperties: {}
  reproRollupResponse:
    type: object
  reproRollupType:
    type: string
    enum:
      - UNKNOWN_ROLLUP
      - APPLE
      - BANANA
      - CARROT
    default: UNKNOWN_ROLLUP
    title: |-
      - APPLE: Apples are good
       - CARROT: Carrots are mediocre
  rpcStatus:
    type: object
    properties:
      code:
        type: integer
        format: int32
      details:
        type: array
        items:
          $ref: '#/definitions/protobufAny'
      message:
        type: string
```