### PR TITLE
add macros example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ gRPC-Gateway, and a gRPC server, see
 [this example by CoreOS](https://github.com/philips/grpc-gateway-example/blob/master/cmd/serve.go)
 (and its accompanying [blog post](https://web.archive.org/web/20201112010739/https://coreos.com/blog/grpc-protobufs-swagger.html)).
 
-[This example by neiro.ai](https://github.com/mynalabsai/grpc_gateway_media_example) (and its accompanying [blog post](https://medium.com/neiro-ai/grpc-gateway-for-media-api-by-neiro-9033caab12c8)) shows how mediafiles can be integrated in rpc message by middleware for `multipart/form-data` and macros.
+[This example by neiro.ai](https://github.com/mynalabsai/grpc_gateway_media_example) (and its accompanying [blog post](https://medium.com/neiro-ai/grpc-gateway-for-media-api-by-neiro-9033caab12c8)) shows how mediafiles using `multipart/form-data` can be integrated into rpc messages using a middleware.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -556,6 +556,8 @@ gRPC-Gateway, and a gRPC server, see
 [this example by CoreOS](https://github.com/philips/grpc-gateway-example/blob/master/cmd/serve.go)
 (and its accompanying [blog post](https://web.archive.org/web/20201112010739/https://coreos.com/blog/grpc-protobufs-swagger.html)).
 
+[This example by neiro.ai](https://github.com/mynalabsai/grpc_gateway_media_example) (and its accompanying [blog post](https://medium.com/neiro-ai/grpc-gateway-for-media-api-by-neiro-9033caab12c8)) shows how mediafiles can be integrated in rpc message by middleware for `multipart/form-data` and macros.
+
 ## Features
 
 ### Supported


### PR DESCRIPTION
This pull request adds an example of the gRPC-gateway service in the documentation (there can't be too much!).  The provided service shows one possible approach to fit media files in the request. It can be useful either for those who want to write their own middleware and want ideas or for those who look for a way to send media files with other data in one request.

#### References to other Issues or PRs

Fixes #3198

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

Added an example of repository with:

* Macros for multipart/form-data requests
* Shared wrapper for common logic such as latency measurements

#### Other comments
