### PR TITLE
Enable a few more golangci-lint linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3
         with:
-          version: v1.52.2
-          args: --enable goimports
+          version: v1.54.2
   fuzz:
     runs-on: ubuntu-latest
     steps:

--- a/protoc-gen-openapiv2/internal/genopenapi/generator_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/generator_test.go
@@ -1685,7 +1685,7 @@ func TestFindExpectedPaths(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 
-		t.Run(string(tc.testName), func(t *testing.T) {
+		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
 			foundPaths := []string{}

--- a/protoc-gen-openapiv2/internal/genopenapi/helpers.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/helpers.go
@@ -22,6 +22,7 @@ func getUniqueFields(schemaFieldsRequired []string, fieldsRequired []string) []s
 	for j, schemaFieldRequired := range schemaFieldsRequired {
 		index = nil
 		for i, fieldRequired := range fieldsRequired {
+			i := i
 			if schemaFieldRequired == fieldRequired {
 				index = &i
 				break

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -3537,6 +3537,7 @@ func TestApplyTemplateRequestWithBodyQueryParameters(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			reg := descriptor.NewRegistry()
 			if err := AddErrorDefs(reg); err != nil {
@@ -3802,8 +3803,8 @@ func TestApplyTemplateProtobufAny(t *testing.T) {
 
 func generateFieldsForJSONReservedName() []*descriptor.Field {
 	fields := make([]*descriptor.Field, 0)
-	fieldName := string("json_name")
-	fieldJSONName := string("jsonNAME")
+	fieldName := "json_name"
+	fieldJSONName := "jsonNAME"
 	fieldDescriptor := descriptorpb.FieldDescriptorProto{Name: &fieldName, JsonName: &fieldJSONName}
 	field := &descriptor.Field{FieldDescriptorProto: &fieldDescriptor}
 	return append(fields, field)
@@ -9906,7 +9907,7 @@ func TestGetPathItemObjectSwaggerObjectMethod(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 
-		t.Run(string(tc.testName), func(t *testing.T) {
+		t.Run(tc.testName, func(t *testing.T) {
 			actualPathItemObject := tc.swaggerObject.getPathItemObject(tc.path)
 			if isEqual := reflect.DeepEqual(actualPathItemObject, tc.expectedPathItemObject); !isEqual {
 				t.Fatalf("Got pathItemObject: %#v, want pathItemObject: %#v", actualPathItemObject, tc.expectedPathItemObject)
@@ -9989,7 +9990,7 @@ func TestGetPathItemObjectFunction(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 
-		t.Run(string(tc.testName), func(t *testing.T) {
+		t.Run(tc.testName, func(t *testing.T) {
 			actualPathItemObject, actualIsPathPresent := getPathItemObject(tc.paths, tc.path)
 			if isEqual := reflect.DeepEqual(actualPathItemObject, tc.expectedPathItemObject); !isEqual {
 				t.Fatalf("Got pathItemObject: %#v, want pathItemObject: %#v", actualPathItemObject, tc.expectedPathItemObject)
@@ -10087,7 +10088,7 @@ func TestUpdatePaths(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 
-		t.Run(string(tc.testName), func(t *testing.T) {
+		t.Run(tc.testName, func(t *testing.T) {
 			updatePaths(&tc.paths, tc.pathToUpdate, tc.newPathItemObject)
 			if pathsCorrectlyUpdated := reflect.DeepEqual(tc.paths, tc.expectedUpdatedPaths); !pathsCorrectlyUpdated {
 				t.Fatalf("Paths not correctly updated. Want %#v, got %#v", tc.expectedUpdatedPaths, tc.paths)

--- a/protoc-gen-openapiv2/internal/genopenapi/types_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/types_test.go
@@ -40,7 +40,7 @@ func TestRawExample(t *testing.T) {
 		t.Run(string(tc.In), func(t *testing.T) {
 			t.Parallel()
 
-			ex := RawExample(tc.In)
+			ex := tc.In
 
 			out, err := yaml.Marshal(ex)
 			switch {

--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -20,9 +20,9 @@ func TestAnnotateContext_WorksWithEmpty(t *testing.T) {
 	ctx := context.Background()
 	expectedRPCName := "/example.Example/Example"
 	expectedHTTPPathPattern := "/v1"
-	request, err := http.NewRequest("GET", "http://www.example.com/v1", nil)
+	request, err := http.NewRequestWithContext(ctx, "GET", "http://www.example.com/v1", nil)
 	if err != nil {
-		t.Fatalf("http.NewRequest(%q, %q, nil) failed with %v; want success", "GET", "http://www.example.com", err)
+		t.Fatalf("http.NewRequestWithContext(ctx, %q, %q, nil) failed with %v; want success", "GET", "http://www.example.com", err)
 	}
 	request.Header.Add("Some-Irrelevant-Header", "some value")
 	annotated, err := runtime.AnnotateContext(ctx, runtime.NewServeMux(), request, expectedRPCName, runtime.WithHTTPPathPattern(expectedHTTPPathPattern))
@@ -40,9 +40,9 @@ func TestAnnotateContext_ForwardsGrpcMetadata(t *testing.T) {
 	ctx := context.Background()
 	expectedRPCName := "/example.Example/Example"
 	expectedHTTPPathPattern := "/v1"
-	request, err := http.NewRequest("GET", "http://www.example.com/v1", nil)
+	request, err := http.NewRequestWithContext(ctx, "GET", "http://www.example.com/v1", nil)
 	if err != nil {
-		t.Fatalf("http.NewRequest(%q, %q, nil) failed with %v; want success", "GET", "http://www.example.com", err)
+		t.Fatalf("http.NewRequestWithContext(ctx, %q, %q, nil) failed with %v; want success", "GET", "http://www.example.com", err)
 	}
 	request.Header.Add("Some-Irrelevant-Header", "some value")
 	request.Header.Add("Grpc-Metadata-FooBar", "Value1")
@@ -86,9 +86,9 @@ func TestAnnotateContext_ForwardsGrpcMetadata(t *testing.T) {
 func TestAnnotateContext_ForwardGrpcBinaryMetadata(t *testing.T) {
 	ctx := context.Background()
 	expectedRPCName := "/example.Example/Example"
-	request, err := http.NewRequest("GET", "http://www.example.com", nil)
+	request, err := http.NewRequestWithContext(ctx, "GET", "http://www.example.com", nil)
 	if err != nil {
-		t.Fatalf("http.NewRequest(%q, %q, nil) failed with %v; want success", "GET", "http://www.example.com", err)
+		t.Fatalf("http.NewRequestWithContext(ctx, %q, %q, nil) failed with %v; want success", "GET", "http://www.example.com", err)
 	}
 
 	binData := []byte("\x00test-binary-data")
@@ -116,9 +116,9 @@ func TestAnnotateContext_ForwardGrpcBinaryMetadata(t *testing.T) {
 func TestAnnotateContext_XForwardedFor(t *testing.T) {
 	ctx := context.Background()
 	expectedRPCName := "/example.Example/Example"
-	request, err := http.NewRequest("GET", "http://bar.foo.example.com", nil)
+	request, err := http.NewRequestWithContext(ctx, "GET", "http://bar.foo.example.com", nil)
 	if err != nil {
-		t.Fatalf("http.NewRequest(%q, %q, nil) failed with %v; want success", "GET", "http://bar.foo.example.com", err)
+		t.Fatalf("http.NewRequestWithContext(ctx, %q, %q, nil) failed with %v; want success", "GET", "http://bar.foo.example.com", err)
 	}
 	request.Header.Add("X-Forwarded-For", "192.0.2.100") // client
 	request.RemoteAddr = "192.0.2.200:12345"             // proxy
@@ -149,9 +149,9 @@ func TestAnnotateContext_XForwardedFor(t *testing.T) {
 func TestAnnotateContext_SupportsTimeouts(t *testing.T) {
 	ctx := context.Background()
 	expectedRPCName := "/example.Example/Example"
-	request, err := http.NewRequest("GET", "http://example.com", nil)
+	request, err := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
 	if err != nil {
-		t.Fatalf(`http.NewRequest("GET", "http://example.com", nil failed with %v; want success`, err)
+		t.Fatalf(`http.NewRequestWithContext(ctx, "GET", "http://example.com", nil) failed with %v; want success`, err)
 	}
 	annotated, err := runtime.AnnotateContext(ctx, runtime.NewServeMux(), request, expectedRPCName)
 	if err != nil {
@@ -228,15 +228,16 @@ func TestAnnotateContext_SupportsTimeouts(t *testing.T) {
 	}
 }
 func TestAnnotateContext_SupportsCustomAnnotators(t *testing.T) {
+	ctx := context.Background()
 	md1 := func(context.Context, *http.Request) metadata.MD { return metadata.New(map[string]string{"foo": "bar"}) }
 	md2 := func(context.Context, *http.Request) metadata.MD { return metadata.New(map[string]string{"baz": "qux"}) }
 	expected := metadata.New(map[string]string{"foo": "bar", "baz": "qux"})
 	expectedRPCName := "/example.Example/Example"
-	request, err := http.NewRequest("GET", "http://example.com", nil)
+	request, err := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
 	if err != nil {
-		t.Fatalf(`http.NewRequest("GET", "http://example.com", nil failed with %v; want success`, err)
+		t.Fatalf(`http.NewRequestWithContext(ctx, "GET", "http://example.com", nil) failed with %v; want success`, err)
 	}
-	annotated, err := runtime.AnnotateContext(context.Background(), runtime.NewServeMux(runtime.WithMetadata(md1), runtime.WithMetadata(md2)), request, expectedRPCName)
+	annotated, err := runtime.AnnotateContext(ctx, runtime.NewServeMux(runtime.WithMetadata(md1), runtime.WithMetadata(md2)), request, expectedRPCName)
 	if err != nil {
 		t.Errorf("runtime.AnnotateContext(ctx, %#v) failed with %v; want success", request, err)
 		return
@@ -258,9 +259,9 @@ func TestAnnotateIncomingContext_WorksWithEmpty(t *testing.T) {
 	ctx := context.Background()
 	expectedRPCName := "/example.Example/Example"
 	expectedHTTPPathPattern := "/v1"
-	request, err := http.NewRequest("GET", "http://www.example.com/v1", nil)
+	request, err := http.NewRequestWithContext(ctx, "GET", "http://www.example.com/v1", nil)
 	if err != nil {
-		t.Fatalf("http.NewRequest(%q, %q, nil) failed with %v; want success", "GET", "http://www.example.com", err)
+		t.Fatalf("http.NewRequestWithContext(ctx, %q, %q, nil) failed with %v; want success", "GET", "http://www.example.com", err)
 	}
 	request.Header.Add("Some-Irrelevant-Header", "some value")
 	annotated, err := runtime.AnnotateIncomingContext(ctx, runtime.NewServeMux(), request, expectedRPCName, runtime.WithHTTPPathPattern(expectedHTTPPathPattern))
@@ -283,9 +284,9 @@ func TestAnnotateIncomingContext_ForwardsGrpcMetadata(t *testing.T) {
 	ctx := context.Background()
 	expectedRPCName := "/example.Example/Example"
 	expectedHTTPPathPattern := "/v1"
-	request, err := http.NewRequest("GET", "http://www.example.com/v1", nil)
+	request, err := http.NewRequestWithContext(ctx, "GET", "http://www.example.com/v1", nil)
 	if err != nil {
-		t.Fatalf("http.NewRequest(%q, %q, nil) failed with %v; want success", "GET", "http://www.example.com", err)
+		t.Fatalf("http.NewRequestWithContext(ctx, %q, %q, nil) failed with %v; want success", "GET", "http://www.example.com", err)
 	}
 	request.Header.Add("Some-Irrelevant-Header", "some value")
 	request.Header.Add("Grpc-Metadata-FooBar", "Value1")
@@ -328,9 +329,9 @@ func TestAnnotateIncomingContext_ForwardsGrpcMetadata(t *testing.T) {
 func TestAnnotateIncomingContext_ForwardGrpcBinaryMetadata(t *testing.T) {
 	ctx := context.Background()
 	expectedRPCName := "/example.Example/Example"
-	request, err := http.NewRequest("GET", "http://www.example.com", nil)
+	request, err := http.NewRequestWithContext(ctx, "GET", "http://www.example.com", nil)
 	if err != nil {
-		t.Fatalf("http.NewRequest(%q, %q, nil) failed with %v; want success", "GET", "http://www.example.com", err)
+		t.Fatalf("http.NewRequestWithContext(ctx, %q, %q, nil) failed with %v; want success", "GET", "http://www.example.com", err)
 	}
 
 	binData := []byte("\x00test-binary-data")
@@ -358,9 +359,9 @@ func TestAnnotateIncomingContext_ForwardGrpcBinaryMetadata(t *testing.T) {
 func TestAnnotateIncomingContext_XForwardedFor(t *testing.T) {
 	ctx := context.Background()
 	expectedRPCName := "/example.Example/Example"
-	request, err := http.NewRequest("GET", "http://bar.foo.example.com", nil)
+	request, err := http.NewRequestWithContext(ctx, "GET", "http://bar.foo.example.com", nil)
 	if err != nil {
-		t.Fatalf("http.NewRequest(%q, %q, nil) failed with %v; want success", "GET", "http://bar.foo.example.com", err)
+		t.Fatalf("http.NewRequestWithContext(ctx, %q, %q, nil) failed with %v; want success", "GET", "http://bar.foo.example.com", err)
 	}
 	request.Header.Add("X-Forwarded-For", "192.0.2.100") // client
 	request.RemoteAddr = "192.0.2.200:12345"             // proxy
@@ -393,9 +394,9 @@ func TestAnnotateIncomingContext_SupportsTimeouts(t *testing.T) {
 	runtime.DefaultContextTimeout = 0 * time.Second
 	expectedRPCName := "/example.Example/Example"
 	ctx := context.Background()
-	request, err := http.NewRequest("GET", "http://example.com", nil)
+	request, err := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
 	if err != nil {
-		t.Fatalf(`http.NewRequest("GET", "http://example.com", nil failed with %v; want success`, err)
+		t.Fatalf(`http.NewRequestWithContext(ctx, "GET", "http://example.com", nil) failed with %v; want success`, err)
 	}
 	annotated, err := runtime.AnnotateIncomingContext(ctx, runtime.NewServeMux(), request, expectedRPCName)
 	if err != nil {
@@ -472,15 +473,16 @@ func TestAnnotateIncomingContext_SupportsTimeouts(t *testing.T) {
 	}
 }
 func TestAnnotateIncomingContext_SupportsCustomAnnotators(t *testing.T) {
+	ctx := context.Background()
 	md1 := func(context.Context, *http.Request) metadata.MD { return metadata.New(map[string]string{"foo": "bar"}) }
 	md2 := func(context.Context, *http.Request) metadata.MD { return metadata.New(map[string]string{"baz": "qux"}) }
 	expected := metadata.New(map[string]string{"foo": "bar", "baz": "qux"})
 	expectedRPCName := "/example.Example/Example"
-	request, err := http.NewRequest("GET", "http://example.com", nil)
+	request, err := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
 	if err != nil {
-		t.Fatalf(`http.NewRequest("GET", "http://example.com", nil failed with %v; want success`, err)
+		t.Fatalf(`http.NewRequestWithContext(ctx, "GET", "http://example.com", nil) failed with %v; want success`, err)
 	}
-	annotated, err := runtime.AnnotateIncomingContext(context.Background(), runtime.NewServeMux(runtime.WithMetadata(md1), runtime.WithMetadata(md2)), request, expectedRPCName)
+	annotated, err := runtime.AnnotateIncomingContext(ctx, runtime.NewServeMux(runtime.WithMetadata(md1), runtime.WithMetadata(md2)), request, expectedRPCName)
 	if err != nil {
 		t.Errorf("runtime.AnnotateIncomingContext(ctx, %#v) failed with %v; want success", request, err)
 		return

--- a/runtime/errors_test.go
+++ b/runtime/errors_test.go
@@ -73,7 +73,7 @@ func TestDefaultHTTPError(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("", "", nil) // Pass in an empty request to match the signature
+			req, _ := http.NewRequestWithContext(ctx, "", "", nil) // Pass in an empty request to match the signature
 			mux := runtime.NewServeMux()
 			marshaler := &runtime.JSONPb{}
 			runtime.HTTPError(ctx, mux, marshaler, w, req, spec.err)

--- a/runtime/fieldmask.go
+++ b/runtime/fieldmask.go
@@ -27,7 +27,7 @@ func FieldMaskFromRequestBody(r io.Reader, msg proto.Message) (*field_mask.Field
 	var root interface{}
 
 	if err := json.NewDecoder(r).Decode(&root); err != nil {
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return fm, nil
 		}
 		return nil, err

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -48,7 +49,7 @@ func ForwardResponseStream(ctx context.Context, mux *ServeMux, marshaler Marshal
 	var wroteHeader bool
 	for {
 		resp, err := recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return
 		}
 		if err != nil {

--- a/runtime/marshaler_registry_test.go
+++ b/runtime/marshaler_registry_test.go
@@ -1,6 +1,7 @@
 package runtime_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -11,7 +12,8 @@ import (
 )
 
 func TestMarshalerForRequest(t *testing.T) {
-	r, err := http.NewRequest("GET", "http://example.com", nil)
+	ctx := context.Background()
+	r, err := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
 	if err != nil {
 		t.Fatalf(`http.NewRequest("GET", "http://example.com", nil) failed with %v; want success`, err)
 	}

--- a/runtime/mux_test.go
+++ b/runtime/mux_test.go
@@ -584,7 +584,8 @@ func TestMuxServeHTTP(t *testing.T) {
 			}
 
 			reqUrl := fmt.Sprintf("https://host.example%s", spec.reqPath)
-			r, err := http.NewRequest(spec.reqMethod, reqUrl, bytes.NewReader(nil))
+			ctx := context.Background()
+			r, err := http.NewRequestWithContext(ctx, spec.reqMethod, reqUrl, bytes.NewReader(nil))
 			if err != nil {
 				t.Fatalf("http.NewRequest(%q, %q, nil) failed with %v; want success", spec.reqMethod, reqUrl, err)
 			}

--- a/runtime/pattern_test.go
+++ b/runtime/pattern_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -181,7 +182,7 @@ func TestNewPatternWithWrongOp(t *testing.T) {
 			t.Errorf("NewPattern(%d, %v, %q, %q) succeeded; want failure with %v", validVersion, spec.ops, spec.pool, spec.verb, ErrInvalidPattern)
 			continue
 		}
-		if err != ErrInvalidPattern {
+		if !errors.Is(err, ErrInvalidPattern) {
 			t.Errorf("NewPattern(%d, %v, %q, %q) failed with %v; want failure with %v", validVersion, spec.ops, spec.pool, spec.verb, err, ErrInvalidPattern)
 			continue
 		}
@@ -207,7 +208,7 @@ func TestNewPatternWithStackUnderflow(t *testing.T) {
 			t.Errorf("NewPattern(%d, %v, %q, %q) succeeded; want failure with %v", validVersion, spec.ops, spec.pool, spec.verb, ErrInvalidPattern)
 			continue
 		}
-		if err != ErrInvalidPattern {
+		if !errors.Is(err, ErrInvalidPattern) {
 			t.Errorf("NewPattern(%d, %v, %q, %q) failed with %v; want failure with %v", validVersion, spec.ops, spec.pool, spec.verb, err, ErrInvalidPattern)
 			continue
 		}
@@ -354,7 +355,7 @@ func TestMatch(t *testing.T) {
 				t.Errorf("pat.Match(%q) succeeded; want failure with %v; pattern = (%v, %q)", path, ErrNotMatch, spec.ops, spec.pool)
 				continue
 			}
-			if err != ErrNotMatch {
+			if !errors.Is(err, ErrNotMatch) {
 				t.Errorf("pat.Match(%q) failed with %v; want failure with %v; pattern = (%v, %q)", spec.notMatch, err, ErrNotMatch, spec.ops, spec.pool)
 			}
 		}


### PR DESCRIPTION
Update grpc-gateway to enable a few more useful golangci-lint linters (and fix the issues reported by them). As part of this, no style linters were added as those can be tailored appropriately by the primary maintainers as needed (except for goimports which is already enabled by CI job).