### PR TITLE
Handle httpbody not having data to return

### DIFF
--- a/runtime/marshal_httpbodyproto.go
+++ b/runtime/marshal_httpbodyproto.go
@@ -26,7 +26,7 @@ func (h *HTTPBodyMarshaler) ContentType(v interface{}) string {
 // google.api.HttpBody message, otherwise it falls back to the default Marshaler.
 func (h *HTTPBodyMarshaler) Marshal(v interface{}) ([]byte, error) {
 	if httpBody, ok := v.(*httpbody.HttpBody); ok {
-		return httpBody.Data, nil
+		return httpBody.GetData(), nil
 	}
 	return h.Marshaler.Marshal(v)
 }


### PR DESCRIPTION
#### Brief description of what is fixed or changed

I was testing out a case in my code where I was trying to make it fail. An abstract caller of this method was passed a `nil` that was typed properly and discovered that instead of handling the zero value properly, it panics. This should resolve that.