### PR TITLE
Parse request body when using X-HTTP-Method-Override header

### DIFF
--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -341,13 +341,13 @@ func (s *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if override := r.Header.Get("X-HTTP-Method-Override"); override != "" && s.isPathLengthFallback(r) {
-		r.Method = strings.ToUpper(override)
 		if err := r.ParseForm(); err != nil {
 			_, outboundMarshaler := MarshalerForRequest(s, r)
 			sterr := status.Error(codes.InvalidArgument, err.Error())
 			s.errorHandler(ctx, s, outboundMarshaler, w, r, sterr)
 			return
 		}
+		r.Method = strings.ToUpper(override)
 	}
 
 	var pathComponents []string

--- a/runtime/mux_test.go
+++ b/runtime/mux_test.go
@@ -607,6 +607,19 @@ func TestMuxServeHTTP(t *testing.T) {
 	}
 }
 
+func TestServeHTTP_WithMethodOverrideAndFormParsing(t *testing.T) {
+	r := httptest.NewRequest("POST", "/foo", strings.NewReader("bar=hoge"))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Set("X-HTTP-Method-Override", "GET")
+	w := httptest.NewRecorder()
+
+	runtime.NewServeMux().ServeHTTP(w, r)
+
+	if r.FormValue("bar") != "hoge" {
+		t.Error("form is not parsed")
+	}
+}
+
 var defaultHeaderMatcherTests = []struct {
 	name     string
 	in       string


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

Fixes #3688

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

Fix to parse request body when using X-HTTP-Method-Override header

#### Other comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logic flow for HTTP method override in conjunction with form parsing.

- **Tests**
	- Added tests to ensure proper behavior of form parsing with HTTP method override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->