### PR TITLE
wip: Fix nil SourceCodeInfo in descriptor.File

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"log"
 	"math"
 	"net/textproto"
 	"os"
@@ -2330,8 +2331,7 @@ func enumValueProtoComments(reg *descriptor.Registry, enum *descriptor.Enum) str
 
 func protoComments(reg *descriptor.Registry, file *descriptor.File, outers []string, typeName string, typeIndex int32, fieldPaths ...int32) string {
 	if file.SourceCodeInfo == nil {
-		fmt.Fprintln(os.Stderr, file.GetName(), "descriptor.File should not contain nil SourceCodeInfo")
-		return ""
+		log.Fatalf("%s: descriptor.File should not contain nil SourceCodeInfo", file.GetName())
 	}
 
 	outerPaths := make([]int32, len(outers))


### PR DESCRIPTION
In the `protoComments` function, if the `file.SourceCodeInfo` is nil,
print an error message and exit with a non-zero status code.

The change fixes an issue where the `descriptor.File` should not contain
a nil `SourceCodeInfo`, providing better error handling.

Signed-off-by: aimuz <mr.imuz@gmail.com>

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

Update #1870
Update #3542

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

#### Other comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Bug Fix":
- Updated error handling in `protoc-gen-openapiv2/internal/genopenapi/template.go`. The program will now exit with a non-zero status code when the `file.SourceCodeInfo` is nil, preventing potential silent failures.
- Enhanced logging by replacing `fmt.Fprintln` with `log.Fatalf` for more informative error messages and immediate program termination on fatal conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->