### PR TITLE
Switch the use of glog to grpclog.

### DIFF
--- a/runtime/BUILD.bazel
+++ b/runtime/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
     deps = [
         "//internal/httprule",
         "//utilities",
-        "@com_github_golang_glog//:glog",
         "@go_googleapis//google/api:httpbody_go_proto",
         "@io_bazel_rules_go//proto/wkt:field_mask_go_proto",
         "@org_golang_google_grpc//codes",

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/glog"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
@@ -155,7 +155,7 @@ func annotateContext(ctx context.Context, mux *ServeMux, req *http.Request, rpcM
 			}
 			if h, ok := mux.incomingHeaderMatcher(key); ok {
 				if !isValidGRPCMetadataKey(h) {
-					glog.Errorf("HTTP header name %q is not valid as gRPC metadata key; skipping", h)
+					grpclog.Errorf("HTTP header name %q is not valid as gRPC metadata key; skipping", h)
 					continue
 				}
 				// Handles "-bin" metadata in grpc, since grpc will do another base64
@@ -168,7 +168,7 @@ func annotateContext(ctx context.Context, mux *ServeMux, req *http.Request, rpcM
 
 					val = string(b)
 				} else if !isValidGRPCMetadataTextValue(val) {
-					glog.Errorf("Value of HTTP header %q contains non-ASCII value (not valid as gRPC metadata): skipping", h)
+					grpclog.Errorf("Value of HTTP header %q contains non-ASCII value (not valid as gRPC metadata): skipping", h)
 					continue
 				}
 				pairs = append(pairs, h, val)


### PR DESCRIPTION
It appears other files in runtime package are using grpclog, there's no reason to use glog in context.go.

Fixes #3204

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

#### Other comments
