### PR TITLE
(fix) remove internal comments from generated protoComments

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -2476,6 +2476,7 @@ func protoComments(reg *descriptor.Registry, file *descriptor.File, outers []str
 			// - trim every line only if that is the case
 			// - join by \n
 			comments = strings.ReplaceAll(comments, "\n ", "\n")
+			comments = removeInternalComments(comments)
 		}
 		if loc.TrailingComments != nil {
 			trailing := strings.TrimSpace(*loc.TrailingComments)

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -10473,6 +10473,36 @@ func TestUpdatePaths(t *testing.T) {
 	}
 }
 
+// Test that enum values have internal comments removed
+func TestEnumValueProtoComments(t *testing.T) {
+	reg := descriptor.NewRegistry()
+	name := "kind"
+	comments := "(-- this is a comment --)"
+
+	enum := &descriptor.Enum{
+		EnumDescriptorProto: &descriptorpb.EnumDescriptorProto{
+			Name: &name,
+		},
+		File: &descriptor.File{
+			FileDescriptorProto: &descriptorpb.FileDescriptorProto{
+				Name:    new(string),
+				Package: new(string),
+				SourceCodeInfo: &descriptorpb.SourceCodeInfo{
+					Location: []*descriptorpb.SourceCodeInfo_Location{
+						&descriptorpb.SourceCodeInfo_Location{
+							LeadingComments: &comments,
+						},
+					},
+				},
+			},
+		},
+	}
+	comments = enumValueProtoComments(reg, enum)
+	if comments != "" {
+		t.Errorf("expected '', got '%v'", comments)
+	}
+}
+
 func MustMarshal(v interface{}) []byte {
 	b, err := json.Marshal(v)
 	if err != nil {


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #3778 .

#### Brief description of what is fixed or changed
Internal comments on enum types within proto schemas were leaking into the description field of generated query parameter definitions. 

This fix leverages the existing `removeInternalComments` method for removing internal comments from the enum proto type.

#### Other comments
I added a unit test that constructs an enum type with a similar definition as to the one that I saw was generated through the code generator. If there is a better unit testing strategy here please let me know and I'll update the PR. 

Verified fixed through reproducing the bug before and after this code change.
https://github.com/grpc-ecosystem/grpc-gateway/issues/3778#issue-2021381754

### Verification steps:
1. Build `protoc-gen-openapiv2` by executing `go build` in `protoc-gen-openapiv2/`.
2. Generate code with binary present in path
```
$ PATH=$PATH:<path_to_dir>/protoc-gen-openapiv2/ buf generate
```

_**buf.yaml**_
```
version: v1
breaking:
  use:
    - FILE
lint:
  use:
    - DEFAULT
deps:
  - buf.build/googleapis/googleapis
```

_**buf.gen.yaml**_
```
version: v1
plugins:
  - plugin: openapiv2 # references local binary built with fix
    out: gen/openapiv2
    opt:
      - remove_internal_comments=true
```

_**example/v1/example.proto**_
```
syntax = "proto3";

package example.v1;

import "google/api/annotations.proto";

option go_package = "./";

service ExampleService {
  rpc Example(ExampleRequest) returns (ExampleResponse) {
    option (google.api.http) = {
      post: "/example"
      body: "example"
    };
  }
}

enum ExampleKind {
  // (-- aip.dev/not-precedent: This preceded the AIP standards
  // buf:lint:ignore ENUM_ZERO_VALUE_SUFFIX --)
  FIRST = 0;
  SECOND = 1;
}

message Example {}

message ExampleRequest {
  Example example = 1;
  ExampleKind kind = 2;
}

message ExampleResponse {}

```

##### Full Output of generated swagger against this change:
```
{
  "swagger": "2.0",
  "info": {
    "title": "example/v1/example.proto",
    "version": "version not set"
  },
  "tags": [
    {
      "name": "ExampleService"
    }
  ],
  "consumes": [
    "application/json"
  ],
  "produces": [
    "application/json"
  ],
  "paths": {
    "/example": {
      "post": {
        "operationId": "ExampleService_Example",
        "responses": {
          "200": {
            "description": "A successful response.",
            "schema": {
              "$ref": "#/definitions/v1ExampleResponse"
            }
          },
          "default": {
            "description": "An unexpected error response.",
            "schema": {
              "$ref": "#/definitions/rpcStatus"
            }
          }
        },
        "parameters": [
          {
            "name": "example",
            "in": "body",
            "required": true,
            "schema": {
              "$ref": "#/definitions/examplev1Example"
            }
          },
          {
            "name": "kind",
            "in": "query",
            "required": false,
            "type": "string",
            "enum": [
              "FIRST",
              "SECOND"
            ],
            "default": "FIRST"
          }
        ],
        "tags": [
          "ExampleService"
        ]
      }
    }
  },
  "definitions": {
    "examplev1Example": {
      "type": "object"
    },
    "protobufAny": {
      "type": "object",
      "properties": {
        "@type": {
          "type": "string"
        }
      },
      "additionalProperties": {}
    },
    "rpcStatus": {
      "type": "object",
      "properties": {
        "code": {
          "type": "integer",
          "format": "int32"
        },
        "message": {
          "type": "string"
        },
        "details": {
          "type": "array",
          "items": {
            "type": "object",
            "$ref": "#/definitions/protobufAny"
          }
        }
      }
    },
    "v1ExampleKind": {
      "type": "string",
      "enum": [
        "FIRST",
        "SECOND"
      ],
      "default": "FIRST"
    },
    "v1ExampleResponse": {
      "type": "object"
    }
  }
}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Internal comments are now automatically removed to enhance the clarity of public documentation.

- **Tests**
  - Implemented new tests to ensure internal comments are correctly stripped from enum values in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->