### PR TITLE
Fix goreleaser problem for SLSA generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
+          # Temporary fix for https://github.com/goreleaser/goreleaser/issues/3344.
+          #checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
+          checksum_file=$(cat _output/artifacts.json | jq -r '.[] | select (.type=="Checksum") | .path')
           echo "::set-output name=hashes::$(cat $checksum_file | base64 -w0)"
+
   provenance:
     needs: [goreleaser]
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,6 @@ jobs:
           #checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
           checksum_file=$(cat _output/artifacts.json | jq -r '.[] | select (.type=="Checksum") | .path')
           echo "::set-output name=hashes::$(cat $checksum_file | base64 -w0)"
-
   provenance:
     needs: [goreleaser]
     permissions:


### PR DESCRIPTION
There is a problem in goreleaser which causes the SLSA provenance generation to fail: https://github.com/goreleaser/goreleaser-action/issues/368

This PR is a temporary fix to the problem, as suggested in the tracking issue above.

/cc @johanbrandhorst