### PR TITLE
chore(logspam): allow_repeated_fields_in_body is deprecated

### DIFF
--- a/protoc-gen-grpc-gateway/BUILD.bazel
+++ b/protoc-gen-grpc-gateway/BUILD.bazel
@@ -24,10 +24,7 @@ go_binary(
 
 go_proto_compiler(
     name = "go_gen_grpc_gateway",
-    options = [
-        "logtostderr=true",
-        "allow_repeated_fields_in_body=true",
-    ],
+    options = ["logtostderr=true"],
     plugin = ":protoc-gen-grpc-gateway",
     suffix = ".pb.gw.go",
     visibility = ["//visibility:public"],

--- a/protoc-gen-openapiv2/defs.bzl
+++ b/protoc-gen-openapiv2/defs.bzl
@@ -75,7 +75,6 @@ def _run_proto_gen_openapi(
     args.add("--plugin", "protoc-gen-openapiv2=%s" % protoc_gen_openapiv2.path)
 
     args.add("--openapiv2_opt", "logtostderr=true")
-    args.add("--openapiv2_opt", "allow_repeated_fields_in_body=true")
 
     extra_inputs = []
     if grpc_api_configuration:


### PR DESCRIPTION
This flag causes logspam due to https://github.com/grpc-ecosystem/grpc-gateway/commit/672f079d1ec726166bbdf413b1fa24bf6da2cb35

It seems that change just neglected to remove the explicit flag settings for Bazel users.
