### PR TITLE
fix: remove default service tag generation for methods

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -1380,13 +1380,7 @@ func renderServices(services []*descriptor.Service, paths openapiPathsObject, re
 					responseSchema.Ref = ""
 				}
 
-				tag := svc.GetName()
-				if pkg := svc.File.GetPackage(); pkg != "" && reg.IsIncludePackageInTags() {
-					tag = pkg + "." + tag
-				}
-
 				operationObject := &openapiOperationObject{
-					Tags:       []string{tag},
 					Parameters: parameters,
 					Responses: openapiResponsesObject{
 						"200": openapiResponseObject{
@@ -1396,6 +1390,15 @@ func renderServices(services []*descriptor.Service, paths openapiPathsObject, re
 						},
 					},
 				}
+
+				if !reg.GetDisableServiceTags() {
+					tag := svc.GetName()
+					if pkg := svc.File.GetPackage(); pkg != "" && reg.IsIncludePackageInTags() {
+						tag = pkg + "." + tag
+					}
+					operationObject.Tags = []string{tag}
+				}
+
 				if !reg.GetDisableDefaultErrors() {
 					errDef, hasErrDef := fullyQualifiedNameToOpenAPIName(".google.rpc.Status", reg)
 					if hasErrDef {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs
[Issue #2917](https://github.com/grpc-ecosystem/grpc-gateway/issues/2917)

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)? YES

#### Brief description of what is fixed or changed
As part of [Issue #2917](https://github.com/grpc-ecosystem/grpc-gateway/issues/2917), generation of service tags should be disabled if the flag is set to true as part of the corresponding [PR](https://github.com/grpc-ecosystem/grpc-gateway/pull/2928). However, although the tags are not generated at the service level, we missed a spot where service tags were still being generated on the `operation`/`method` level. 

For example, if a `method` did not explicitly have `tags` defined in its `options`, it would still generate the service name as a tag and apply it to the `method`. This behavior should not happen if the flag `disable_service_tags` is set to `true`.

This PR is to address that

#### Other comments