### PR TITLE
Record the filename of files that are missing SourceCodeInfo

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -2330,7 +2330,7 @@ func enumValueProtoComments(reg *descriptor.Registry, enum *descriptor.Enum) str
 
 func protoComments(reg *descriptor.Registry, file *descriptor.File, outers []string, typeName string, typeIndex int32, fieldPaths ...int32) string {
 	if file.SourceCodeInfo == nil {
-		fmt.Fprintln(os.Stderr, "descriptor.File should not contain nil SourceCodeInfo")
+		fmt.Fprintln(os.Stderr, file.GetName(), "descriptor.File should not contain nil SourceCodeInfo")
 		return ""
 	}
 


### PR DESCRIPTION
This came out of #3542 - I think it would be useful when this error shows to let the user know which file had a problem.
