### PR TITLE
Add openapiv2_opt support for passing values to go templates via cli

### DIFF
--- a/internal/descriptor/registry.go
+++ b/internal/descriptor/registry.go
@@ -78,6 +78,9 @@ type Registry struct {
 	// in your protofile comments
 	useGoTemplate bool
 
+	// goTemplateArgs specifies a list of key value pair inputs to be displayed in Go templates
+	goTemplateArgs map[string]string
+
 	// ignoreComments determines whether all protofile comments should be excluded from output
 	ignoreComments bool
 
@@ -581,6 +584,19 @@ func (r *Registry) SetUseGoTemplate(use bool) {
 // GetUseGoTemplate returns useGoTemplate
 func (r *Registry) GetUseGoTemplate() bool {
 	return r.useGoTemplate
+}
+
+func (r *Registry) SetGoTemplateArgs(kvs []string) {
+	r.goTemplateArgs = make(map[string]string)
+	for _, kv := range kvs {
+		if key, value, found := strings.Cut(kv, "="); found {
+			r.goTemplateArgs[key] = value
+		}
+	}
+}
+
+func (r *Registry) GetGoTemplateArgs() map[string]string {
+	return r.goTemplateArgs
 }
 
 // SetIgnoreComments sets ignoreComments

--- a/protoc-gen-openapiv2/defs.bzl
+++ b/protoc-gen-openapiv2/defs.bzl
@@ -60,6 +60,7 @@ def _run_proto_gen_openapi(
         fqn_for_openapi_name,
         openapi_naming_strategy,
         use_go_templates,
+        go_template_args,
         ignore_comments,
         remove_internal_comments,
         disable_default_errors,
@@ -109,6 +110,9 @@ def _run_proto_gen_openapi(
 
     if use_go_templates:
         args.add("--openapiv2_opt", "use_go_templates=true")
+
+    for go_template_arg in go_template_args:
+        args.add("--openapiv2_opt", "go_template_args=%s" % go_template_arg)
 
     if ignore_comments:
         args.add("--openapiv2_opt", "ignore_comments=true")
@@ -232,6 +236,7 @@ def _proto_gen_openapi_impl(ctx):
                     fqn_for_openapi_name = ctx.attr.fqn_for_openapi_name,
                     openapi_naming_strategy = ctx.attr.openapi_naming_strategy,
                     use_go_templates = ctx.attr.use_go_templates,
+                    go_template_args = ctx.attr.go_template_args,
                     ignore_comments = ctx.attr.ignore_comments,
                     remove_internal_comments = ctx.attr.remove_internal_comments,
                     disable_default_errors = ctx.attr.disable_default_errors,
@@ -311,6 +316,12 @@ protoc_gen_openapiv2 = rule(
             default = False,
             mandatory = False,
             doc = "if set, you can use Go templates in protofile comments",
+        ),
+        "go_template_args": attr.string_list(
+            mandatory = False,
+            doc = "specify a key value pair as inputs to the Go template of the protofile" +
+                  " comments. Repeat this option to specify multiple template arguments." +
+                  " Requires the `use_go_templates` option to be set.",
         ),
         "ignore_comments": attr.bool(
             default = False,

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -2486,6 +2486,12 @@ func goTemplateComments(comment string, data interface{}, reg *descriptor.Regist
 		"fieldcomments": func(msg *descriptor.Message, field *descriptor.Field) string {
 			return strings.ReplaceAll(fieldProtoComments(reg, msg, field), "\n", "<br>")
 		},
+		"arg": func(name string) string {
+			if v, f := reg.GetGoTemplateArgs()[name]; f {
+				return v
+			}
+			return fmt.Sprintf("goTemplateArg %s not found", name)
+		},
 	}).Parse(comment)
 	if err != nil {
 		// If there is an error parsing the templating insert the error as string in the comment

--- a/protoc-gen-openapiv2/main.go
+++ b/protoc-gen-openapiv2/main.go
@@ -30,6 +30,7 @@ var (
 	useFQNForOpenAPIName           = flag.Bool("fqn_for_openapi_name", false, "if set, the object's OpenAPI names will use the fully qualified names from the proto definition (ie my.package.MyMessage.MyInnerMessage). DEPRECATED: prefer `openapi_naming_strategy=fqn`")
 	openAPINamingStrategy          = flag.String("openapi_naming_strategy", "", "use the given OpenAPI naming strategy. Allowed values are `legacy`, `fqn`, `simple`. If unset, either `legacy` or `fqn` are selected, depending on the value of the `fqn_for_openapi_name` flag")
 	useGoTemplate                  = flag.Bool("use_go_templates", false, "if set, you can use Go templates in protofile comments")
+	goTemplateArgs                 = utilities.StringArrayFlag(flag.CommandLine, "go_template_args", "provide a custom value that can override a key in the Go template. Requires the `use_go_templates` option to be set")
 	ignoreComments                 = flag.Bool("ignore_comments", false, "if set, all protofile comments are excluded from output")
 	removeInternalComments         = flag.Bool("remove_internal_comments", false, "if set, removes all substrings in comments that start with `(--` and end with `--)` as specified in https://google.aip.dev/192#internal-comments")
 	disableDefaultErrors           = flag.Bool("disable_default_errors", false, "if set, disables generation of default errors. This is useful if you have defined custom error handling")
@@ -134,6 +135,12 @@ func main() {
 	reg.SetUseGoTemplate(*useGoTemplate)
 	reg.SetIgnoreComments(*ignoreComments)
 	reg.SetRemoveInternalComments(*removeInternalComments)
+
+	if len(*goTemplateArgs) > 0 && !*useGoTemplate {
+		emitError(fmt.Errorf("`go_template_args` requires `use_go_templates` to be enabled"))
+		return
+	}
+	reg.SetGoTemplateArgs(*goTemplateArgs)
 
 	reg.SetOpenAPINamingStrategy(namingStrategy)
 	reg.SetEnumsAsInts(*enumsAsInts)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #3388 

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

As proposed by @jgiles in #3388, this MR adds support for a new OpenAPI option that allows for Go template values to be interpolated.

For example, by specifying the following option:  `--openapiv2_opt go_template_args=my_key=my_value`, `my_value` can then be passed to the Go templates generating the swagger comments. In this case, the go template can refer to the specific key here with `{{ arg "my_key" }}`.

Multiple `go_template_args` arguments can be specified.

#### Other comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to use custom values in Go templates for generating proto file comments, enhancing documentation customization based on different environments.
  - Added a new flag `goTemplateArgs` to provide custom values that can override keys in Go templates, improving template flexibility.

- **Documentation**
  - Updated documentation with instructions on enabling `use_go_templates` and specifying custom values using `go_template_args`.
  - Added examples demonstrating the use of custom values within proto file comments.

- **Bug Fixes**
  - Implemented validation to ensure `goTemplateArgs` is used only when `use_go_templates` is enabled, preventing potential configuration errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->