### PR TITLE
chore(examples): add one example to log request body when the status code is non 200

### DIFF
--- a/docs/docs/operations/logging.md
+++ b/docs/docs/operations/logging.md
@@ -1,0 +1,58 @@
+---
+layout: default
+title: Logging the request body pattern for a request
+nav_order: 5
+parent: Operations
+---
+
+# Logging the request body pattern for a request
+
+If you want to log the request body in the `customErrorHandler` middleware, unfortunately the request body has been consumed in the `customErrorHandler` middleware and can't be read again. To log the request body, you can use one middleware to buffer the request body before it's consumed.
+
+1. `logRequestBody` middleware，which logs the request body when the response status code is not 200.
+
+```go
+type logResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rsp *logResponseWriter) WriteHeader(code int) {
+	rsp.statusCode = code
+	rsp.ResponseWriter.WriteHeader(code)
+}
+
+func newLogResponseWriter(w http.ResponseWriter) *logResponseWriter {
+	return &logResponseWriter{w, http.StatusOK}
+}
+
+// logRequestBody logs the request body when the response status code is not 200.
+func logRequestBody(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lw := newLogResponseWriter(w)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("grpc server read request body err %+v", err), http.StatusBadRequest)
+			return
+		}
+		clonedR := r.Clone(r.Context())
+		clonedR.Body = io.NopCloser(bytes.NewReader(body))
+
+		h.ServeHTTP(lw, clonedR)
+
+		if lw.statusCode != http.StatusOK {
+			grpclog.Errorf("http error %+v request body %+v", lw.statusCode, string(body))
+		}
+	})
+}
+```
+
+2. Wrap the `logRequestBody` middleware with the `http.ServeMux`:
+
+```go
+    mux := http.NewServeMux()
+
+    s := &http.Server{
+        Handler: logRequestBody(mux),
+    }
+```

--- a/examples/internal/gateway/handlers.go
+++ b/examples/internal/gateway/handlers.go
@@ -92,7 +92,6 @@ func logRequestBody(h http.Handler) http.Handler {
 			return
 		}
 		clonedR := r.Clone(r.Context())
-		r.Body = io.NopCloser(bytes.NewReader(body))
 		clonedR.Body = io.NopCloser(bytes.NewReader(body))
 
 		h.ServeHTTP(lw, clonedR)

--- a/examples/internal/gateway/handlers.go
+++ b/examples/internal/gateway/handlers.go
@@ -1,7 +1,9 @@
 package gateway
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"path"
 	"strings"
@@ -27,7 +29,7 @@ func openAPIServer(dir string) http.HandlerFunc {
 	}
 }
 
-// allowCORS allows Cross Origin Resoruce Sharing from any origin.
+// allowCORS allows Cross Origin Resource Sharing from any origin.
 // Don't do this without consideration in production systems.
 func allowCORS(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -63,4 +65,40 @@ func healthzServer(conn *grpc.ClientConn) http.HandlerFunc {
 		}
 		fmt.Fprintln(w, "ok")
 	}
+}
+
+type logResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rsp *logResponseWriter) WriteHeader(code int) {
+	rsp.statusCode = code
+	rsp.ResponseWriter.WriteHeader(code)
+}
+
+func newLogResponseWriter(w http.ResponseWriter) *logResponseWriter {
+	return &logResponseWriter{w, http.StatusOK}
+}
+
+// logRequestBody logs the request body when the response status code is not 200.
+// This addresses the issue of being unable to retrieve the request body in the customErrorHandler middleware.
+func logRequestBody(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lw := newLogResponseWriter(w)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("grpc server read request body err %+v", err), http.StatusBadRequest)
+			return
+		}
+		clonedR := r.Clone(r.Context())
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		clonedR.Body = io.NopCloser(bytes.NewReader(body))
+
+		h.ServeHTTP(lw, clonedR)
+
+		if lw.statusCode != http.StatusOK {
+			grpclog.Errorf("http error %+v request body %+v", lw.statusCode, string(body))
+		}
+	})
 }

--- a/examples/internal/gateway/main.go
+++ b/examples/internal/gateway/main.go
@@ -58,7 +58,7 @@ func Run(ctx context.Context, opts Options) error {
 
 	s := &http.Server{
 		Addr:    opts.Addr,
-		Handler: allowCORS(mux),
+		Handler: logRequestBody(allowCORS(mux)),
 	}
 	go func() {
 		<-ctx.Done()


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

Add one sample to resolve the issue https://github.com/grpc-ecosystem/grpc-gateway/issues/3780

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

One outer wrapper to clone the request body, since the body of the request has been consumed in the customErrorHandler.

#### Other comments
