### PR TITLE
Make read_only work with references using AllOf

### DIFF
--- a/internal/descriptor/registry.go
+++ b/internal/descriptor/registry.go
@@ -136,6 +136,10 @@ type Registry struct {
 	// disableDefaultResponses disables the generation of default responses.
 	// Useful if you have to support custom response codes that are not 200.
 	disableDefaultResponses bool
+
+	// useAllOfForRefs, if set, will use allOf as container for $ref to preserve same-level
+	// properties
+	useAllOfForRefs bool
 }
 
 type repeatedFieldSeparator struct {
@@ -771,4 +775,14 @@ func (r *Registry) SetDisableDefaultResponses(use bool) {
 // GetDisableDefaultResponses returns disableDefaultResponses
 func (r *Registry) GetDisableDefaultResponses() bool {
 	return r.disableDefaultResponses
+}
+
+// SetUseAllOfForRefs sets useAllOfForRefs
+func (r *Registry) SetUseAllOfForRefs(use bool) {
+	r.useAllOfForRefs = use
+}
+
+// GetUseAllOfForRefs returns useAllOfForRefs
+func (r *Registry) GetUseAllOfForRefs() bool {
+	return r.useAllOfForRefs
 }

--- a/protoc-gen-openapiv2/defs.bzl
+++ b/protoc-gen-openapiv2/defs.bzl
@@ -356,6 +356,12 @@ protoc_gen_openapiv2 = rule(
                   " Repeat this option to supply multiple values. Elements without" +
                   " visibility annotations are unaffected by this setting.",
         ),
+        "use_allof_for_refs": attr.bool(
+            default = False,
+            mandatory = False,
+            doc = "if set, will use allOf as container for $ref to preserve" +
+                  " same-level properties.",
+        ),
         "_protoc": attr.label(
             default = "@com_google_protobuf//:protoc",
             executable = True,

--- a/protoc-gen-openapiv2/internal/genopenapi/types.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/types.go
@@ -182,6 +182,10 @@ type schemaCore struct {
 	Default string   `json:"default,omitempty" yaml:"default,omitempty"`
 }
 
+type allOfEntry struct {
+	Ref string `json:"$ref,omitempty" yaml:"$ref,omitempty"`
+}
+
 type RawExample json.RawMessage
 
 func (m RawExample) MarshalJSON() ([]byte, error) {
@@ -321,6 +325,8 @@ type openapiSchemaObject struct {
 	Required         []string `json:"required,omitempty" yaml:"required,omitempty"`
 
 	extensions []extension
+
+	AllOf []allOfEntry `json:"allOf,omitempty" yaml:"allOf,omitempty"`
 }
 
 // http://swagger.io/specification/#definitionsObject

--- a/protoc-gen-openapiv2/main.go
+++ b/protoc-gen-openapiv2/main.go
@@ -42,6 +42,7 @@ var (
 	visibilityRestrictionSelectors = utilities.StringArrayFlag(flag.CommandLine, "visibility_restriction_selectors", "list of `google.api.VisibilityRule` visibility labels to include in the generated output when a visibility annotation is defined. Repeat this option to supply multiple values. Elements without visibility annotations are unaffected by this setting.")
 	disableServiceTags             = flag.Bool("disable_service_tags", false, "if set, disables generation of service tags. This is useful if you do not want to expose the names of your backend grpc services.")
 	disableDefaultResponses        = flag.Bool("disable_default_responses", false, "if set, disables generation of default responses. Useful if you have to support custom response codes that are not 200.")
+	useAllOfForRefs                = flag.Bool("use_allof_for_refs", false, "if set, will use allOf as container for $ref to preserve same-level properties.")
 )
 
 // Variables set by goreleaser at build time
@@ -127,6 +128,7 @@ func main() {
 	reg.SetVisibilityRestrictionSelectors(*visibilityRestrictionSelectors)
 	reg.SetDisableServiceTags(*disableServiceTags)
 	reg.SetDisableDefaultResponses(*disableDefaultResponses)
+	reg.SetUseAllOfForRefs(*useAllOfForRefs)
 	if err := reg.SetRepeatedPathParamSeparator(*repeatedPathParamSeparator); err != nil {
 		emitError(err)
 		return


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #1137

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

As described here:

https://github.com/grpc-ecosystem/grpc-gateway/issues/1137

This partially reverts the recent commit:

a0fe8d7c8676db9674ccbc4c4fc642790a8b8065

Which doesn't solve the problem for read_only being set on the field.

This feature will require setting the "use_allof_for_refs" to true since this breaks existing compatibility with swagger-codegen generated files from the AllOf'd schema - type is now "object" and not $ref.

Test added + ReDoc now works with read_only message/enum fields.

#### Other comments
