### PR TITLE
Fix bug with non-ASCII HTTP headers

### DIFF
--- a/examples/internal/integration/integration_test.go
+++ b/examples/internal/integration/integration_test.go
@@ -53,7 +53,8 @@ func TestEcho(t *testing.T) {
 			testEchoBody(t, 8089, apiPrefix, true)
 			testEchoBody(t, 8089, apiPrefix, false)
 			testEchoBodyParamOverwrite(t, 8088)
-			testEchoWithNonASCIIHeaders(t, 8088, apiPrefix)
+			testEchoWithNonASCIIHeaderValues(t, 8088, apiPrefix)
+			testEchoWithInvalidHeaderKey(t, 8088, apiPrefix)
 		})
 	}
 }
@@ -2506,7 +2507,7 @@ func testABETrace(t *testing.T, port int) {
 	}
 }
 
-func testEchoWithNonASCIIHeaders(t *testing.T, port int, apiPrefix string) {
+func testEchoWithNonASCIIHeaderValues(t *testing.T, port int, apiPrefix string) {
 	apiURL := fmt.Sprintf("http://localhost:%d/%s/example/echo/myid", port, apiPrefix)
 
 	req, err := http.NewRequest("POST", apiURL, strings.NewReader("{}"))
@@ -2516,6 +2517,44 @@ func testEchoWithNonASCIIHeaders(t *testing.T, port int, apiPrefix string) {
 	}
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Grpc-Metadata-Location", "Gjøvik")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Errorf("http.Post(%q) failed with %v; want success", apiURL, err)
+		return
+	}
+	defer resp.Body.Close()
+
+	buf, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
+		return
+	}
+
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Errorf("resp.StatusCode = %d; want %d", got, want)
+		t.Logf("%s", buf)
+	}
+
+	msg := new(examplepb.UnannotatedSimpleMessage)
+	if err := marshaler.Unmarshal(buf, msg); err != nil {
+		t.Errorf("marshaler.Unmarshal(%s, msg) failed with %v; want success", buf, err)
+		return
+	}
+	if got, want := msg.Id, "myid"; got != want {
+		t.Errorf("msg.Id = %q; want %q", got, want)
+	}
+}
+
+func testEchoWithInvalidHeaderKey(t *testing.T, port int, apiPrefix string) {
+	apiURL := fmt.Sprintf("http://localhost:%d/%s/example/echo/myid", port, apiPrefix)
+
+	req, err := http.NewRequest("POST", apiURL, strings.NewReader("{}"))
+	if err != nil {
+		t.Errorf("http.NewRequest() = err: %v", err)
+		return
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Grpc-Metadata-Foo+Bar", "Hello")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Errorf("http.Post(%q) failed with %v; want success", apiURL, err)

--- a/examples/internal/integration/integration_test.go
+++ b/examples/internal/integration/integration_test.go
@@ -53,6 +53,7 @@ func TestEcho(t *testing.T) {
 			testEchoBody(t, 8089, apiPrefix, true)
 			testEchoBody(t, 8089, apiPrefix, false)
 			testEchoBodyParamOverwrite(t, 8088)
+			testEchoWithNonASCIIHeaders(t, 8088, apiPrefix)
 		})
 	}
 }
@@ -2502,5 +2503,43 @@ func testABETrace(t *testing.T, port int) {
 	if err := marshaler.Unmarshal(buf, want); err != nil {
 		t.Errorf("marshaler.Unmarshal(%s, want) failed with %v; want success", buf, err)
 		return
+	}
+}
+
+func testEchoWithNonASCIIHeaders(t *testing.T, port int, apiPrefix string) {
+	apiURL := fmt.Sprintf("http://localhost:%d/%s/example/echo/myid", port, apiPrefix)
+
+	req, err := http.NewRequest("POST", apiURL, strings.NewReader("{}"))
+	if err != nil {
+		t.Errorf("http.NewRequest() = err: %v", err)
+		return
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Grpc-Metadata-Location", "Gjøvik")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Errorf("http.Post(%q) failed with %v; want success", apiURL, err)
+		return
+	}
+	defer resp.Body.Close()
+
+	buf, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("io.ReadAll(resp.Body) failed with %v; want success", err)
+		return
+	}
+
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Errorf("resp.StatusCode = %d; want %d", got, want)
+		t.Logf("%s", buf)
+	}
+
+	msg := new(examplepb.UnannotatedSimpleMessage)
+	if err := marshaler.Unmarshal(buf, msg); err != nil {
+		t.Errorf("marshaler.Unmarshal(%s, msg) failed with %v; want success", buf, err)
+		return
+	}
+	if got, want := msg.Id, "myid"; got != want {
+		t.Errorf("msg.Id = %q; want %q", got, want)
 	}
 }

--- a/runtime/BUILD.bazel
+++ b/runtime/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
     deps = [
         "//internal/httprule",
         "//utilities",
+        "@com_github_golang_glog//:glog",
         "@go_googleapis//google/api:httpbody_go_proto",
         "@io_bazel_rules_go//proto/wkt:field_mask_go_proto",
         "@org_golang_google_grpc//codes",

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -142,7 +142,7 @@ func annotateContext(ctx context.Context, mux *ServeMux, req *http.Request, rpcM
 			}
 			if h, ok := mux.incomingHeaderMatcher(key); ok {
 				if !isValidGRPCMetadataKey(h) {
-					glog.Errorf("HTTP header %q is not valid as gRPC metadata; skipping", h)
+					glog.Errorf("HTTP header name %q is not valid as gRPC metadata key; skipping", h)
 					continue
 				}
 
@@ -156,7 +156,7 @@ func annotateContext(ctx context.Context, mux *ServeMux, req *http.Request, rpcM
 
 					val = string(b)
 				} else if !isValidGRPCMetadataTextValue(val) {
-					glog.Errorf("HTTP header %q contains non-ASCII value (not valid as gRPC metadata): skipping", h)
+					glog.Errorf("Value of HTTP header %q contains non-ASCII value (not valid as gRPC metadata): skipping", h)
 					continue
 				}
 

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -104,12 +104,15 @@ func isValidGRPCMetadataKey(key string) bool {
 	// Must be a valid gRPC "Header-Name" as defined here:
 	//   https://github.com/grpc/grpc/blob/4b05dc88b724214d0c725c8e7442cbc7a61b1374/doc/PROTOCOL-HTTP2.md
 	// This means 0-9 a-z _ - .
+	// Only lowercase letters are valid in the wire protocol, but the client library will normalize
+	// uppercase ASCII to lowercase, so uppercase ASCII is also acceptable.
 	bytes := []byte(key) // gRPC validates strings on the byte level, not Unicode.
 	for _, ch := range bytes {
-		validLowercaseLetter := ch >= 'a' && ch <= '<'
+		validLowercaseLetter := ch >= 'a' && ch <= 'z'
+		validUppercaseLetter := ch >= 'A' && ch <= 'Z'
 		validDigit := ch >= '0' && ch <= '9'
 		validOther := ch == '.' || ch == '-' || ch == '_'
-		if !validLowercaseLetter && !validDigit && !validOther {
+		if !validLowercaseLetter && !validUppercaseLetter && !validDigit && !validOther {
 			return false
 		}
 	}

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -113,10 +113,10 @@ func isValidGRPCMetadataKey(key string) bool {
 func isValidGRPCMetadataTextValue(textValue string) bool {
 	for i := 0; i < len(textValue); i++ {
 		if textValue[i] < 0x20 || textValue[i] > 0x7E {
-			return true
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 func annotateContext(ctx context.Context, mux *ServeMux, req *http.Request, rpcMethodName string, options ...AnnotateContextOption) (context.Context, metadata.MD, error) {


### PR DESCRIPTION
gRPC metadata (for the non-binary keys) must be printable ASCII, i.e. each byte must be between 0x20 and 0x7E inclusive.

#### References to other Issues or PRs

Have not created an issue, but this fixes a problem we've had in our deployment of argoproj/argo-workflows (which uses grpc-gateway) where any API request with a header value containing a non-ASCII character gets rejected.

HTTP headers can by convention be general ISO-8859-1, not just US ASCII. E.g. 'æ', 'ø', 'å' should be fine in HTTP headers, but they're not acceptable in gRPC metadata.

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

When copying HTTP headers over to gRPC metadata, skip headers where the key or the value would not be accepted by gRPC. (These requests would be rejected anyway if the metadata were included.)

#### Other comments
