### PR TITLE
Fix field order in yaml generated OAS file

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/types.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/types.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor"
+	"gopkg.in/yaml.v3"
 )
 
 type param struct {
@@ -259,13 +260,23 @@ type keyVal struct {
 type openapiSchemaObjectProperties []keyVal
 
 func (p openapiSchemaObjectProperties) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, len(p))
-
-	for _, v := range p {
-		m[v.Key] = v.Value
+	n := yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: make([]*yaml.Node, len(p)*2),
 	}
-
-	return m, nil
+	for i, v := range p {
+		keyNode := yaml.Node{}
+		if err := keyNode.Encode(v.Key); err != nil {
+			return nil, err
+		}
+		valueNode := yaml.Node{}
+		if err := valueNode.Encode(v.Value); err != nil {
+			return nil, err
+		}
+		n.Content[i*2+0] = &keyNode
+		n.Content[i*2+1] = &valueNode
+	}
+	return n, nil
 }
 
 func (op openapiSchemaObjectProperties) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

Today, the field order in swagger.json files is consistent with the actual order of fields in the .proto messages.
(i.e. not by protobuf index/tag and not alphabetically sorted, but actually in the same order inside the protobuf)

However, in swagger.yaml files the order becomes alphabetical due to automatic map[string]interface{} ordering in yaml marshaling.
This gives less control over generated documentation (Redoc) from those yaml files.

This PR uses yaml.Node introduces in yaml.v3 to keep the same field order in yaml generated files as well.

#### Other comments
