### PR TITLE
feat: message supports enum field option for query params

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -328,6 +328,7 @@ func nestedQueryParams(message *descriptor.Message, field *descriptor.Field, pre
 			Pattern:     schema.Pattern,
 			Required:    required,
 			extensions:  schema.extensions,
+			Enum:        schema.Enum,
 		}
 		if param.Type == "array" {
 			param.CollectionFormat = "multi"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

Fixes #3341 

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

YES

#### Brief description of what is fixed or changed

message supports enum field option for query params

#### Other comments

test output: 

<img width="711" alt="image" src="https://github.com/grpc-ecosystem/grpc-gateway/assets/5210208/73566da9-7c5f-4594-aa16-47ba1a1d0e4a">

<img width="404" alt="image" src="https://github.com/grpc-ecosystem/grpc-gateway/assets/5210208/1e778055-e0be-4f18-8c3a-5dba589a6b25">
