### PR TITLE
Adjust the return value "result"

### DIFF
--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -72,12 +72,11 @@ func ForwardResponseStream(ctx context.Context, mux *ServeMux, marshaler Marshal
 		case isHTTPBody:
 			buf = httpBody.GetData()
 		default:
-			result := map[string]interface{}{"result": resp}
 			if rb, ok := resp.(responseBody); ok {
-				result["result"] = rb.XXX_ResponseBody()
+				buf, err = marshaler.Marshal(rb.XXX_ResponseBody())
+			} else {
+				buf, err = marshaler.Marshal(resp)
 			}
-
-			buf, err = marshaler.Marshal(result)
 		}
 
 		if err != nil {

--- a/runtime/handler_test.go
+++ b/runtime/handler_test.go
@@ -146,9 +146,9 @@ func TestForwardResponseStream(t *testing.T) {
 						t.Errorf("stream responseBody failed %v", err)
 					}
 
-					b, err = marshaler.Marshal(map[string]interface{}{"result": rb.XXX_ResponseBody()})
+					b, err = marshaler.Marshal(rb.XXX_ResponseBody())
 				} else {
-					b, err = marshaler.Marshal(map[string]interface{}{"result": msg.pb})
+					b, err = marshaler.Marshal(msg.pb)
 				}
 
 				if err != nil {
@@ -252,7 +252,7 @@ func TestForwardResponseStreamCustomMarshaler(t *testing.T) {
 				if msg.err != nil {
 					t.Skip("checking erorr encodings")
 				}
-				b, err := marshaler.Marshal(map[string]proto.Message{"result": msg.pb})
+				b, err := marshaler.Marshal(msg.pb)
 				if err != nil {
 					t.Errorf("marshaler.Marshal() failed %v", err)
 				}


### PR DESCRIPTION
fix: "result" is a redundant return value, which will lead to inconsistency with the grpc request result.