### PR TITLE
Use tag instead of has pin for SLSA generator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@dc705baf82c5178c9d1555594b0652f569e22779 # tag=v1.2.1
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.1
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true # upload to a new release

--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,11 @@
                 "github-pages"
             ],
             "enabled": false
+        },
+        {
+            "matchManagers": ["github-actions"],
+            "matchPackageNames": ["slsa-framework/slsa-github-generator"],
+            "pinDigests": false
         }
     ]
 }


### PR DESCRIPTION
As explained in https://github.com/slsa-framework/slsa-github-generator/#referencing-slsa-builders-and-generators, the SLSA generator does not support being pinned by hash yet, due to a limitation of existing GitHub APIs.

This PR uses a tag instead of a hash pin.