### PR TITLE
mux: calculate verb correctly for cases like DELETE /foo/bar:archive when user provided wrong method

### DIFF
--- a/runtime/mux_test.go
+++ b/runtime/mux_test.go
@@ -120,6 +120,19 @@ func TestMuxServeHTTP(t *testing.T) {
 		{
 			patterns: []stubPattern{
 				{
+					method: "POST",
+					ops:    []int{int(utilities.OpLitPush), 0, int(utilities.OpPush), 0, int(utilities.OpConcatN), 1, int(utilities.OpCapture), 1},
+					pool:   []string{"foo", "id"},
+					verb:   "archive",
+				},
+			},
+			reqMethod:  "DELETE",
+			reqPath:    "/foo/bar:archive",
+			respStatus: http.StatusNotImplemented,
+		},
+		{
+			patterns: []stubPattern{
+				{
 					method: "GET",
 					ops:    []int{int(utilities.OpLitPush), 0},
 					pool:   []string{"foo"},


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

In the test, the method the user meant was POST, which is supported.
DELETE is not supported, but I believe this should be NotImplemented, not NotFound.

#### Other comments

I think maybe the bug is because for this variable:

```
// Verb out here is to memoize for the fallback case below
var verb string
```

It's only ever set in the loop using `s.handlers[r.Method]` but the loop never enters because the request method is different to the registered route method. Hence `verb` is always an empty string in the later logic.

Of course, please challenge me on this being the desired behaviour or not.
