### PR TITLE
Use `debug.ReadBuildInfo` for retrieving plugin version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grpc-ecosystem/grpc-gateway/v2
 
-go 1.18
+go 1.17
 
 require (
 	github.com/antihax/optional v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grpc-ecosystem/grpc-gateway/v2
 
-go 1.17
+go 1.18
 
 require (
 	github.com/antihax/optional v1.0.0

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -49,7 +49,7 @@ func main() {
 	defer glog.Flush()
 
 	if *versionFlag {
-		fmt.Printf("Version %v, commit %v, built at %v\n", version, commit, date)
+		fmt.Printf("Version %v, commit %v, built at %v\n", readVersion(), commit, date)
 		os.Exit(0)
 	}
 

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -13,7 +13,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"runtime/debug"
 	"strings"
 
 	"github.com/golang/glog"
@@ -45,20 +44,12 @@ var (
 	date    = "unknown"
 )
 
-func buildVersion() string {
-	v, ok := debug.ReadBuildInfo()
-	if !ok {
-		return version
-	}
-	return v.Main.Version
-}
-
 func main() {
 	flag.Parse()
 	defer glog.Flush()
 
 	if *versionFlag {
-		fmt.Printf("Version %v, commit %v, built at %v\n", buildVersion(), commit, date)
+		fmt.Printf("Version %v, commit %v, built at %v\n", version, commit, date)
 		os.Exit(0)
 	}
 

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -13,6 +13,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"strings"
 
 	"github.com/golang/glog"
@@ -44,12 +45,20 @@ var (
 	date    = "unknown"
 )
 
+func buildVersion() string {
+	v, ok := debug.ReadBuildInfo()
+	if !ok {
+		return version
+	}
+	return v.Main.Version
+}
+
 func main() {
 	flag.Parse()
 	defer glog.Flush()
 
 	if *versionFlag {
-		fmt.Printf("Version %v, commit %v, built at %v\n", version, commit, date)
+		fmt.Printf("Version %v, commit %v, built at %v\n", buildVersion(), commit, date)
 		os.Exit(0)
 	}
 

--- a/protoc-gen-grpc-gateway/main_go1.18.go
+++ b/protoc-gen-grpc-gateway/main_go1.18.go
@@ -1,0 +1,12 @@
+//go:build go1.18
+
+package main
+
+import "runtime/debug"
+
+func init() {
+	v, ok := debug.ReadBuildInfo()
+	if ok {
+		version = v.Main.Version
+	}
+}

--- a/protoc-gen-grpc-gateway/main_go1.18.go
+++ b/protoc-gen-grpc-gateway/main_go1.18.go
@@ -4,9 +4,10 @@ package main
 
 import "runtime/debug"
 
-func init() {
+func readVersion() string {
 	v, ok := debug.ReadBuildInfo()
-	if ok {
-		version = v.Main.Version
+	if !ok {
+		return version
 	}
+	return v.Main.Version
 }

--- a/protoc-gen-grpc-gateway/main_go_less1.18.go
+++ b/protoc-gen-grpc-gateway/main_go_less1.18.go
@@ -1,0 +1,7 @@
+//go:build !go1.18
+
+package main
+
+func readVersion() string {
+	return version
+}

--- a/protoc-gen-openapiv2/main.go
+++ b/protoc-gen-openapiv2/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"runtime/debug"
 	"strings"
 
 	"github.com/golang/glog"
@@ -52,20 +51,12 @@ var (
 	date    = "unknown"
 )
 
-func buildVersion() string {
-	v, ok := debug.ReadBuildInfo()
-	if !ok {
-		return version
-	}
-	return v.Main.Version
-}
-
 func main() {
 	flag.Parse()
 	defer glog.Flush()
 
 	if *versionFlag {
-		fmt.Printf("Version %v, commit %v, built at %v\n", buildVersion(), commit, date)
+		fmt.Printf("Version %v, commit %v, built at %v\n", version, commit, date)
 		os.Exit(0)
 	}
 

--- a/protoc-gen-openapiv2/main.go
+++ b/protoc-gen-openapiv2/main.go
@@ -56,7 +56,7 @@ func main() {
 	defer glog.Flush()
 
 	if *versionFlag {
-		fmt.Printf("Version %v, commit %v, built at %v\n", version, commit, date)
+		fmt.Printf("Version %v, commit %v, built at %v\n", readVersion(), commit, date)
 		os.Exit(0)
 	}
 

--- a/protoc-gen-openapiv2/main.go
+++ b/protoc-gen-openapiv2/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"strings"
 
 	"github.com/golang/glog"
@@ -51,12 +52,20 @@ var (
 	date    = "unknown"
 )
 
+func buildVersion() string {
+	v, ok := debug.ReadBuildInfo()
+	if !ok {
+		return version
+	}
+	return v.Main.Version
+}
+
 func main() {
 	flag.Parse()
 	defer glog.Flush()
 
 	if *versionFlag {
-		fmt.Printf("Version %v, commit %v, built at %v\n", version, commit, date)
+		fmt.Printf("Version %v, commit %v, built at %v\n", buildVersion(), commit, date)
 		os.Exit(0)
 	}
 

--- a/protoc-gen-openapiv2/main_go1.18.go
+++ b/protoc-gen-openapiv2/main_go1.18.go
@@ -1,0 +1,12 @@
+//go:build go1.18
+
+package main
+
+import "runtime/debug"
+
+func init() {
+	v, ok := debug.ReadBuildInfo()
+	if ok {
+		version = v.Main.Version
+	}
+}

--- a/protoc-gen-openapiv2/main_go1.18.go
+++ b/protoc-gen-openapiv2/main_go1.18.go
@@ -4,9 +4,10 @@ package main
 
 import "runtime/debug"
 
-func init() {
+func readVersion() string {
 	v, ok := debug.ReadBuildInfo()
-	if ok {
-		version = v.Main.Version
+	if !ok {
+		return version
 	}
+	return v.Main.Version
 }

--- a/protoc-gen-openapiv2/main_go_less1.18.go
+++ b/protoc-gen-openapiv2/main_go_less1.18.go
@@ -1,0 +1,7 @@
+//go:build !go1.18
+
+package main
+
+func readVersion() string {
+	return version
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs
closes #3022 

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

Retrieve version of grpc-gateway and openapiv2 plugins via `debug.ReadBuildInfo`, upgraded go version to 1.18 (probably last part is not necessary)

#### Other comments
