### PR TITLE
Fix renovate.yml overwriting .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,2 @@
-startup --output_base /home/vscode/.cache/_grpc_gateway_bazel
-build --test_output errors
-build --features race
-# Protobuf v3.22.0+ requires C++14
-build --repo_env=BAZEL_CXXOPTS=-std=c++14
-# Workaround https://github.com/bazelbuild/bazel/issues/3645
-# See https://docs.bazel.build/versions/0.23.0/command-line-reference.html
-build --local_ram_resources=7168 # Github runners have 7G of memory
-build --local_cpu_resources=2    # Github runners have 2 vCPU
+build --cxxopt=-std=c++14 --host_cxxopt=-std=c++14
+build --test_output=errors

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,13 +25,11 @@ jobs:
           key: v1-bazel-cache-${{ hashFiles('repositories.bzl') }}
           restore-keys: v1-bazel-cache-
       - name: Configure bazel
-        run: |
-          cat > .bazelrc << EOF
+        run:
+          | # put .bazelrc in $HOME so that it's read before project's .bazelrc
+          cat > /home/vscode/.bazelrc << EOF
           startup --output_base /home/vscode/.cache/_grpc_gateway_bazel
-          build --test_output errors
-          build --features race
-          # Protobuf v3.22.0+ requires C++14
-          build --repo_env=BAZEL_CXXOPTS=-std=c++14
+          build --@io_bazel_rules_go//go/config:race
           # Workaround https://github.com/bazelbuild/bazel/issues/3645
           # See https://docs.bazel.build/versions/0.23.0/command-line-reference.html
           build --local_ram_resources=7168 # Github runners have 7G of memory

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ docker run -itv $(pwd):/grpc-gateway -w /grpc-gateway --entrypoint /bin/bash --r
     ghcr.io/grpc-ecosystem/grpc-gateway/build-env:1.19 -c '\
         bazel run :gazelle -- update-repos -from_file=go.mod -to_macro=repositories.bzl%go_repositories && \
         bazel run :gazelle && \
-        BAZEL_CXXOPTS="-std=c++14" bazel run :buildifier'
+        bazel run :buildifier'
 ```
 
 You may need to authenticate with GitHub to pull `docker.pkg.github.com/grpc-ecosystem/grpc-gateway/build-env`.


### PR DESCRIPTION
#### Brief description of what is fixed or changed

In https://github.com/grpc-ecosystem/grpc-gateway/pull/3413, I introduced a few changes to Bazel files. One of them was introducing `.bazelrc` which used to be ignored. I did not notice that `renovate.yml` may overwrite and commit it, leading to a situation where `.bazelrc` contains GitHub Actions specific options.

This change fixes `renovate.yml` and reverts `.bazelrc`.
