### PR TITLE
fix: Partial resource update, no longer generate updateMask field

### DIFF
--- a/docs/docs/mapping/patch_feature.md
+++ b/docs/docs/mapping/patch_feature.md
@@ -15,7 +15,9 @@ There are two scenarios:
 
 - The FieldMask is hidden from the REST request as per the
   [Google API design guide](https://cloud.google.com/apis/design/standard_methods#update) (as in the first additional binding in the
-  [UpdateV2](https://github.com/grpc-ecosystem/grpc-gateway/blob/370d869f65d1ffb3d07187fb0db238eca2371ce3/examples/internal/proto/examplepb/a_bit_of_everything.proto#L428-L431) example). In this case, the FieldMask is updated from the request body and set in the gRPC request message.
+  [UpdateV2](https://github.com/grpc-ecosystem/grpc-gateway/blob/370d869f65d1ffb3d07187fb0db238eca2371ce3/examples/internal/proto/examplepb/a_bit_of_everything.proto#L428-L431) example). In this case, the FieldMask is updated from the request body and set in the gRPC request message. 
+  - By default this feature is enabled, if you need to disable it, you can use the plugin option `allow_patch_feature=false`. 
+  - Note: The same option is supported by the `protoc-gen-openapiv2` plugin.
 - The FieldMask is exposed to the REST request (as in the second additional binding in the [UpdateV2](https://github.com/grpc-ecosystem/grpc-gateway/blob/370d869f65d1ffb3d07187fb0db238eca2371ce3/examples/internal/proto/examplepb/a_bit_of_everything.proto#L432-L435) example). For this case, the field mask is left untouched by the gateway.
 
 ## Example Usage

--- a/examples/internal/clients/abe/api/swagger.yaml
+++ b/examples/internal/clients/abe/api/swagger.yaml
@@ -4144,13 +4144,6 @@ paths:
         schema:
           $ref: "The book to update."
         x-exportParamName: "Book"
-      - name: "updateMask"
-        in: "query"
-        description: "The list of fields to be updated."
-        required: false
-        type: "string"
-        x-exportParamName: "UpdateMask"
-        x-optionalDataType: "String"
       - name: "allowMissing"
         in: "query"
         description: "If set to true, and the book is not found, a new book will be\
@@ -4315,13 +4308,6 @@ paths:
         schema:
           $ref: "#/definitions/A bit of everything_3"
         x-exportParamName: "Abe"
-      - name: "updateMask"
-        in: "query"
-        description: "The paths to update."
-        required: false
-        type: "string"
-        x-exportParamName: "UpdateMask"
-        x-optionalDataType: "String"
       responses:
         200:
           description: "A successful response."

--- a/examples/internal/clients/abe/api_a_bit_of_everything_service.go
+++ b/examples/internal/clients/abe/api_a_bit_of_everything_service.go
@@ -6064,14 +6064,12 @@ ABitOfEverythingServiceApiService
  * @param bookName The resource name of the book.  Format: &#x60;publishers/{publisher}/books/{book}&#x60;  Example: &#x60;publishers/1257894000000000000/books/my-book&#x60;
  * @param book The book to update.  The book&#39;s &#x60;name&#x60; field is used to identify the book to be updated. Format: publishers/{publisher}/books/{book}
  * @param optional nil or *ABitOfEverythingServiceUpdateBookOpts - Optional Parameters:
-     * @param "UpdateMask" (optional.String) -  The list of fields to be updated.
      * @param "AllowMissing" (optional.Bool) -  If set to true, and the book is not found, a new book will be created. In this situation, &#x60;update_mask&#x60; is ignored.
 
 @return ExamplepbBook
 */
 
 type ABitOfEverythingServiceUpdateBookOpts struct { 
-	UpdateMask optional.String
 	AllowMissing optional.Bool
 }
 
@@ -6092,9 +6090,6 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateBook(ct
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-	if localVarOptionals != nil && localVarOptionals.UpdateMask.IsSet() {
-		localVarQueryParams.Add("updateMask", parameterToString(localVarOptionals.UpdateMask.Value(), ""))
-	}
 	if localVarOptionals != nil && localVarOptionals.AllowMissing.IsSet() {
 		localVarQueryParams.Add("allowMissing", parameterToString(localVarOptionals.AllowMissing.Value(), ""))
 	}
@@ -6406,17 +6401,10 @@ ABitOfEverythingServiceApiService
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param uuidName
  * @param abe A bit of everything  Intentionally complicated message type to cover many features of Protobuf.
- * @param optional nil or *ABitOfEverythingServiceUpdateV22Opts - Optional Parameters:
-     * @param "UpdateMask" (optional.String) -  The paths to update.
 
 @return interface{}
 */
-
-type ABitOfEverythingServiceUpdateV22Opts struct { 
-	UpdateMask optional.String
-}
-
-func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV22(ctx context.Context, uuidName string, abe ABitOfEverything3, localVarOptionals *ABitOfEverythingServiceUpdateV22Opts) (interface{}, *http.Response, error) {
+func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV22(ctx context.Context, uuidName string, abe ABitOfEverything3) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Patch")
 		localVarPostBody   interface{}
@@ -6433,9 +6421,6 @@ func (a *ABitOfEverythingServiceApiService) ABitOfEverythingServiceUpdateV22(ctx
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-	if localVarOptionals != nil && localVarOptionals.UpdateMask.IsSet() {
-		localVarQueryParams.Add("updateMask", parameterToString(localVarOptionals.UpdateMask.Value(), ""))
-	}
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{"application/json", "application/x-foo-mime"}
 

--- a/examples/internal/clients/echo/api/swagger.yaml
+++ b/examples/internal/clients/echo/api/swagger.yaml
@@ -759,12 +759,6 @@ paths:
         schema:
           $ref: "#/definitions/examplepbDynamicMessage"
         x-exportParamName: "Body"
-      - name: "updateMask"
-        in: "query"
-        required: false
-        type: "string"
-        x-exportParamName: "UpdateMask"
-        x-optionalDataType: "String"
       responses:
         200:
           description: "A successful response."

--- a/examples/internal/clients/echo/api_echo_service.go
+++ b/examples/internal/clients/echo/api_echo_service.go
@@ -1446,17 +1446,10 @@ func (a *EchoServiceApiService) EchoServiceEchoDelete(ctx context.Context, local
 EchoServiceApiService EchoPatch method receives a NonStandardUpdateRequest and returns it.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param body
- * @param optional nil or *EchoServiceEchoPatchOpts - Optional Parameters:
-     * @param "UpdateMask" (optional.String) - 
 
 @return ExamplepbDynamicMessageUpdate
 */
-
-type EchoServiceEchoPatchOpts struct { 
-	UpdateMask optional.String
-}
-
-func (a *EchoServiceApiService) EchoServiceEchoPatch(ctx context.Context, body ExamplepbDynamicMessage, localVarOptionals *EchoServiceEchoPatchOpts) (ExamplepbDynamicMessageUpdate, *http.Response, error) {
+func (a *EchoServiceApiService) EchoServiceEchoPatch(ctx context.Context, body ExamplepbDynamicMessage) (ExamplepbDynamicMessageUpdate, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Patch")
 		localVarPostBody   interface{}
@@ -1472,9 +1465,6 @@ func (a *EchoServiceApiService) EchoServiceEchoPatch(ctx context.Context, body E
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-	if localVarOptionals != nil && localVarOptionals.UpdateMask.IsSet() {
-		localVarQueryParams.Add("updateMask", parameterToString(localVarOptionals.UpdateMask.Value(), ""))
-	}
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{"application/json"}
 

--- a/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
+++ b/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
@@ -5261,13 +5261,6 @@
             }
           },
           {
-            "name": "updateMask",
-            "description": "The list of fields to be updated.",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name": "allowMissing",
             "description": "If set to true, and the book is not found, a new book will be created.\nIn this situation, `update_mask` is ignored.",
             "in": "query",
@@ -5968,13 +5961,6 @@
               ],
               "x-a-bit-of-everything-foo": "bar"
             }
-          },
-          {
-            "name": "updateMask",
-            "description": "The paths to update.",
-            "in": "query",
-            "required": false,
-            "type": "string"
           }
         ],
         "tags": [

--- a/examples/internal/proto/examplepb/echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/echo_service.swagger.json
@@ -887,12 +887,6 @@
             "schema": {
               "$ref": "#/definitions/examplepbDynamicMessage"
             }
-          },
-          {
-            "name": "updateMask",
-            "in": "query",
-            "required": false,
-            "type": "string"
           }
         ],
         "tags": [

--- a/examples/internal/proto/examplepb/non_standard_names.swagger.json
+++ b/examples/internal/proto/examplepb/non_standard_names.swagger.json
@@ -42,12 +42,6 @@
             "schema": {
               "$ref": "#/definitions/examplepbNonStandardMessage"
             }
-          },
-          {
-            "name": "updateMask",
-            "in": "query",
-            "required": false,
-            "type": "string"
           }
         ],
         "tags": [
@@ -81,12 +75,6 @@
             "schema": {
               "$ref": "#/definitions/examplepbNonStandardMessageWithJSONNames"
             }
-          },
-          {
-            "name": "updateMask",
-            "in": "query",
-            "required": false,
-            "type": "string"
           }
         ],
         "tags": [

--- a/internal/descriptor/registry.go
+++ b/internal/descriptor/registry.go
@@ -140,6 +140,9 @@ type Registry struct {
 	// useAllOfForRefs, if set, will use allOf as container for $ref to preserve same-level
 	// properties
 	useAllOfForRefs bool
+
+	// allowPatchFeature determines whether to use PATCH feature involving update masks (using google.protobuf.FieldMask).
+	allowPatchFeature bool
 }
 
 type repeatedFieldSeparator struct {
@@ -784,4 +787,14 @@ func (r *Registry) SetUseAllOfForRefs(use bool) {
 // GetUseAllOfForRefs returns useAllOfForRefs
 func (r *Registry) GetUseAllOfForRefs() bool {
 	return r.useAllOfForRefs
+}
+
+// SetAllowPatchFeature sets allowPatchFeature
+func (r *Registry) SetAllowPatchFeature(allow bool) {
+	r.allowPatchFeature = allow
+}
+
+// GetAllowPatchFeature returns allowPatchFeature
+func (r *Registry) GetAllowPatchFeature() bool {
+	return r.allowPatchFeature
 }

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -145,9 +145,12 @@ func getEnumDefault(reg *descriptor.Registry, enum *descriptor.Enum) string {
 }
 
 // messageToQueryParameters converts a message to a list of OpenAPI query parameters.
-func messageToQueryParameters(message *descriptor.Message, reg *descriptor.Registry, pathParams []descriptor.Parameter, body *descriptor.Body) (params []openapiParameterObject, err error) {
+func messageToQueryParameters(message *descriptor.Message, reg *descriptor.Registry, pathParams []descriptor.Parameter, body *descriptor.Body, httpMethod string) (params []openapiParameterObject, err error) {
 	for _, field := range message.Fields {
 		if !isVisible(getFieldVisibilityOption(field), reg) {
+			continue
+		}
+		if reg.GetAllowPatchFeature() && field.GetTypeName() == ".google.protobuf.FieldMask" && field.GetName() == "update_mask" && httpMethod == "PATCH" && len(body.FieldPath) != 0 {
 			continue
 		}
 
@@ -1271,7 +1274,7 @@ func renderServices(services []*descriptor.Service, paths openapiPathsObject, re
 				}
 
 				// add the parameters to the query string
-				queryParams, err := messageToQueryParameters(meth.RequestType, reg, b.PathParams, b.Body)
+				queryParams, err := messageToQueryParameters(meth.RequestType, reg, b.PathParams, b.Body, b.HTTPMethod)
 				if err != nil {
 					return err
 				}

--- a/protoc-gen-openapiv2/main.go
+++ b/protoc-gen-openapiv2/main.go
@@ -43,6 +43,7 @@ var (
 	disableServiceTags             = flag.Bool("disable_service_tags", false, "if set, disables generation of service tags. This is useful if you do not want to expose the names of your backend grpc services.")
 	disableDefaultResponses        = flag.Bool("disable_default_responses", false, "if set, disables generation of default responses. Useful if you have to support custom response codes that are not 200.")
 	useAllOfForRefs                = flag.Bool("use_allof_for_refs", false, "if set, will use allOf as container for $ref to preserve same-level properties.")
+	allowPatchFeature              = flag.Bool("allow_patch_feature", true, "whether to hide update_mask fields in PATCH requests from the generated swagger file.")
 )
 
 // Variables set by goreleaser at build time
@@ -129,6 +130,7 @@ func main() {
 	reg.SetDisableServiceTags(*disableServiceTags)
 	reg.SetDisableDefaultResponses(*disableDefaultResponses)
 	reg.SetUseAllOfForRefs(*useAllOfForRefs)
+	reg.SetAllowPatchFeature(*allowPatchFeature)
 	if err := reg.SetRepeatedPathParamSeparator(*repeatedPathParamSeparator); err != nil {
 		emitError(err)
 		return

--- a/runtime/internal/examplepb/non_standard_names.swagger.json
+++ b/runtime/internal/examplepb/non_standard_names.swagger.json
@@ -42,12 +42,6 @@
             "schema": {
               "$ref": "#/definitions/examplepbNonStandardMessage"
             }
-          },
-          {
-            "name": "updateMask",
-            "in": "query",
-            "required": false,
-            "type": "string"
           }
         ],
         "tags": [
@@ -81,12 +75,6 @@
             "schema": {
               "$ref": "#/definitions/examplepbNonStandardMessageWithJSONNames"
             }
-          },
-          {
-            "name": "updateMask",
-            "in": "query",
-            "required": false,
-            "type": "string"
           }
         ],
         "tags": [


### PR DESCRIPTION
**References to other Issues or PRs**
Fixes https://github.com/grpc-ecosystem/grpc-gateway/issues/2988

**Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?**
Yes

**Brief description of what is fixed or changed**
When the request method is patch, and the http body is not "*", do not need to generate updateMask field to swagger document