### PR TITLE
add separate_package option to grpc-gateway plugin

### DIFF
--- a/internal/descriptor/registry.go
+++ b/internal/descriptor/registry.go
@@ -2,6 +2,7 @@ package descriptor
 
 import (
 	"fmt"
+	"path"
 	"sort"
 	"strings"
 
@@ -221,6 +222,16 @@ func (r *Registry) load(gen *protogen.Plugin) error {
 // It does not load services and methods in "file".  You need to call
 // loadServices after loadFiles is called for all files to load services and methods.
 func (r *Registry) loadFile(filePath string, file *protogen.File) {
+	if r.separatePackage {
+		file.GoPackageName += "gateway"
+		dir := path.Dir(file.GeneratedFilenamePrefix)
+		base := path.Base(file.GeneratedFilenamePrefix)
+		file.GeneratedFilenamePrefix = path.Join(
+			dir,
+			string(file.GoPackageName),
+			base,
+		)
+	}
 	pkg := GoPackage{
 		Path: string(file.GoImportPath),
 		Name: string(file.GoPackageName),

--- a/internal/descriptor/registry.go
+++ b/internal/descriptor/registry.go
@@ -136,6 +136,8 @@ type Registry struct {
 	// disableDefaultResponses disables the generation of default responses.
 	// Useful if you have to support custom response codes that are not 200.
 	disableDefaultResponses bool
+
+	separatePackage bool
 }
 
 type repeatedFieldSeparator struct {
@@ -216,7 +218,7 @@ func (r *Registry) load(gen *protogen.Plugin) error {
 }
 
 // loadFile loads messages, enumerations and fields from "file".
-// It does not loads services and methods in "file".  You need to call
+// It does not load services and methods in "file".  You need to call
 // loadServices after loadFiles is called for all files to load services and methods.
 func (r *Registry) loadFile(filePath string, file *protogen.File) {
 	pkg := GoPackage{
@@ -397,6 +399,11 @@ func (r *Registry) SetPrefix(prefix string) {
 // SetStandalone registers standalone flag to control package prefix
 func (r *Registry) SetStandalone(standalone bool) {
 	r.standalone = standalone
+}
+
+// SetSeparatePackage registers flag to enable code generate to a sub package
+func (r *Registry) SetSeparatePackage(separatePackage bool) {
+	r.separatePackage = separatePackage
 }
 
 // SetRecursiveDepth records the max recursion count

--- a/internal/descriptor/services.go
+++ b/internal/descriptor/services.go
@@ -35,9 +35,6 @@ func (r *Registry) loadServices(file *File) error {
 					Name:  svc.File.GoPkg.Name + "grpc",
 					Alias: "extGRPC" + strings.TrimPrefix(svc.File.GoPkg.Alias, "ext"),
 				},
-				Messages: svc.File.Messages,
-				Enums:    svc.File.Enums,
-				Services: svc.File.Services,
 			}
 		}
 		for _, md := range sd.GetMethod() {

--- a/internal/descriptor/types.go
+++ b/internal/descriptor/types.go
@@ -162,8 +162,11 @@ func (e *Enum) GoType(currentPackage string) string {
 // Service wraps descriptorpb.ServiceDescriptorProto for richer features.
 type Service struct {
 	*descriptorpb.ServiceDescriptorProto
-	// File is the file where this service is defined.
+	// File is the file where this service's messages are defined.
 	File *File
+	// GRPCFile is the file where this service's gRPC stubs are defined.
+	// This is nil if the service's gRPC stubs are defined alongside the messages.
+	GRPCFile *File
 	// Methods is the list of methods defined in this service.
 	Methods []*Method
 	// ForcePrefixedName when set to true, prefixes a type with a package prefix.
@@ -173,7 +176,9 @@ type Service struct {
 // FQSN returns the fully qualified service name of this service.
 func (s *Service) FQSN() string {
 	components := []string{""}
-	if s.File.Package != nil {
+	if s.GRPCFile != nil && s.GRPCFile.Package != nil {
+		components = append(components, s.GRPCFile.GetPackage())
+	} else if s.File.Package != nil {
 		components = append(components, s.File.GetPackage())
 	}
 	components = append(components, s.GetName())
@@ -185,7 +190,11 @@ func (s *Service) InstanceName() string {
 	if !s.ForcePrefixedName {
 		return s.GetName()
 	}
-	return fmt.Sprintf("%s.%s", s.File.Pkg(), s.GetName())
+	pkg := s.File.Pkg()
+	if s.GRPCFile != nil {
+		pkg = s.GRPCFile.Pkg()
+	}
+	return fmt.Sprintf("%s.%s", pkg, s.GetName())
 }
 
 // ClientConstructorName returns name of the Client constructor with package prefix if needed
@@ -194,7 +203,11 @@ func (s *Service) ClientConstructorName() string {
 	if !s.ForcePrefixedName {
 		return constructor
 	}
-	return fmt.Sprintf("%s.%s", s.File.Pkg(), constructor)
+	pkg := s.File.Pkg()
+	if s.GRPCFile != nil {
+		pkg = s.GRPCFile.Pkg()
+	}
+	return fmt.Sprintf("%s.%s", pkg, constructor)
 }
 
 // Method wraps descriptorpb.MethodDescriptorProto for richer features.

--- a/protoc-gen-grpc-gateway/internal/gengateway/generator.go
+++ b/protoc-gen-grpc-gateway/internal/gengateway/generator.go
@@ -90,19 +90,10 @@ func (g *generator) Generate(targets []*descriptor.File) ([]*descriptor.Response
 			glog.Errorf("%v: %s", err, code)
 			return nil, err
 		}
-		goPkg := file.GoPkg
-		filePrefix := file.GeneratedFilenamePrefix
-		if g.separatePackage {
-			goPkg = descriptor.GoPackage{
-				Path: path.Join(goPkg.Path, filepath.Base(goPkg.Path)+"gateway"),
-				Name: goPkg.Name + "gateway",
-			}
-			filePrefix = path.Join(filepath.Dir(file.GeneratedFilenamePrefix), filepath.Base(goPkg.Path), filepath.Base(file.GeneratedFilenamePrefix))
-		}
 		files = append(files, &descriptor.ResponseFile{
-			GoPkg: goPkg,
+			GoPkg: file.GoPkg,
 			CodeGeneratorResponse_File: &pluginpb.CodeGeneratorResponse_File{
-				Name:    proto.String(filePrefix + ".pb.gw.go"),
+				Name:    proto.String(file.GeneratedFilenamePrefix + ".pb.gw.go"),
 				Content: proto.String(string(formatted)),
 			},
 		})

--- a/protoc-gen-grpc-gateway/internal/gengateway/generator_test.go
+++ b/protoc-gen-grpc-gateway/internal/gengateway/generator_test.go
@@ -96,3 +96,27 @@ func TestGenerator_Generate(t *testing.T) {
 		t.Fatalf("invalid name %q, expected %q", gotName, expectedName)
 	}
 }
+
+func TestGenerator_GenerateSeparatePackage(t *testing.T) {
+	g := new(generator)
+	g.separatePackage = true
+	g.reg = descriptor.NewRegistry()
+	g.reg.SetSeparatePackage(true)
+	result, err := g.Generate([]*descriptor.File{
+		crossLinkFixture(newExampleFileDescriptorWithGoPkg(&descriptor.GoPackage{
+			Path: "example.com/path/to/example",
+			Name: "example_pb",
+		}, "path/to/example")),
+	})
+	if err != nil {
+		t.Fatalf("failed to generate stubs: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected to generate one file, got: %d", len(result))
+	}
+	expectedName := "path/to/examplegateway/example.pb.gw.go"
+	gotName := result[0].GetName()
+	if gotName != expectedName {
+		t.Fatalf("invalid name %q, expected %q", gotName, expectedName)
+	}
+}


### PR DESCRIPTION
Add a new option `separate_package` to grpc-gateway plugin which does the following:

- Assumes that gRPC generated code is found in a `<base>grpc` package, where `<base>` is the last component of the go_package (i.e. `v1grpc`).
- Generates the grpc-gateway code to a `<base>gateway` directory, where `<base>` is the last component of the go_package (i.e. `v1gateway`).

This option requires the `standalone=true` option to be set.

Here's an example layout of the generated code:

```
gen
├── go
│   └── your
│       └── service
│           └── v1
│               ├── v1gateway
│               │   └── your_service.pb.gw.go
│               ├── v1grpc
│               │   └── your_service_grpc.pb.go
│               └── your_service.pb.go
```

Here's an example `buf.gen.yaml` demonstrating the option:

```yaml
version: v1
plugins:
  - plugin: buf.build/protocolbuffers/go
    out: gen/go
    opt:
      - paths=source_relative
  - plugin: buf.build/grpc/go
    out: gen/go
    opt:
      - paths=source_relative
      - separate_package=true
  - plugin: grpc-gateway
    out: gen/go
    opt:
      - paths=source_relative
      - standalone=true
      - separate_package=true
```

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

#### Other comments
