### PR TITLE
Added support for writing Etag headers and handling If-None-Match request headers

### DIFF
--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -2,6 +2,8 @@ package runtime
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"errors"
 	"io"
 	"net/http"
@@ -181,8 +183,25 @@ func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marsha
 		w.Header().Set("Content-Length", strconv.Itoa(len(buf)))
 	}
 
-	if _, err = w.Write(buf); err != nil {
-		grpclog.Infof("Failed to write response: %v", err)
+	// Generate an Etag for any messages larger than 100 bytes.
+	// Writing the Etag in the response takes 39 bytes, so it's not worth doing for smaller messages.
+	etag := ""
+	if len(buf) > 100 {
+		h := md5.New()
+		h.Write(buf)
+		etag = hex.EncodeToString(h.Sum(nil))
+		w.Header().Set("Etag", etag)
+	}
+
+	// Check if the client has provided an Etag and if it matches the generated Etag.
+	// If it does, send a 304 Not Modified response.
+	ifNoneMatch := req.Header.Get("If-None-Match")
+	if ifNoneMatch != "" && ifNoneMatch == etag {
+		w.WriteHeader(http.StatusNotModified)
+	} else {
+		if _, err = w.Write(buf); err != nil {
+			grpclog.Infof("Failed to write response: %v", err)
+		}
 	}
 
 	if doForwardTrailers {

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -183,14 +183,14 @@ func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marsha
 		w.Header().Set("Content-Length", strconv.Itoa(len(buf)))
 	}
 
-	// Generate an Etag for any messages larger than 100 bytes.
+	// Generate an Etag for any GET requests with messages larger than 100 bytes.
 	// Writing the Etag in the response takes 39 bytes, so it's not worth doing for smaller messages.
 	etag := ""
-	if len(buf) > 100 {
+	if len(buf) > 100 && req.Method == http.MethodGet {
 		h := md5.New()
 		h.Write(buf)
 		etag = hex.EncodeToString(h.Sum(nil))
-		w.Header().Set("Etag", etag)
+		w.Header().Set("Etag", "\""+etag+"\"")
 	}
 
 	// Check if the client has provided an Etag and if it matches the generated Etag.

--- a/runtime/handler_test.go
+++ b/runtime/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -542,7 +543,7 @@ func TestOutgoingTrailerMatcher(t *testing.T) {
 			headers: http.Header{
 				"Transfer-Encoding": []string{"chunked"},
 				"Content-Type":      []string{"application/json"},
-				"Trailer":           []string{"Grpc-Trailer-Foo", "Grpc-Trailer-Baz"},
+				"Trailer":           []string{"Grpc-Trailer-Baz", "Grpc-Trailer-Foo"},
 			},
 			trailer: http.Header{
 				"Grpc-Trailer-Foo": []string{"bar"},
@@ -607,7 +608,7 @@ func TestOutgoingTrailerMatcher(t *testing.T) {
 			headers: http.Header{
 				"Transfer-Encoding": []string{"chunked"},
 				"Content-Type":      []string{"application/json"},
-				"Trailer":           []string{"Grpc-Trailer-Foo", "Grpc-Trailer-Baz"},
+				"Trailer":           []string{"Grpc-Trailer-Baz", "Grpc-Trailer-Foo"},
 				"Etag":              []string{"\"41bf5d28a47f59b2a649e44f2607b0ea\""},
 			},
 			trailer: http.Header{
@@ -678,6 +679,9 @@ func TestOutgoingTrailerMatcher(t *testing.T) {
 			if w.StatusCode != http.StatusOK {
 				t.Fatalf("StatusCode %d want %d", w.StatusCode, http.StatusOK)
 			}
+
+			// Sort to the trailer headers to ensure the test is deterministic
+			sort.Strings(w.Header["Trailer"])
 
 			if !reflect.DeepEqual(w.Header, tc.headers) {
 				t.Fatalf("Header %v want %v", w.Header, tc.headers)


### PR DESCRIPTION
* Entity tags (Etag) are used to identify specific versions of a resource.  CDNs and Clients will use this in future requests to the server, using the If-None-Match header, to specify what data they already have and reduce the amount of data transferred if they already have the latest version.
* The Etag is only written for GET requests with messages greater than 100 bytes and is set to the md5 hash of the message.
* If a client sends the If-None-Match request header, the server will compare that value to the calculated etag.  If they match, it will return http.StatusNotModified (304) and not write the message in the response.
* Added additional tests to ensure the correct headers are being returned and that If-None-Match works.
