### PR TITLE
docs/mapping/examples.md: update CoreOS example GitHub branch to `master` branch

### DIFF
--- a/docs/docs/mapping/examples.md
+++ b/docs/docs/mapping/examples.md
@@ -23,5 +23,5 @@ Examples are available under `examples/internal` directory.
   entrypoint of the generated reverse proxy.
 
 To use the same port for custom HTTP handlers (e.g. serving `swagger.json`),
-gRPC-Gateway, and a gRPC server, see [this code example by CoreOS](https://github.com/philips/grpc-gateway-example/blob/main/cmd/serve.go) (and it's accompanying
+gRPC-Gateway, and a gRPC server, see [this code example by CoreOS](https://github.com/philips/grpc-gateway-example/blob/master/cmd/serve.go) (and it's accompanying
 [blog post](https://coreos.com/blog/grpc-protobufs-swagger.html)).


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs
N/A

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?
Yes

#### Brief description of what is fixed or changed
Changing CoreOS example GitHub branch in `docs/docs/mapping/examples.md` to be `master` instead of `main` since `main` branch is not found.
#### Other comments
N/A