### PR TITLE
Only allow POST -> GET path length fallback

### DIFF
--- a/runtime/mux_test.go
+++ b/runtime/mux_test.go
@@ -217,6 +217,47 @@ func TestMuxServeHTTP(t *testing.T) {
 			reqMethod: "POST",
 			reqPath:   "/foo",
 			headers: map[string]string{
+				"Content-Type": "application/x-www-form-urlencoded",
+			},
+			respStatus:  http.StatusOK,
+			respContent: "GET /foo",
+		},
+		{
+			patterns: []stubPattern{
+				{
+					method: "DELETE",
+					ops:    []int{int(utilities.OpLitPush), 0},
+					pool:   []string{"foo"},
+				},
+				{
+					method: "PUT",
+					ops:    []int{int(utilities.OpLitPush), 0},
+					pool:   []string{"foo"},
+				},
+				{
+					method: "PATCH",
+					ops:    []int{int(utilities.OpLitPush), 0},
+					pool:   []string{"foo"},
+				},
+			},
+			reqMethod: "POST",
+			reqPath:   "/foo",
+			headers: map[string]string{
+				"Content-Type": "application/x-www-form-urlencoded",
+			},
+			respStatus: http.StatusNotImplemented,
+		},
+		{
+			patterns: []stubPattern{
+				{
+					method: "GET",
+					ops:    []int{int(utilities.OpLitPush), 0},
+					pool:   []string{"foo"},
+				},
+			},
+			reqMethod: "POST",
+			reqPath:   "/foo",
+			headers: map[string]string{
 				"Content-Type": "application/json",
 			},
 			respStatus: http.StatusNotImplemented,


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes https://github.com/grpc-ecosystem/grpc-gateway/issues/3266

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

This PR changes the mux logic that implements the HTTP length fallback to prevent it from falling back to potentially dangerous methods. With these changes, the fallback mechanism is only allowed for `POST -> GET` instead of allowing it for any defined method.

#### Other comments

The discussion about this mechanism can be found at https://github.com/grpc-ecosystem/grpc-gateway/issues/447, and it is specifically designed to target `POST -> GET` fallbacks. However, the current code could fallback to other methods like DELETE, which could be potentially dangerous.
