### PR TITLE
Fix docs build by pinning remote_theme value

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,7 +9,7 @@ baseurl: "/grpc-gateway" # the subpath of your site, e.g. /blog
 url: "https://grpc-ecosystem.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
 repository: grpc-ecosystem/grpc-gateway
-remote_theme: pmarsceill/just-the-docs
+remote_theme: pmarsceill/just-the-docs@v0.6.2
 
 permalink: pretty
 exclude: ["run.sh"]


### PR DESCRIPTION
I noticed that our [docs build workflow](https://github.com/grpc-ecosystem/grpc-gateway/actions/workflows/pages/pages-build-deployment) stopped working a few days ago

After digging into it a bit, it turns out that we are using the [jekyll-remote-theme](https://github.com/benbalter/jekyll-remote-theme) plugin, which dynamically downloads a publicly hosted Jekyll theme. It is specified [here](https://github.com/grpc-ecosystem/grpc-gateway/blob/0046dfdb14e233332543f5468a18ca940584a2b6/docs/_config.yml#L12) and it points to the [just-the-docs](https://github.com/just-the-docs/just-the-docs) theme. The problem is that this theme recently introduced a breaking change described in its [CHANGELOG.md](https://github.com/just-the-docs/just-the-docs/blob/main/CHANGELOG.md), which broke our build.

"jekyll-remote-theme" allows to pin a remote theme:
> You may also optionally specify a branch, tag, or commit to use by appending an @ and the Git ref (e.g., benbalter/retlab@v1.0.0 or benbalter/retlab@develop). If you don't specify a Git ref, the HEAD ref will be used.

#### Alternative

An alternative fix might be to point `nav.html` to the right place in our source code. Still, I think it's worth pinning the release version to avoid future problems like this.