### PR TITLE
runtime: Add outgoing trailer matching

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -137,7 +137,7 @@ func DefaultHTTPErrorHandler(ctx context.Context, mux *ServeMux, marshaler Marsh
 	doForwardTrailers := requestAcceptsTrailers(r)
 
 	if doForwardTrailers {
-		handleForwardResponseTrailerHeader(w, md)
+		handleForwardResponseTrailerHeader(w, mux, md)
 		w.Header().Set("Transfer-Encoding", "chunked")
 	}
 
@@ -152,7 +152,7 @@ func DefaultHTTPErrorHandler(ctx context.Context, mux *ServeMux, marshaler Marsh
 	}
 
 	if doForwardTrailers {
-		handleForwardResponseTrailer(w, md)
+		handleForwardResponseTrailer(w, mux, md)
 	}
 }
 

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -3,7 +3,6 @@ package runtime
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/textproto"
@@ -109,18 +108,20 @@ func handleForwardResponseServerMetadata(w http.ResponseWriter, mux *ServeMux, m
 	}
 }
 
-func handleForwardResponseTrailerHeader(w http.ResponseWriter, md ServerMetadata) {
+func handleForwardResponseTrailerHeader(w http.ResponseWriter, mux *ServeMux, md ServerMetadata) {
 	for k := range md.TrailerMD {
-		tKey := textproto.CanonicalMIMEHeaderKey(fmt.Sprintf("%s%s", MetadataTrailerPrefix, k))
-		w.Header().Add("Trailer", tKey)
+		if h, ok := mux.outgoingTrailerMatcher(k); ok {
+			w.Header().Add("Trailer", textproto.CanonicalMIMEHeaderKey(h))
+		}
 	}
 }
 
-func handleForwardResponseTrailer(w http.ResponseWriter, md ServerMetadata) {
+func handleForwardResponseTrailer(w http.ResponseWriter, mux *ServeMux, md ServerMetadata) {
 	for k, vs := range md.TrailerMD {
-		tKey := fmt.Sprintf("%s%s", MetadataTrailerPrefix, k)
-		for _, v := range vs {
-			w.Header().Add(tKey, v)
+		if h, ok := mux.outgoingTrailerMatcher(k); ok {
+			for _, v := range vs {
+				w.Header().Add(h, v)
+			}
 		}
 	}
 }
@@ -148,11 +149,9 @@ func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marsha
 	doForwardTrailers := requestAcceptsTrailers(req)
 
 	if doForwardTrailers {
-		handleForwardResponseTrailerHeader(w, md)
+		handleForwardResponseTrailerHeader(w, mux, md)
 		w.Header().Set("Transfer-Encoding", "chunked")
 	}
-
-	handleForwardResponseTrailerHeader(w, md)
 
 	contentType := marshaler.ContentType(resp)
 	w.Header().Set("Content-Type", contentType)
@@ -179,7 +178,7 @@ func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marsha
 	}
 
 	if doForwardTrailers {
-		handleForwardResponseTrailer(w, md)
+		handleForwardResponseTrailer(w, mux, md)
 	}
 }
 

--- a/runtime/handler_test.go
+++ b/runtime/handler_test.go
@@ -5,11 +5,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	pb "github.com/grpc-ecosystem/grpc-gateway/v2/runtime/internal/examplepb"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
@@ -314,6 +316,170 @@ func TestForwardResponseMessage(t *testing.T) {
 
 			if string(body) != string(want) {
 				t.Errorf("ForwardResponseMessage() = \"%s\" want \"%s\"", body, want)
+			}
+		})
+	}
+}
+
+func TestOutgoingHeaderMatcher(t *testing.T) {
+	t.Parallel()
+	msg := &pb.SimpleMessage{Id: "foo"}
+	for _, tc := range []struct {
+		name    string
+		md      runtime.ServerMetadata
+		headers http.Header
+		matcher runtime.HeaderMatcherFunc
+	}{
+		{
+			name: "default matcher",
+			md: runtime.ServerMetadata{
+				HeaderMD: metadata.Pairs(
+					"foo", "bar",
+					"baz", "qux",
+				),
+			},
+			headers: http.Header{
+				"Content-Type":      []string{"application/json"},
+				"Grpc-Metadata-Foo": []string{"bar"},
+				"Grpc-Metadata-Baz": []string{"qux"},
+			},
+		},
+		{
+			name: "custom matcher",
+			md: runtime.ServerMetadata{
+				HeaderMD: metadata.Pairs(
+					"foo", "bar",
+					"baz", "qux",
+				),
+			},
+			headers: http.Header{
+				"Content-Type": []string{"application/json"},
+				"Custom-Foo":   []string{"bar"},
+			},
+			matcher: func(key string) (string, bool) {
+				switch key {
+				case "foo":
+					return "custom-foo", true
+				default:
+					return "", false
+				}
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := runtime.NewServerMetadataContext(context.Background(), tc.md)
+
+			req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+			resp := httptest.NewRecorder()
+
+			runtime.ForwardResponseMessage(ctx, runtime.NewServeMux(runtime.WithOutgoingHeaderMatcher(tc.matcher)), &runtime.JSONPb{}, resp, req, msg)
+
+			w := resp.Result()
+			defer w.Body.Close()
+			if w.StatusCode != http.StatusOK {
+				t.Fatalf("StatusCode %d want %d", w.StatusCode, http.StatusOK)
+			}
+
+			if !reflect.DeepEqual(w.Header, tc.headers) {
+				t.Fatalf("Header %v want %v", w.Header, tc.headers)
+			}
+		})
+	}
+}
+
+func TestOutgoingTrailerMatcher(t *testing.T) {
+	t.Parallel()
+	msg := &pb.SimpleMessage{Id: "foo"}
+	for _, tc := range []struct {
+		name    string
+		md      runtime.ServerMetadata
+		caller  http.Header
+		headers http.Header
+		trailer http.Header
+		matcher runtime.HeaderMatcherFunc
+	}{
+		{
+			name: "default matcher, caller accepts",
+			md: runtime.ServerMetadata{
+				TrailerMD: metadata.Pairs(
+					"foo", "bar",
+					"baz", "qux",
+				),
+			},
+			caller: http.Header{
+				"Te": []string{"trailers"},
+			},
+			headers: http.Header{
+				"Content-Type": []string{"application/json"},
+				"Trailer":      []string{"Grpc-Trailer-Foo,Grpc-Trailer-Baz"},
+			},
+			trailer: http.Header{
+				"Grpc-Trailer-Foo": []string{"bar"},
+				"Grpc-Trailer-Baz": []string{"qux"},
+			},
+		},
+		{
+			name: "default matcher, caller rejects",
+			md: runtime.ServerMetadata{
+				TrailerMD: metadata.Pairs(
+					"foo", "bar",
+					"baz", "qux",
+				),
+			},
+			headers: http.Header{
+				"Content-Type": []string{"application/json"},
+			},
+		},
+		{
+			name: "custom matcher",
+			md: runtime.ServerMetadata{
+				TrailerMD: metadata.Pairs(
+					"foo", "bar",
+					"baz", "qux",
+				),
+			},
+			caller: http.Header{
+				"Te": []string{"trailers"},
+			},
+			headers: http.Header{
+				"Content-Type": []string{"application/json"},
+				"Trailer":      []string{"Custom-Trailer-Foo"},
+			},
+			trailer: http.Header{
+				"Custom-Trailer-Foo": []string{"bar"},
+			},
+			matcher: func(key string) (string, bool) {
+				switch key {
+				case "foo":
+					return "custom-trailer-foo", true
+				default:
+					return "", false
+				}
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := runtime.NewServerMetadataContext(context.Background(), tc.md)
+
+			req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+			req.Header = tc.caller
+			resp := httptest.NewRecorder()
+
+			runtime.ForwardResponseMessage(ctx, runtime.NewServeMux(runtime.WithOutgoingTrailerMatcher(tc.matcher)), &runtime.JSONPb{}, resp, req, msg)
+
+			w := resp.Result()
+			_, _ = io.Copy(io.Discard, w.Body)
+			defer w.Body.Close()
+			if w.StatusCode != http.StatusOK {
+				t.Fatalf("StatusCode %d want %d", w.StatusCode, http.StatusOK)
+			}
+
+			if !reflect.DeepEqual(w.Trailer, tc.trailer) {
+				t.Fatalf("Trailer %v want %v", w.Trailer, tc.trailer)
 			}
 		})
 	}

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -126,7 +126,7 @@ func defaultOutgoingTrailerMatcher(key string) (string, bool) {
 // WithIncomingHeaderMatcher returns a ServeMuxOption representing a headerMatcher for incoming request to gateway.
 //
 // This matcher will be called with each header in http.Request. If matcher returns true, that header will be
-// passed to gRPC context. To transform the header before passing to gRPC context, matcher should return modified header.
+// passed to gRPC context. To transform the header before passing to gRPC context, matcher should return the modified header.
 func WithIncomingHeaderMatcher(fn HeaderMatcherFunc) ServeMuxOption {
 	for _, header := range fn.matchedMalformedHeaders() {
 		grpclog.Warningf("The configured forwarding filter would allow %q to be sent to the gRPC server, which will likely cause errors. See https://github.com/grpc/grpc-go/pull/4803#issuecomment-986093310 for more information.", header)
@@ -156,7 +156,7 @@ func (fn HeaderMatcherFunc) matchedMalformedHeaders() []string {
 //
 // This matcher will be called with each header in response header metadata. If matcher returns true, that header will be
 // passed to http response returned from gateway. To transform the header before passing to response,
-// matcher should return modified header.
+// matcher should return the modified header.
 func WithOutgoingHeaderMatcher(fn HeaderMatcherFunc) ServeMuxOption {
 	return func(mux *ServeMux) {
 		mux.outgoingHeaderMatcher = fn
@@ -167,7 +167,7 @@ func WithOutgoingHeaderMatcher(fn HeaderMatcherFunc) ServeMuxOption {
 //
 // This matcher will be called with each header in response trailer metadata. If matcher returns true, that header will be
 // passed to http response returned from gateway. To transform the header before passing to response,
-// matcher should return modified header.
+// matcher should return the modified header.
 func WithOutgoingTrailerMatcher(fn HeaderMatcherFunc) ServeMuxOption {
 	return func(mux *ServeMux) {
 		mux.outgoingTrailerMatcher = fn

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -290,14 +290,14 @@ func NewServeMux(opts ...ServeMuxOption) *ServeMux {
 		opt(serveMux)
 	}
 
-	for matcher, fallback := range map[*HeaderMatcherFunc]HeaderMatcherFunc{
-		&serveMux.incomingHeaderMatcher:  DefaultHeaderMatcher,
-		&serveMux.outgoingHeaderMatcher:  defaultOutgoingHeaderMatcher,
-		&serveMux.outgoingTrailerMatcher: defaultOutgoingTrailerMatcher,
-	} {
-		if *matcher == nil {
-			*matcher = fallback
-		}
+	if serveMux.incomingHeaderMatcher == nil {
+		serveMux.incomingHeaderMatcher = DefaultHeaderMatcher
+	}
+	if serveMux.outgoingHeaderMatcher == nil {
+		serveMux.outgoingHeaderMatcher = defaultOutgoingHeaderMatcher
+	}
+	if serveMux.outgoingTrailerMatcher == nil {
+		serveMux.outgoingTrailerMatcher = defaultOutgoingTrailerMatcher
 	}
 
 	return serveMux


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Closes https://github.com/grpc-ecosystem/grpc-gateway/issues/1697

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

- Avoid partially forwarding trailers if the caller did not accept them explicitly.
  - This seems to be a copy paste failure of the original PR (see [this](https://github.com/grpc-ecosystem/grpc-gateway/pull/2124/files#diff-4e2f81dd46cb78503d268ddc2f7b88ac214651ac316dc000ec32f3d180464203R154)).
  - It does not make sense to send the `Trailers` header if the trailers themselves will not be included, especially if the caller did not signal that it accepts trailers.
  - The error handling code did not do this duplication, so more reasons to consider this a bug.
- Add outgoing trailer matching.
  - The previous behavior is the default one.

#### Other comments

1. I implemented this change due to https://github.com/grpc/grpc-go/pull/6662 , as I would like to skip this trailer completely since the error details are present in the body. But maybe `grpc-gateway` should convert back binary header/trailer values to base64 before sending them to the HTTP caller, by default ? (similar to how binary metadata is decoded from the HTTP caller to the gRPC client)

2. There is no trailer support for streaming responses - should this be added ?

3. Should we expose the default matchers ? Currently only the incoming header matcher is a public function, and it is badly named given that there are three matchers now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling with improved access to server instances.
	- Introduced matching for outgoing headers and trailers.
- **Bug Fixes**
	- Adjusted function signatures for better operational efficiency.
- **Tests**
	- Added new tests for outgoing header and trailer matching.
- **Refactor**
	- Removed unnecessary package imports.
	- Updated server initialization to set default matchers if not set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->