### PR TITLE
release: Update release.yml with option to workaround SLSA generator failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
       contents: write # To add assets to a release.
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.1
     with:
+      compile-generator: true # Workaround for https://github.com/slsa-framework/slsa-github-generator/issues/1163
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true # upload to a new release
 


### PR DESCRIPTION
### Description

This updates the SLSA generator workflow with a workaround due to an issue. https://github.com/slsa-framework/slsa-github-generator/issues/1163

The rough context is that Sigstore made a final breaking change related to an online service that distributes its trust root material (a TUF repository) which was backwards incompatible with their older libraries. Thus, our older builders failed, and we are working on updates. 

Adding `compile-generator: true` means that the generator code is compiled from source rather than download and verified with Sigstore. The Sigstore verification was broken due to the above problem in the old builders verifier versions.

### Other

We are tracking stability improvements: https://github.com/slsa-framework/slsa-github-generator/milestone/9
