### PR TITLE
Use go templates on tag descriptions too

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -1096,10 +1096,16 @@ func renderServiceTags(services []*descriptor.Service, reg *descriptor.Registry)
 		}
 		if opts != nil {
 			tag.Description = opts.Description
+			if reg.GetUseGoTemplate() {
+				tag.Description = goTemplateComments(tag.Description, svc, reg)
+			}
 			if opts.ExternalDocs != nil {
 				tag.ExternalDocs = &openapiExternalDocumentationObject{
 					Description: opts.ExternalDocs.Description,
 					URL:         opts.ExternalDocs.Url,
+				}
+				if reg.GetUseGoTemplate() {
+					tag.ExternalDocs.Description = goTemplateComments(opts.ExternalDocs.Description, svc, reg)
 				}
 			}
 		}
@@ -1992,10 +1998,16 @@ func applyTemplate(p param) (*openapiSwaggerObject, error) {
 				newTag := openapiTagObject{}
 				newTag.Name = v.Name
 				newTag.Description = v.Description
+				if p.reg.GetUseGoTemplate() {
+					newTag.Description = goTemplateComments(newTag.Description, nil, p.reg)
+				}
 				if v.ExternalDocs != nil {
 					newTag.ExternalDocs = &openapiExternalDocumentationObject{
 						Description: v.ExternalDocs.Description,
 						URL:         v.ExternalDocs.Url,
+					}
+					if p.reg.GetUseGoTemplate() {
+						newTag.ExternalDocs.Description = goTemplateComments(v.ExternalDocs.Description, nil, p.reg)
 					}
 				}
 				if v.Extensions != nil {


### PR DESCRIPTION
Using go templates is extremely useful for tag sections such as "Getting Started" etc, which it is a lot easier to just simply import a markdown file.

P.S.
I don't super like the fact that if the file is not found, it fails silently - I imagine cases where documentation will be missing in CI systems (internal repo paths will be exposed), and all for the sake of "debuggability" - might as well fail the process.
But I kept the current implementation for missing imports.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

#### Other comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the `renderServiceTags` and `applyTemplate` functions in `template.go`. These changes allow for dynamic modification of the `Description` field of tags based on certain conditions, improving flexibility and customization.
- Test: Added a new test function `TestTagsWithGoTemplate` in `template_test.go`. This function tests the generation of tags using Go templates, ensuring the accuracy and reliability of the new feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->