### PR TITLE
Fixing TestOutgoingTrailerMatcher, which was non-deterministic

### DIFF
--- a/runtime/handler_test.go
+++ b/runtime/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -416,7 +417,7 @@ func TestOutgoingTrailerMatcher(t *testing.T) {
 			headers: http.Header{
 				"Transfer-Encoding": []string{"chunked"},
 				"Content-Type":      []string{"application/json"},
-				"Trailer":           []string{"Grpc-Trailer-Foo", "Grpc-Trailer-Baz"},
+				"Trailer":           []string{"Grpc-Trailer-Baz", "Grpc-Trailer-Foo"},
 			},
 			trailer: http.Header{
 				"Grpc-Trailer-Foo": []string{"bar"},
@@ -482,6 +483,9 @@ func TestOutgoingTrailerMatcher(t *testing.T) {
 			if w.StatusCode != http.StatusOK {
 				t.Fatalf("StatusCode %d want %d", w.StatusCode, http.StatusOK)
 			}
+
+			// Sort to the trailer headers to ensure the test is deterministic
+			sort.Strings(w.Header["Trailer"])
 
 			if !reflect.DeepEqual(w.Header, tc.headers) {
 				t.Fatalf("Header %v want %v", w.Header, tc.headers)


### PR DESCRIPTION
Recently the test was updated to also check the headers.  The test will sometimes fail when checking the headers returned, when there were multiple pairs added to the TrailerMD.  This is caused by the TrailerMD being a map, which has a non-deterministic read order.  The simple fix is to just sorts the Trailer headers returned before comparing.

Fixes #4264 