### PR TITLE
If no subfields are set in a map, add the field to fieldMask

### DIFF
--- a/runtime/fieldmask.go
+++ b/runtime/fieldmask.go
@@ -41,7 +41,7 @@ func FieldMaskFromRequestBody(r io.Reader, msg proto.Message) (*field_mask.Field
 
 		m, ok := item.node.(map[string]interface{})
 		switch {
-		case ok:
+		case ok && len(m) > 0:
 			// if the item is an object, then enqueue all of its children
 			for k, v := range m {
 				if item.msg == nil {
@@ -96,6 +96,8 @@ func FieldMaskFromRequestBody(r io.Reader, msg proto.Message) (*field_mask.Field
 					queue = append(queue, child)
 				}
 			}
+		case ok && len(m) == 0:
+			fallthrough
 		case len(item.path) > 0:
 			// otherwise, it's a leaf node so print its path
 			fm.Paths = append(fm.Paths, item.path)

--- a/runtime/fieldmask_test.go
+++ b/runtime/fieldmask_test.go
@@ -29,8 +29,13 @@ func TestFieldMaskFromRequestBody(t *testing.T) {
 			expected: newFieldMask(),
 		},
 		{
-			name: "simple",
-
+			name:     "EmptyMessage",
+			msg:      &examplepb.ABitOfEverything{},
+			input:    `{"oneof_empty": {}}`,
+			expected: newFieldMask("oneof_empty"),
+		},
+		{
+			name:     "simple",
 			msg:      &examplepb.ABitOfEverything{},
 			input:    `{"uuid":"1234", "floatValue":3.14}`,
 			expected: newFieldMask("uuid", "float_value"),


### PR DESCRIPTION
If no subfields are set, the user might still want to set the default values of the map/object. In this case, add the parent field to fieldMask



#### References to other Issues or PRs

Fixes #3866


#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

yes
#### Brief description of what is fixed or changed

If no subfields are set for a map/object, the user might still want to set the default values of the map/object. In this case, add the parent field to fieldMask

#### Other comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of object lengths in field mask processing.
	- Enhanced test coverage for field mask functionality with refined test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->