### PR TITLE
Sort tags by explicit Swagger annotation first

### DIFF
--- a/examples/internal/clients/abe/api/swagger.yaml
+++ b/examples/internal/clients/abe/api/swagger.yaml
@@ -12,6 +12,9 @@ info:
     url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/main/LICENSE.txt"
   x-something-something: "yadda"
 tags:
+- name: "echo rpc"
+  description: "Echo Rpc description"
+  x-traitTag: true
 - name: "ABitOfEverythingService"
   description: "ABitOfEverythingService description -- which should not be used in\
     \ place of the documentation comment!"
@@ -21,9 +24,6 @@ tags:
 - name: "camelCaseServiceName"
 - name: "AnotherServiceWithNoBindings"
 - name: "SnakeEnumService"
-- name: "echo rpc"
-  description: "Echo Rpc description"
-  x-traitTag: true
 schemes:
 - "http"
 - "https"

--- a/examples/internal/clients/unannotatedecho/api/swagger.yaml
+++ b/examples/internal/clients/unannotatedecho/api/swagger.yaml
@@ -16,17 +16,17 @@ info:
     url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/main/LICENSE.txt"
   x-something-something: "yadda"
 tags:
+- name: "Echo"
+  description: "Echo description"
+- name: "Internal"
+  description: "Internal description"
+  x-traitTag: true
 - name: "UnannotatedEchoService"
   description: "UnannotatedEchoService description -- which should not be used in\
     \ place of the documentation comment!"
   externalDocs:
     description: "Find out more about UnannotatedEchoService"
     url: "https://github.com/grpc-ecosystem/grpc-gateway"
-- name: "Echo"
-  description: "Echo description"
-- name: "Internal"
-  description: "Internal description"
-  x-traitTag: true
 schemes:
 - "http"
 - "https"

--- a/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
+++ b/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
@@ -16,6 +16,11 @@
   },
   "tags": [
     {
+      "name": "echo rpc",
+      "description": "Echo Rpc description",
+      "x-traitTag": true
+    },
+    {
       "name": "ABitOfEverythingService",
       "description": "ABitOfEverythingService description -- which should not be used in place of the documentation comment!",
       "externalDocs": {
@@ -31,11 +36,6 @@
     },
     {
       "name": "SnakeEnumService"
-    },
-    {
-      "name": "echo rpc",
-      "description": "Echo Rpc description",
-      "x-traitTag": true
     }
   ],
   "schemes": [

--- a/examples/internal/proto/examplepb/unannotated_echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/unannotated_echo_service.swagger.json
@@ -17,14 +17,6 @@
   },
   "tags": [
     {
-      "name": "UnannotatedEchoService",
-      "description": "UnannotatedEchoService description -- which should not be used in place of the documentation comment!",
-      "externalDocs": {
-        "description": "Find out more about UnannotatedEchoService",
-        "url": "https://github.com/grpc-ecosystem/grpc-gateway"
-      }
-    },
-    {
       "name": "Echo",
       "description": "Echo description"
     },
@@ -32,6 +24,14 @@
       "name": "Internal",
       "description": "Internal description",
       "x-traitTag": true
+    },
+    {
+      "name": "UnannotatedEchoService",
+      "description": "UnannotatedEchoService description -- which should not be used in place of the documentation comment!",
+      "externalDocs": {
+        "description": "Find out more about UnannotatedEchoService",
+        "url": "https://github.com/grpc-ecosystem/grpc-gateway"
+      }
     }
   ],
   "schemes": [


### PR DESCRIPTION
I believe it what most people would expect, since the order of tags extracted from methods is harder to control, especially if swagger file is merged from multiple proto files.

In addition, allow merging properties.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

#### Other comments




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced a `mergeTags` function in `template.go` to merge existing tags with rendered service tags, enhancing flexibility in handling service tags.
- Test: Added a new test function `TestMergeTags` in `template_test.go` to validate the correct merging of tag objects under various scenarios.
- Test: Implemented a helper function `MustMarshal` in `template_test.go` for marshalling objects into JSON format, improving test data manipulation.
- Refactor: Updated the `applyTemplate` function in `template.go` to use the new `mergeTags` function, ensuring consistent and efficient tag merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->