### PR TITLE
fix(docs): add  protoc-gen-openapiv2 to tutorial

### DIFF
--- a/docs/docs/tutorials/introduction.md
+++ b/docs/docs/tutorials/introduction.md
@@ -27,7 +27,7 @@ Before we start coding, we have to install some tools.
 
 We will be using a Go gRPC server in the examples, so please install Go first from [https://golang.org/dl/](https://golang.org/dl/).
 
-After installing Go, use `go get` to download the following packages:
+After installing Go, use `go install` to download and build the following binaries:
 
 ```sh
 $ go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway

--- a/docs/docs/tutorials/introduction.md
+++ b/docs/docs/tutorials/introduction.md
@@ -31,6 +31,7 @@ After installing Go, use `go get` to download the following packages:
 
 ```sh
 $ go get github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway
+$ go get github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2
 $ go get google.golang.org/protobuf/cmd/protoc-gen-go
 $ go get google.golang.org/grpc/cmd/protoc-gen-go-grpc
 ```

--- a/docs/docs/tutorials/introduction.md
+++ b/docs/docs/tutorials/introduction.md
@@ -30,9 +30,9 @@ We will be using a Go gRPC server in the examples, so please install Go first fr
 After installing Go, use `go install` to download and build the following binaries:
 
 ```sh
-$ go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway
-$ go install google.golang.org/protobuf/cmd/protoc-gen-go
-$ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
+$ go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@latest
+$ go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+$ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 ```
 
 This installs the `protoc` generator plugins we need to generate the stubs. Make sure to add `$GOPATH/bin` to your `$PATH` so that executables installed via `go get` are available on your `$PATH`.

--- a/docs/docs/tutorials/introduction.md
+++ b/docs/docs/tutorials/introduction.md
@@ -30,10 +30,9 @@ We will be using a Go gRPC server in the examples, so please install Go first fr
 After installing Go, use `go get` to download the following packages:
 
 ```sh
-$ go get github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway
-$ go get github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2
-$ go get google.golang.org/protobuf/cmd/protoc-gen-go
-$ go get google.golang.org/grpc/cmd/protoc-gen-go-grpc
+$ go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway
+$ go install google.golang.org/protobuf/cmd/protoc-gen-go
+$ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
 ```
 
 This installs the `protoc` generator plugins we need to generate the stubs. Make sure to add `$GOPATH/bin` to your `$PATH` so that executables installed via `go get` are available on your `$PATH`.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed
To use `grpc-gateway` we should install `protoc-gen-openapiv2` as mentioned in the [README.md](https://github.com/grpc-ecosystem/grpc-gateway)

but this line is missing [in the tutorials page document](https://grpc-ecosystem.github.io/grpc-gateway/docs/tutorials/introduction/)

I had difficulties installing the `openapiv2` required for `grpc-gateway`

#### Other comments
