### PR TITLE
feat(bazel): surface --disable_default_responses in rule def

### DIFF
--- a/protoc-gen-openapiv2/defs.bzl
+++ b/protoc-gen-openapiv2/defs.bzl
@@ -73,7 +73,8 @@ def _run_proto_gen_openapi(
         openapi_configuration,
         generate_unbound_methods,
         visibility_restriction_selectors,
-        use_allof_for_refs):
+        use_allof_for_refs,
+        disable_default_responses):
     args = actions.args()
 
     args.add("--plugin", "protoc-gen-openapiv2=%s" % protoc_gen_openapiv2.path)
@@ -143,6 +144,9 @@ def _run_proto_gen_openapi(
 
     if use_allof_for_refs:
         args.add("--openapiv2_opt", "use_allof_for_refs=true")
+
+    if disable_default_responses:
+        args.add("--openapiv2_opt", "disable_default_responses=true")
 
     args.add("--openapiv2_opt", "repeated_path_param_separator=%s" % repeated_path_param_separator)
 
@@ -250,6 +254,7 @@ def _proto_gen_openapi_impl(ctx):
                     generate_unbound_methods = ctx.attr.generate_unbound_methods,
                     visibility_restriction_selectors = ctx.attr.visibility_restriction_selectors,
                     use_allof_for_refs = ctx.attr.use_allof_for_refs,
+                    disable_default_responses = ctx.attr.disable_default_responses,
                 ),
             ),
         ),
@@ -397,6 +402,13 @@ protoc_gen_openapiv2 = rule(
             mandatory = False,
             doc = "if set, will use allOf as container for $ref to preserve" +
                   " same-level properties.",
+        ),
+        "disable_default_responses": attr.bool(
+            default = False,
+            mandatory = False,
+            doc = "if set, disables generation of default responses. Useful" +
+                  " if you have to support custom response codes that are" +
+                  " not 200."
         ),
         "_protoc": attr.label(
             default = "@com_google_protobuf//:protoc",

--- a/protoc-gen-openapiv2/defs.bzl
+++ b/protoc-gen-openapiv2/defs.bzl
@@ -408,7 +408,7 @@ protoc_gen_openapiv2 = rule(
             mandatory = False,
             doc = "if set, disables generation of default responses. Useful" +
                   " if you have to support custom response codes that are" +
-                  " not 200."
+                  " not 200.",
         ),
         "_protoc": attr.label(
             default = "@com_google_protobuf//:protoc",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

Fixes #4123

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)? Yes

#### Brief description of what is fixed or changed

Surfaces the --disable_default_responses flag for the openapi spec generator in the protoc_gen_openapiv2 rule.

#### Other comments

The --disable_default_responses was implemented in [pull/3006](https://github.com/grpc-ecosystem/grpc-gateway/pull/3006)

