### PR TITLE
Signed release binaries with SLSA signatures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ permissions:
 name: release
 jobs:
   goreleaser:
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -18,10 +20,31 @@ jobs:
         with:
           check-latest: true
       - uses: goreleaser/goreleaser-action@v3
+        id: run-goreleaser
         with:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate subject
+        id: hash
+        env:
+          ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
+        run: |
+          set -euo pipefail
+
+          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
+          echo "::set-output name=hashes::$(cat $checksum_file | base64 -w0)"
+  provenance:
+    needs: [goreleaser]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
+    with:
+      base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
+      upload-assets: true # upload to a new release
+
   push_bsr_plugins:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ that's needed to generate a reverse-proxy with this library.
 
 ## Installation
 
+### Compile from source
 The following instructions assume you are using
 [Go Modules](https://github.com/golang/go/wiki/Modules) for dependency
 management. Use a
@@ -94,6 +95,8 @@ This will place four binaries in your `$GOBIN`;
 - `protoc-gen-go-grpc`
 
 Make sure that your `$GOBIN` is in your `$PATH`.
+
+### Download the binaries
 
 You may alternatively download the binaries from the [GitHub releases page](https://github.com/grpc-ecosystem/grpc-gateway/releases/latest).
 We generate [SLSA3 signatures](slsa.dev) using the OpenSSF's [slsa-framework/slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator) during the release process. To verify a release binary:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ gRPC to JSON proxy generator following the gRPC HTTP spec
 <a href="https://github.com/grpc-ecosystem/grpc-gateway/blob/master/LICENSE.txt"><img src="https://img.shields.io/github/license/grpc-ecosystem/grpc-gateway?color=379c9c&style=flat-square"/></a>
 <a href="https://github.com/grpc-ecosystem/grpc-gateway/releases"><img src="https://img.shields.io/github/v/release/grpc-ecosystem/grpc-gateway?color=379c9c&logoColor=ffffff&style=flat-square"/></a>
 <a href="https://github.com/grpc-ecosystem/grpc-gateway/stargazers"><img src="https://img.shields.io/github/stars/grpc-ecosystem/grpc-gateway?color=379c9c&style=flat-square"/></a>
+<a href="https://slsa.dev/images/gh-badge-level3.svg"><img src="https://slsa.dev/images/gh-badge-level3.svg"/></a>
+
 </div>
 
 ## About
@@ -92,6 +94,15 @@ This will place four binaries in your `$GOBIN`;
 - `protoc-gen-go-grpc`
 
 Make sure that your `$GOBIN` is in your `$PATH`.
+
+You may alternatively download the binaries from the [GitHub releases page](https://github.com/grpc-ecosystem/grpc-gateway/releases/latest).
+We generate [SLSA3 signatures](slsa.dev) using the OpenSSF's [slsa-framework/slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator) during the release process. To verify a release binary:
+1. Install the verification tool from [slsa-framework/slsa-verifier#installation](https://github.com/slsa-framework/slsa-verifier#installation).
+2. Download the provenance file `attestation.intoto.jsonl` from the [GitHub releases page](https://github.com/grpc-ecosystem/grpc-gateway/releases/latest).
+3. Run the verifier:
+```shell
+slsa-verifier -artifact-path <the-binary> -provenance attestation.intoto.jsonl -source github.com/grpc-ecosystem/grpc-gateway -tag <the-tag>
+```
 
 Alternatively, see the section on remotely managed plugin versions below.
 


### PR DESCRIPTION
Hi,

I'm reaching out on behalf of the [Open Source Security Foundation (openssf.org)](https://openssf.org/). We work on improving the security of critical open source projects like yours. 

Together with [GitHub](https://github.blog/2022-04-07-slsa-3-compliance-with-github-actions/), we designed a free, easy-to-use method of code signing. It will help your users verify that your release binaries were built from your repository’s [workflow](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/.github/workflows/release.yml) and not altered by anyone. It’s just a few lines of code, but it will make your project more secure against third-party tampering and attacks like [Codecov](https://about.codecov.io/apr-2021-post-mortem/) and [CTX](https://sockpuppets.medium.com/how-i-hacked-ctx-and-phpass-modules-656638c6ec5e).

This PR shows how to add this seamless code signing to your workflow. You don’t have to be a cryptography expert or learn complicated tools and [verification](https://github.com/slsa-framework/slsa-verifier/blob/main/README.md#verification-of-provenance) is simple for your users.  

You can read more on the [SLSA blog](https://slsa.dev/blog/2022/06/slsa-github-workflows). Please reach out if you have any questions!
