### PR TITLE
chore: stop using the deprecated field `archives.replacements`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,8 +24,6 @@ builds:
       - amd64
       - arm64
 archives:
-  - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
+  - name_template: '{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{if eq .Arch "amd64"}}x86_64{{else}}{{ .Arch }}{{end}}'
     format: binary
-    replacements:
-      amd64: x86_64
 dist: _output


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #3435

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

I could reproduce the issue on may laptop.

```console
$ goreleaser --version
  ____       ____      _
 / ___| ___ |  _ \ ___| | ___  __ _ ___  ___ _ __
| |  _ / _ \| |_) / _ \ |/ _ \/ _` / __|/ _ \ '__|
| |_| | (_) |  _ <  __/ |  __/ (_| \__ \  __/ |
 \____|\___/|_| \_\___|_|\___|\__,_|___/\___|_|
goreleaser: Deliver Go Binaries as fast and easily as possible
https://goreleaser.com

GitVersion:    1.19.2
GitCommit:     b95fd394866efeb147769b49a469f88186606177
GitTreeState:  false
BuildDate:     2023-07-07T13:32:08Z
BuiltBy:       goreleaser
GoVersion:     go1.20.5
Compiler:      gc
ModuleSum:     h1:m24wCy0UzBTGO3zqezAxcoA87RBySRRL0dyJjiNfdjQ=
Platform:      darwin/arm64
```

```console
$ goreleaser release --rm-dist --snapshot
Flag --rm-dist has been deprecated, please use --clean instead
  • starting release...
  • loading config file                              file=.goreleaser.yml
  ⨯ release failed after 0s                  error=yaml: unmarshal errors:
  line 29: field replacements not found in type config.Archive
```

And I confirmed this pull request would resolve the issue.

```console
$ goreleaser release --rm-dist --snapshot
Flag --rm-dist has been deprecated, please use --clean instead
  • starting release...
  • loading config file                              file=.goreleaser.yml
    • DEPRECATED: --rm-dist was deprecated in favor of --clean, check https://goreleaser.com/deprecations#-rm-dist for more details
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=79d4a7b3ef9729bc90b818bf19d87101fb91b9da latest tag=v2.16.1
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
    • took: 1s
  • snapshotting
    • building snapshot...                           version=2.16.1-SNAPSHOT-79d4a7b3
  • checking distribution directory
  • loading go mod information
    • took: 1s
  • build prerequisites
  • writing effective config file
    • writing                                        config=_output/config.yaml
  • building binaries
    • building                                       binary=_output/protoc-gen-openapiv2_darwin_arm64/protoc-gen-openapiv2
    • building                                       binary=_output/protoc-gen-grpc-gateway_linux_amd64_v1/protoc-gen-grpc-gateway
    • building                                       binary=_output/protoc-gen-grpc-gateway_windows_amd64_v1/protoc-gen-grpc-gateway.exe
    • building                                       binary=_output/protoc-gen-openapiv2_linux_amd64_v1/protoc-gen-openapiv2
    • building                                       binary=_output/protoc-gen-grpc-gateway_windows_arm64/protoc-gen-grpc-gateway.exe
    • building                                       binary=_output/protoc-gen-openapiv2_linux_arm64/protoc-gen-openapiv2
    • building                                       binary=_output/protoc-gen-grpc-gateway_linux_arm64/protoc-gen-grpc-gateway
    • building                                       binary=_output/protoc-gen-grpc-gateway_darwin_arm64/protoc-gen-grpc-gateway
    • building                                       binary=_output/protoc-gen-grpc-gateway_darwin_amd64_v1/protoc-gen-grpc-gateway
    • building                                       binary=_output/protoc-gen-openapiv2_darwin_amd64_v1/protoc-gen-openapiv2
    • building                                       binary=_output/protoc-gen-openapiv2_windows_amd64_v1/protoc-gen-openapiv2.exe
    • building                                       binary=_output/protoc-gen-openapiv2_windows_arm64/protoc-gen-openapiv2.exe
    • took: 25s
  • archives
    • skip archiving                                 binary=protoc-gen-grpc-gateway.exe name=protoc-gen-grpc-gateway-v2.16.1-windows-arm64.exe
    • skip archiving                                 binary=protoc-gen-grpc-gateway name=protoc-gen-grpc-gateway-v2.16.1-linux-arm64
    • skip archiving                                 binary=protoc-gen-openapiv2 name=protoc-gen-openapiv2-v2.16.1-linux-arm64
    • skip archiving                                 binary=protoc-gen-grpc-gateway name=protoc-gen-grpc-gateway-v2.16.1-darwin-arm64
    • skip archiving                                 binary=protoc-gen-openapiv2 name=protoc-gen-openapiv2-v2.16.1-darwin-arm64
    • skip archiving                                 binary=protoc-gen-openapiv2.exe name=protoc-gen-openapiv2-v2.16.1-windows-arm64.exe
    • skip archiving                                 binary=protoc-gen-grpc-gateway.exe name=protoc-gen-grpc-gateway-v2.16.1-windows-x86_64.exe
    • skip archiving                                 binary=protoc-gen-openapiv2.exe name=protoc-gen-openapiv2-v2.16.1-windows-x86_64.exe
    • skip archiving                                 binary=protoc-gen-grpc-gateway name=protoc-gen-grpc-gateway-v2.16.1-darwin-x86_64
    • skip archiving                                 binary=protoc-gen-openapiv2 name=protoc-gen-openapiv2-v2.16.1-darwin-x86_64
    • skip archiving                                 binary=protoc-gen-grpc-gateway name=protoc-gen-grpc-gateway-v2.16.1-linux-x86_64
    • skip archiving                                 binary=protoc-gen-openapiv2 name=protoc-gen-openapiv2-v2.16.1-linux-x86_64
  • calculating checksums
  • storing release metadata
    • writing                                        file=_output/artifacts.json
    • writing                                        file=_output/metadata.json
  • you are using deprecated options, check the output above for details
  • release succeeded after 26s
  • thanks for using goreleaser!
```

#### Other comments
