### PR TITLE
#4238 Added the WithWriteContentLength ServerMuxOption

### DIFF
--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -177,7 +177,7 @@ func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marsha
 		return
 	}
 
-	if mux.writeContentLength {
+	if !doForwardTrailers && mux.writeContentLength {
 		w.Header().Set("Content-Length", strconv.Itoa(len(buf)))
 	}
 

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -177,7 +177,7 @@ func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marsha
 		return
 	}
 
-	if !doForwardTrailers && mux.writeContentLength {
+	if !doForwardTrailers {
 		w.Header().Set("Content-Length", strconv.Itoa(len(buf)))
 	}
 

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/textproto"
+	"strconv"
 	"strings"
 
 	"google.golang.org/genproto/googleapis/api/httpbody"
@@ -174,6 +175,10 @@ func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marsha
 		grpclog.Infof("Marshal error: %v", err)
 		HTTPError(ctx, mux, marshaler, w, req, err)
 		return
+	}
+
+	if mux.writeContentLength {
+		w.Header().Set("Content-Length", strconv.Itoa(len(buf)))
 	}
 
 	if _, err = w.Write(buf); err != nil {

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -64,7 +64,6 @@ type ServeMux struct {
 	routingErrorHandler       RoutingErrorHandlerFunc
 	disablePathLengthFallback bool
 	unescapingMode            UnescapingMode
-	writeContentLength        bool
 }
 
 // ServeMuxOption is an option that can be given to a ServeMux on construction.
@@ -222,13 +221,6 @@ func WithRoutingErrorHandler(fn RoutingErrorHandlerFunc) ServeMuxOption {
 func WithDisablePathLengthFallback() ServeMuxOption {
 	return func(serveMux *ServeMux) {
 		serveMux.disablePathLengthFallback = true
-	}
-}
-
-// WithWriteContentLength returns a ServeMuxOption to enable writing content length on non-streaming responses
-func WithWriteContentLength() ServeMuxOption {
-	return func(serveMux *ServeMux) {
-		serveMux.writeContentLength = true
 	}
 }
 

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -64,6 +64,7 @@ type ServeMux struct {
 	routingErrorHandler       RoutingErrorHandlerFunc
 	disablePathLengthFallback bool
 	unescapingMode            UnescapingMode
+	writeContentLength        bool
 }
 
 // ServeMuxOption is an option that can be given to a ServeMux on construction.
@@ -221,6 +222,13 @@ func WithRoutingErrorHandler(fn RoutingErrorHandlerFunc) ServeMuxOption {
 func WithDisablePathLengthFallback() ServeMuxOption {
 	return func(serveMux *ServeMux) {
 		serveMux.disablePathLengthFallback = true
+	}
+}
+
+// WithWriteContentLength returns a ServeMuxOption to enable writing content length on non-streaming responses
+func WithWriteContentLength() ServeMuxOption {
+	return func(serveMux *ServeMux) {
+		serveMux.writeContentLength = true
 	}
 }
 


### PR DESCRIPTION
This PR Fixes #4238.  The GRPC Gateway is currently relying on the default behavior of w.Write, which will only set Content-Length on small messages by default.  For users who are running GRPC Gateway behind a CDN (i.e. CloudFront), this means they cannot take advantage of automatic compression handling for client requests.

Always setting the Content-Length header, isn't a great option, as middleware/forwardResponseOptions may be mutating the response and could lead to an invalid Content-Length being printed.  While a forwardResponseOption could be used to write Content-Length, this would result in a double marshaling of the protobuf message and could potentially be incorrect in special cases.

This fix should be backwards compatible and avoids the downsides discussed above.