### PR TITLE
use_allof_for_refs: extend to example field

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -522,13 +522,16 @@ func renderMessageAsDefinition(msg *descriptor.Message, reg *descriptor.Registry
 			if fieldSchema.Ref != "" {
 				// Per the JSON Reference syntax: Any members other than "$ref" in a JSON Reference object SHALL be ignored.
 				// https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03#section-3
-				// However, use allOf to specify Title/Description/readOnly fields.
-				if fieldSchema.Title != "" || fieldSchema.Description != "" || fieldSchema.ReadOnly {
+				// However, use allOf to specify Title/Description/Example/readOnly fields.
+				if fieldSchema.Title != "" || fieldSchema.Description != "" || len(fieldSchema.Example) > 0 || fieldSchema.ReadOnly {
 					fieldSchema = openapiSchemaObject{
 						Title:       fieldSchema.Title,
 						Description: fieldSchema.Description,
-						ReadOnly:    fieldSchema.ReadOnly,
-						AllOf:       []allOfEntry{{Ref: fieldSchema.Ref}},
+						schemaCore: schemaCore{
+							Example: fieldSchema.Example,
+						},
+						ReadOnly: fieldSchema.ReadOnly,
+						AllOf:    []allOfEntry{{Ref: fieldSchema.Ref}},
 					}
 				} else {
 					fieldSchema = openapiSchemaObject{schemaCore: schemaCore{Ref: fieldSchema.Ref}}

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -5372,6 +5372,18 @@ func TestRenderMessagesAsDefinition(t *testing.T) {
 					},
 				},
 			},
+			openAPIOptions: &openapiconfig.OpenAPIOptions{
+				Field: []*openapiconfig.OpenAPIFieldOption{
+					{
+						Field: "example.Message.nested",
+						Option: &openapi_options.JSONSchema{
+							Title:       "nested field title",
+							Description: "nested field desc",
+							Example:     `"ok":"TRUE"`,
+						},
+					},
+				},
+			},
 			defs: map[string]openapiSchemaObject{
 				"exampleMessage": {
 					schemaCore: schemaCore{
@@ -5386,6 +5398,11 @@ func TestRenderMessagesAsDefinition(t *testing.T) {
 							Value: openapiSchemaObject{
 								AllOf:    []allOfEntry{{Ref: "#/definitions/MessageNested"}},
 								ReadOnly: true,
+								schemaCore: schemaCore{
+									Example: RawExample(`"ok":"TRUE"`),
+								},
+								Title:       "nested field title",
+								Description: "nested field desc",
 							},
 						},
 					},


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

Related to https://github.com/grpc-ecosystem/grpc-gateway/issues/3232, https://github.com/grpc-ecosystem/grpc-gateway/issues/2671

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

Extending https://github.com/grpc-ecosystem/grpc-gateway/pull/3082, we can enable setting enum field example in `openapiv2_field` annotation, e.g.

```
  // Severity of this alert
  AlertSeverity severity = 5 [
    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
      example: "\"CRITICAL\""
    }
  ];
```
produces
```
        "severity": {
          "example": "CRITICAL",
          "title": "Severity of this alert",
          "allOf": [
            {
              "$ref": "#/definitions/AlertSeverity"
            }
          ]
        },
```
instead of `example` field being ignored, which is currently the case.

