### PR TITLE
Add a verb test case for mux

### DIFF
--- a/runtime/mux_test.go
+++ b/runtime/mux_test.go
@@ -465,6 +465,48 @@ func TestMuxServeHTTP(t *testing.T) {
 			unescapingMode: runtime.UnescapingModeAllCharacters,
 			respContent:    "POST /api/v1/{name=organizations/*}:action",
 		},
+		{
+			patterns: []stubPattern{
+				{
+					method: "POST",
+					ops: []int{
+						int(utilities.OpLitPush), 0,
+						int(utilities.OpLitPush), 1,
+						int(utilities.OpLitPush), 2,
+					},
+					pool: []string{"api", "v1", "organizations"},
+					verb: "verb",
+				},
+				{
+					method: "POST",
+					ops: []int{
+						int(utilities.OpLitPush), 0,
+						int(utilities.OpLitPush), 1,
+						int(utilities.OpLitPush), 2,
+					},
+					pool: []string{"api", "v1", "organizations"},
+					verb: "",
+				},
+				{
+					method: "POST",
+					ops: []int{
+						int(utilities.OpLitPush), 0,
+						int(utilities.OpLitPush), 1,
+						int(utilities.OpLitPush), 2,
+					},
+					pool: []string{"api", "v1", "dummies"},
+					verb: "verb",
+				},
+			},
+			reqMethod: "POST",
+			reqPath:   "/api/v1/organizations:verb",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+			},
+			respStatus:     http.StatusOK,
+			unescapingMode: runtime.UnescapingModeAllCharacters,
+			respContent:    "POST /api/v1/organizations:verb",
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			var opts []runtime.ServeMuxOption


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

#2990

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

Adding a verb pattern test case for the mux.

1. `POST /api/v1/organizations:verb`
2. `POST /api/v1/organizations`
3. `POST /api/v1/dummies:verb`

Request to `POST /api/v1/organizations:verb` and expect routes to `POST /api/v1/organizations:verb`

#### Other comments
