### PR TITLE
switch ci build env version to 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           ./node_modules/.bin/gulp
   generate:
     container:
-      image: docker.pkg.github.com/grpc-ecosystem/grpc-gateway/build-env:1.17
+      image: docker.pkg.github.com/grpc-ecosystem/grpc-gateway/build-env:1.19
       options: "--user root"
       credentials:
         username: ${{ github.actor }}
@@ -56,7 +56,7 @@ jobs:
       - run: git diff --exit-code
   bazel:
     container:
-      image: docker.pkg.github.com/grpc-ecosystem/grpc-gateway/build-env:1.17
+      image: docker.pkg.github.com/grpc-ecosystem/grpc-gateway/build-env:1.19
       options: "--user root"
       credentials:
         username: ${{ github.actor }}


### PR DESCRIPTION
switch ci build env version to 1.19, mentioned in [this reply](https://github.com/grpc-ecosystem/grpc-gateway/pull/2829#issuecomment-1209836531)
I've run the following commands to regenerate the files. It didn't make any difference.
```
docker run -v $(pwd):/grpc-gateway -w /grpc-gateway --rm ghcr.io/grpc-ecosystem/grpc-gateway/build-env:1.19 \
    /bin/bash -c 'make install && \
        make clean && \
        make generate'
docker run -itv $(pwd):/grpc-gateway -w /grpc-gateway --entrypoint /bin/bash --rm \
    ghcr.io/grpc-ecosystem/grpc-gateway/build-env:1.19 -c '\
        bazel run :gazelle -- update-repos -from_file=go.mod -to_macro=repositories.bzl%go_repositories && \
        bazel run :gazelle && \
        bazel run :buildifier'

```