### PR TITLE
fix(#3049):add items type for array

### DIFF
--- a/examples/internal/helloworld/helloworld.swagger.json
+++ b/examples/internal/helloworld/helloworld.swagger.json
@@ -958,6 +958,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
+++ b/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
@@ -2354,6 +2354,7 @@
                 "nested": {
                   "type": "array",
                   "items": {
+                    "type": "object",
                     "$ref": "#/definitions/ABitOfEverythingNested"
                   }
                 },
@@ -2495,6 +2496,7 @@
                 "repeatedNestedAnnotation": {
                   "type": "array",
                   "items": {
+                    "type": "object",
                     "$ref": "#/definitions/ABitOfEverythingNested"
                   },
                   "description": "Repeated nested object description.",
@@ -4743,6 +4745,7 @@
                 "nested": {
                   "type": "array",
                   "items": {
+                    "type": "object",
                     "$ref": "#/definitions/ABitOfEverythingNested"
                   }
                 },
@@ -4884,6 +4887,7 @@
                 "repeatedNestedAnnotation": {
                   "type": "array",
                   "items": {
+                    "type": "object",
                     "$ref": "#/definitions/ABitOfEverythingNested"
                   },
                   "description": "Repeated nested object description.",
@@ -5404,6 +5408,7 @@
                 "nested": {
                   "type": "array",
                   "items": {
+                    "type": "object",
                     "$ref": "#/definitions/ABitOfEverythingNested"
                   }
                 },
@@ -5545,6 +5550,7 @@
                 "repeatedNestedAnnotation": {
                   "type": "array",
                   "items": {
+                    "type": "object",
                     "$ref": "#/definitions/ABitOfEverythingNested"
                   },
                   "description": "Repeated nested object description.",
@@ -5715,6 +5721,7 @@
                 "nested": {
                   "type": "array",
                   "items": {
+                    "type": "object",
                     "$ref": "#/definitions/ABitOfEverythingNested"
                   }
                 },
@@ -5856,6 +5863,7 @@
                 "repeatedNestedAnnotation": {
                   "type": "array",
                   "items": {
+                    "type": "object",
                     "$ref": "#/definitions/ABitOfEverythingNested"
                   },
                   "description": "Repeated nested object description.",
@@ -6595,6 +6603,7 @@
                     "nested": {
                       "type": "array",
                       "items": {
+                        "type": "object",
                         "$ref": "#/definitions/ABitOfEverythingNested"
                       }
                     },
@@ -6736,6 +6745,7 @@
                     "repeatedNestedAnnotation": {
                       "type": "array",
                       "items": {
+                        "type": "object",
                         "$ref": "#/definitions/ABitOfEverythingNested"
                       },
                       "description": "Repeated nested object description.",
@@ -6958,6 +6968,7 @@
         "nested": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/ABitOfEverythingNested"
           }
         },
@@ -7099,6 +7110,7 @@
         "repeatedNestedAnnotation": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/ABitOfEverythingNested"
           },
           "description": "Repeated nested object description.",
@@ -7513,6 +7525,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           },
           "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use."

--- a/examples/internal/proto/examplepb/echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/echo_service.swagger.json
@@ -859,6 +859,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           },
           "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use."

--- a/examples/internal/proto/examplepb/flow_combination.swagger.json
+++ b/examples/internal/proto/examplepb/flow_combination.swagger.json
@@ -1174,6 +1174,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           },
           "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use."

--- a/examples/internal/proto/examplepb/generate_unbound_methods.swagger.json
+++ b/examples/internal/proto/examplepb/generate_unbound_methods.swagger.json
@@ -161,6 +161,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/examples/internal/proto/examplepb/generated_input.swagger.json
+++ b/examples/internal/proto/examplepb/generated_input.swagger.json
@@ -109,6 +109,7 @@
         "nested": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/ABitOfEverythingNested"
           }
         },
@@ -250,6 +251,7 @@
         "repeatedNestedAnnotation": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/ABitOfEverythingNested"
           },
           "description": "Repeated nested object description.",
@@ -385,6 +387,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           },
           "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use."

--- a/examples/internal/proto/examplepb/non_standard_names.swagger.json
+++ b/examples/internal/proto/examplepb/non_standard_names.swagger.json
@@ -222,6 +222,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           },
           "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use."

--- a/examples/internal/proto/examplepb/openapi_merge.swagger.json
+++ b/examples/internal/proto/examplepb/openapi_merge.swagger.json
@@ -313,6 +313,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/examples/internal/proto/examplepb/openapi_merge_a.swagger.json
+++ b/examples/internal/proto/examplepb/openapi_merge_a.swagger.json
@@ -221,6 +221,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           },
           "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use."

--- a/examples/internal/proto/examplepb/openapi_merge_b.swagger.json
+++ b/examples/internal/proto/examplepb/openapi_merge_b.swagger.json
@@ -138,6 +138,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           },
           "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use."

--- a/examples/internal/proto/examplepb/response_body_service.swagger.json
+++ b/examples/internal/proto/examplepb/response_body_service.swagger.json
@@ -25,6 +25,7 @@
             "schema": {
               "type": "array",
               "items": {
+                "type": "object",
                 "$ref": "#/definitions/examplepbRepeatedResponseBodyOutResponse"
               }
             }
@@ -169,6 +170,7 @@
         "response": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/examplepbRepeatedResponseBodyOutResponse"
           }
         }
@@ -238,6 +240,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           },
           "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use."

--- a/examples/internal/proto/examplepb/stream.swagger.json
+++ b/examples/internal/proto/examplepb/stream.swagger.json
@@ -209,6 +209,7 @@
         "extensions": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           },
           "description": "Application specific response metadata. Must be set in the first response\nfor streaming APIs."
@@ -235,6 +236,7 @@
         "nested": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/ABitOfEverythingNested"
           }
         },
@@ -376,6 +378,7 @@
         "repeatedNestedAnnotation": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/ABitOfEverythingNested"
           },
           "description": "Repeated nested object description.",
@@ -511,6 +514,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           },
           "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use."

--- a/examples/internal/proto/examplepb/unannotated_echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/unannotated_echo_service.swagger.json
@@ -520,6 +520,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/examples/internal/proto/examplepb/use_go_template.swagger.json
+++ b/examples/internal/proto/examplepb/use_go_template.swagger.json
@@ -165,6 +165,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/examples/internal/proto/examplepb/visibility_rule_internal_echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/visibility_rule_internal_echo_service.swagger.json
@@ -649,6 +649,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/examples/internal/proto/examplepb/visibility_rule_none_echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/visibility_rule_none_echo_service.swagger.json
@@ -192,6 +192,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/examples/internal/proto/examplepb/visibility_rule_preview_and_internal_echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/visibility_rule_preview_and_internal_echo_service.swagger.json
@@ -815,6 +815,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/examples/internal/proto/examplepb/visibility_rule_preview_echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/visibility_rule_preview_echo_service.swagger.json
@@ -480,6 +480,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/examples/internal/proto/examplepb/wrappers.swagger.json
+++ b/examples/internal/proto/examplepb/wrappers.swagger.json
@@ -451,6 +451,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           },
           "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use."

--- a/examples/internal/proto/oneofenum/oneof_enum.swagger.json
+++ b/examples/internal/proto/oneofenum/oneof_enum.swagger.json
@@ -34,6 +34,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/examples/internal/proto/pathenum/path_enum.swagger.json
+++ b/examples/internal/proto/pathenum/path_enum.swagger.json
@@ -34,6 +34,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/examples/internal/proto/sub/message.swagger.json
+++ b/examples/internal/proto/sub/message.swagger.json
@@ -34,6 +34,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/examples/internal/proto/sub2/message.swagger.json
+++ b/examples/internal/proto/sub2/message.swagger.json
@@ -34,6 +34,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/internal/descriptor/apiconfig/apiconfig.swagger.json
+++ b/internal/descriptor/apiconfig/apiconfig.swagger.json
@@ -34,6 +34,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/internal/descriptor/openapiconfig/openapiconfig.swagger.json
+++ b/internal/descriptor/openapiconfig/openapiconfig.swagger.json
@@ -34,6 +34,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -704,6 +704,9 @@ func schemaOfField(f *descriptor.Field, reg *descriptor.Registry, refs refMap) o
 
 	switch aggregate {
 	case array:
+		if _, ok := wktSchemas[fd.GetTypeName()]; !ok && fd.GetType() == descriptorpb.FieldDescriptorProto_TYPE_MESSAGE {
+			core.Type = "object"
+		}
 		ret = openapiSchemaObject{
 			schemaCore: schemaCore{
 				Type:  "array",

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -7985,3 +7985,245 @@ func GetPaths(req *openapiSwaggerObject) []string {
 	}
 	return paths
 }
+
+func TestArrayMessageItemsType(t *testing.T) {
+
+	msgDesc := &descriptorpb.DescriptorProto{
+		Name: proto.String("ExampleMessage"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+
+			{
+				Name:     proto.String("children"),
+				Label:    descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+				TypeName: proto.String(".example.ExampleMessage"),
+				Number:   proto.Int32(1),
+				JsonName: proto.String("children"),
+			},
+		},
+	}
+
+	nestDesc := &descriptorpb.DescriptorProto{
+		Name: proto.String("NestDescMessage"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:     proto.String("children"),
+				Label:    descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+				TypeName: proto.String(".example.ExampleMessage"),
+				Number:   proto.Int32(1),
+				JsonName: proto.String("children"),
+			},
+		},
+	}
+
+	meth := &descriptorpb.MethodDescriptorProto{
+		Name:       proto.String("Example"),
+		InputType:  proto.String("ExampleMessage"),
+		OutputType: proto.String("NestDescMessage"),
+	}
+	svc := &descriptorpb.ServiceDescriptorProto{
+		Name:   proto.String("ExampleService"),
+		Method: []*descriptorpb.MethodDescriptorProto{meth},
+	}
+	msg := &descriptor.Message{
+		DescriptorProto: msgDesc,
+	}
+	nsg := &descriptor.Message{
+		DescriptorProto: nestDesc,
+	}
+	msg.Fields = []*descriptor.Field{
+		{
+			Message:              msg,
+			FieldDescriptorProto: msg.GetField()[0],
+		},
+	}
+	nsg.Fields = []*descriptor.Field{
+		{
+			Message:              nsg,
+			FieldDescriptorProto: nsg.GetField()[0],
+		},
+	}
+	file := descriptor.File{
+		FileDescriptorProto: &descriptorpb.FileDescriptorProto{
+			SourceCodeInfo: &descriptorpb.SourceCodeInfo{},
+			Name:           proto.String("example.proto"),
+			Package:        proto.String("example"),
+			MessageType:    []*descriptorpb.DescriptorProto{msgDesc, nestDesc},
+			Service:        []*descriptorpb.ServiceDescriptorProto{svc},
+			Options: &descriptorpb.FileOptions{
+				GoPackage: proto.String("github.com/grpc-ecosystem/grpc-gateway/runtime/internal/examplepb;example"),
+			},
+		},
+		GoPkg: descriptor.GoPackage{
+			Path: "example.com/path/to/example/example.pb",
+			Name: "example_pb",
+		},
+		Messages: []*descriptor.Message{msg, nsg},
+		Services: []*descriptor.Service{
+			{
+				ServiceDescriptorProto: svc,
+				Methods: []*descriptor.Method{
+					{
+						MethodDescriptorProto: meth,
+						RequestType:           msg,
+						ResponseType:          nsg,
+						Bindings: []*descriptor.Binding{
+							{
+								HTTPMethod: "POST",
+								Body: &descriptor.Body{
+									FieldPath: descriptor.FieldPath([]descriptor.FieldPathComponent{}),
+								},
+								PathTmpl: httprule.Template{
+									Version:  1,
+									OpCodes:  []int{0, 0},
+									Template: "/v1/echo", // TODO(achew22): Figure out what this should really be
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	reg := descriptor.NewRegistry()
+	reg.SetUseJSONNamesForFields(true)
+	if err := AddErrorDefs(reg); err != nil {
+		t.Errorf("AddErrorDefs(%#v) failed with %v; want success", reg, err)
+		return
+	}
+	fileCL := crossLinkFixture(&file)
+	if err := reg.Load(&pluginpb.CodeGeneratorRequest{
+		ProtoFile: []*descriptorpb.FileDescriptorProto{
+			{
+				SourceCodeInfo: &descriptorpb.SourceCodeInfo{},
+				Name:           proto.String("acme/example.proto"),
+				Package:        proto.String("example"),
+				MessageType:    []*descriptorpb.DescriptorProto{msgDesc, nestDesc},
+				Service:        []*descriptorpb.ServiceDescriptorProto{},
+				Options: &descriptorpb.FileOptions{
+					GoPackage: proto.String("acme/example"),
+				},
+			},
+		},
+	}); err != nil {
+		t.Errorf("reg.Load(%#v) failed with %v; want success", reg, err)
+		return
+	}
+	expect := openapiDefinitionsObject{
+		"rpcStatus": openapiSchemaObject{
+			schemaCore: schemaCore{
+				Type: "object",
+			},
+			Properties: &openapiSchemaObjectProperties{
+				keyVal{
+					Key: "code",
+					Value: openapiSchemaObject{
+						schemaCore: schemaCore{
+							Type:   "integer",
+							Format: "int32",
+						},
+					},
+				},
+				keyVal{
+					Key: "message",
+					Value: openapiSchemaObject{
+						schemaCore: schemaCore{
+							Type: "string",
+						},
+					},
+				},
+				keyVal{
+					Key: "details",
+					Value: openapiSchemaObject{
+						schemaCore: schemaCore{
+							Type: "array",
+							Items: &openapiItemsObject{
+								schemaCore: schemaCore{
+									Type: "object",
+									Ref:  "#/definitions/protobufAny",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"exampleExampleMessage": openapiSchemaObject{
+			schemaCore: schemaCore{
+				Type: "object",
+			},
+			Properties: &openapiSchemaObjectProperties{
+				keyVal{
+					Key: "children",
+					Value: openapiSchemaObject{
+						schemaCore: schemaCore{
+							Type: "array",
+							Items: &openapiItemsObject{
+								schemaCore: schemaCore{
+									Type: "object",
+									Ref:  "#/definitions/exampleExampleMessage",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"exampleNestDescMessage": openapiSchemaObject{
+			schemaCore: schemaCore{
+				Type: "object",
+			},
+			Properties: &openapiSchemaObjectProperties{
+				keyVal{
+					Key: "children",
+					Value: openapiSchemaObject{
+						schemaCore: schemaCore{
+							Type: "array",
+							Items: &openapiItemsObject{
+								schemaCore: schemaCore{
+									Type: "object",
+									Ref:  "#/definitions/exampleExampleMessage",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"protobufAny": openapiSchemaObject{
+			schemaCore: schemaCore{
+				Type: "object",
+			},
+			Properties: &openapiSchemaObjectProperties{
+				keyVal{
+					Key: "@type",
+					Value: openapiSchemaObject{
+						schemaCore: schemaCore{
+							Type: "string",
+						},
+					},
+				},
+			},
+			AdditionalProperties: &openapiSchemaObject{},
+		},
+	}
+
+	result, err := applyTemplate(param{File: fileCL, reg: reg})
+	if err != nil {
+		t.Errorf("applyTemplate(%#v) failed with %v; want success", reg, err)
+		return
+	}
+	if want, is, name := []string{"application/json"}, result.Produces, "Produces"; !reflect.DeepEqual(is, want) {
+		t.Errorf("applyTemplate(%#v).%s = %s want to be %s", file, name, is, want)
+	}
+	if want, is, name := expect, result.Definitions, "Produces"; !reflect.DeepEqual(is, want) {
+
+		t.Errorf("applyTemplate(%#v).%s = %v want to be %v", file, name, is, want)
+	}
+	// If there was a failure, print out the input and the json result for debugging.
+	if t.Failed() {
+		t.Errorf("had: %s", file)
+		t.Errorf("got: %s", fmt.Sprint(result))
+	}
+}

--- a/protoc-gen-openapiv2/options/annotations.swagger.json
+++ b/protoc-gen-openapiv2/options/annotations.swagger.json
@@ -34,6 +34,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/protoc-gen-openapiv2/options/openapiv2.swagger.json
+++ b/protoc-gen-openapiv2/options/openapiv2.swagger.json
@@ -34,6 +34,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/runtime/internal/examplepb/example.swagger.json
+++ b/runtime/internal/examplepb/example.swagger.json
@@ -36,6 +36,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/runtime/internal/examplepb/non_standard_names.swagger.json
+++ b/runtime/internal/examplepb/non_standard_names.swagger.json
@@ -236,6 +236,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/runtime/internal/examplepb/proto2.swagger.json
+++ b/runtime/internal/examplepb/proto2.swagger.json
@@ -36,6 +36,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }

--- a/runtime/internal/examplepb/proto3.swagger.json
+++ b/runtime/internal/examplepb/proto3.swagger.json
@@ -36,6 +36,7 @@
         "details": {
           "type": "array",
           "items": {
+            "type": "object",
             "$ref": "#/definitions/protobufAny"
           }
         }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs
Fixes https://github.com/grpc-ecosystem/grpc-gateway/issues/3049

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?
Yep!

#### Brief description of what is fixed or changed
This PR is adding the items type field for array elements are of a custom type in the OpenAPI generator, which was not set in some cases.

#### Other comments
This is my first PR for an open source project. Comments are welcome
