### PR TITLE
fix path with : in the middle #3517 issue

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -962,8 +962,7 @@ func templateToParts(path string, reg *descriptor.Registry, fields []*descriptor
 	depth := 0
 	buffer := ""
 	jsonBuffer := ""
-pathLoop:
-	for i, char := range path {
+	for _, char := range path {
 		switch char {
 		case '{':
 			// Push on the stack
@@ -987,16 +986,16 @@ pathLoop:
 				jsonBuffer = ""
 			}
 		case '/':
+			if depth == 0 {
+				parts = append(parts, buffer)
+				buffer = ""
+				// Since the stack was empty when we hit the '/' we are done with this
+				// section.
+				continue
+			}
 			buffer += string(char)
 			jsonBuffer += string(char)
 		case ':':
-			if depth == 0 {
-				// As soon as we find a ":" outside a variable,
-				// everything following is a verb
-				parts = append(parts, buffer)
-				buffer = path[i:]
-				break pathLoop
-			}
 			buffer += string(char)
 			jsonBuffer += string(char)
 		default:

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -987,13 +987,6 @@ pathLoop:
 				jsonBuffer = ""
 			}
 		case '/':
-			if depth == 0 {
-				parts = append(parts, buffer)
-				buffer = ""
-				// Since the stack was empty when we hit the '/' we are done with this
-				// section.
-				continue
-			}
 			buffer += string(char)
 			jsonBuffer += string(char)
 		case ':':

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -3918,6 +3918,7 @@ func TestTemplateToOpenAPIPath(t *testing.T) {
 		{"/{user.name=prefix/*}:customMethod", "/{user.name}:customMethod"},
 		{"/{user.name=prefix1/*/prefix2/*}:customMethod", "/{user.name}:customMethod"},
 		{"/{parent=prefix/*}/children:customMethod", "/{parent}/children:customMethod"},
+		{"/item/search:items/{item_no_query}", "/item/search:items/{item_no_query}"},
 	}
 	reg := descriptor.NewRegistry()
 	reg.SetUseJSONNamesForFields(false)

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -3858,6 +3858,7 @@ func TestTemplateWithJsonCamelCase(t *testing.T) {
 		{"test/{ab_c}", "test/{abC}"},
 		{"test/{json_name}", "test/{jsonNAME}"},
 		{"test/{field_abc.field_newName}", "test/{fieldAbc.RESERVEDJSONNAME}"},
+		{"/item/search:items/{item_no_query}", "/item/search:items/{itemNoQuery}"},
 	}
 	reg := descriptor.NewRegistry()
 	reg.SetUseJSONNamesForFields(true)
@@ -3918,7 +3919,6 @@ func TestTemplateToOpenAPIPath(t *testing.T) {
 		{"/{user.name=prefix/*}:customMethod", "/{user.name}:customMethod"},
 		{"/{user.name=prefix1/*/prefix2/*}:customMethod", "/{user.name}:customMethod"},
 		{"/{parent=prefix/*}/children:customMethod", "/{parent}/children:customMethod"},
-		{"/item/search:items/{item_no_query}", "/item/search:items/{item_no_query}"},
 	}
 	reg := descriptor.NewRegistry()
 	reg.SetUseJSONNamesForFields(false)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #3517

#### Brief description of what is fixed or changed

The assumption that a colon can only appear on the end of a path seems to wrong. Removing the special case code that exploits this assumption seems to fix the issue. However I'm not sure about the full impact on other parts of the code.

#### Other comments
