### PR TITLE
Updated gRPC code Cancelled replaced with HTTP code 499

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -38,7 +38,7 @@ func HTTPStatusFromCode(code codes.Code) int {
 	case codes.OK:
 		return http.StatusOK
 	case codes.Canceled:
-		return http.StatusRequestTimeout
+		return 499
 	case codes.Unknown:
 		return http.StatusInternalServerError
 	case codes.InvalidArgument:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs
#2707 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?
Yes

#### Brief description of what is fixed or changed

Incorrect mapping from grpc code to http code for canceled request.

The reference for error mapping in HTTPStatusFromCode is followed from:
https://github.com/googleapis/googleapis/blob/942691f8dcf3e521be35d909de9bba3239feb471/google/rpc/code.proto#L40
And the reference claims that http code mapping for CANCELED grpc code is 499 (Client Closed Request), and not 408 (StatusRequestTimeout).

Note: HTTP error code 499 const is not supported by go http pkg, hence I have used the integer literal.

#### Other comments
Please add hacktoberfest label on this PR & hacktoberfest-accepted label if its accepted