### PR TITLE
Make registry load packages deterministically

### DIFF
--- a/internal/descriptor/registry.go
+++ b/internal/descriptor/registry.go
@@ -2,6 +2,7 @@ package descriptor
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/golang/glog"
@@ -187,12 +188,18 @@ func (r *Registry) LoadFromPlugin(gen *protogen.Plugin) error {
 }
 
 func (r *Registry) load(gen *protogen.Plugin) error {
-	for filePath, f := range gen.FilesByPath {
-		r.loadFile(filePath, f)
+	filePaths := make([]string, 0, len(gen.FilesByPath))
+	for filePath := range gen.FilesByPath {
+		filePaths = append(filePaths, filePath)
+	}
+	sort.Strings(filePaths)
+
+	for _, filePath := range filePaths {
+		r.loadFile(filePath, gen.FilesByPath[filePath])
 	}
 
-	for filePath, f := range gen.FilesByPath {
-		if !f.Generate {
+	for _, filePath := range filePaths {
+		if !gen.FilesByPath[filePath].Generate {
 			continue
 		}
 		file := r.files[filePath]


### PR DESCRIPTION
Using a map to iterate over the package file paths makes it non-deterministic. In scenarios with multiple aliases makes the alias id to change between executions. This change uses a sorted slice helper to avoid it.

#### References to other Issues or PRs

The change was introduced here https://github.com/grpc-ecosystem/grpc-gateway/pull/1756/files#diff-d687866048a4c701abca666154733de33a7beddf3160e0478db02cb393380ed2R153


#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

See above.

#### Other comments

- I tried to upgrade to Go 1.19 to use `maps.Keys()` and `slices.Sort()` but gave up, maybe in another PR.
- I tried to test it but found it hard, so I finally tested this manually in our private repo where the issue happened, which has tons of packages with the same name (i.e `v2` from an API). If the need for a unit test is a blocker, let me know.