### PR TITLE
Support field extensions with use_allof_for_refs

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -520,11 +520,12 @@ func renderMessageAsDefinition(msg *descriptor.Message, reg *descriptor.Registry
 				// Per the JSON Reference syntax: Any members other than "$ref" in a JSON Reference object SHALL be ignored.
 				// https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03#section-3
 				// However, use allOf to specify Title/Description/readOnly fields.
-				if fieldSchema.Title != "" || fieldSchema.Description != "" || fieldSchema.ReadOnly {
+				if fieldSchema.Title != "" || fieldSchema.Description != "" || fieldSchema.ReadOnly || len(fieldSchema.extensions) > 0 {
 					fieldSchema = openapiSchemaObject{
 						Title:       fieldSchema.Title,
 						Description: fieldSchema.Description,
 						ReadOnly:    fieldSchema.ReadOnly,
+						extensions:  fieldSchema.extensions,
 						AllOf:       []allOfEntry{{Ref: fieldSchema.Ref}},
 					}
 				} else {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

Allow extensions to be used with the recently added AllOf feature

#### Other comments
