### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ that's needed to generate a reverse-proxy with this library.
 ### Compile from source
 
 The following instructions assume you are using
-[Go Modules](https://github.com/golang/go/wiki/Modules) for dependency
+[Go Modules](https://go.dev/wiki/Modules) for dependency
 management. Use a
-[tool dependency](https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module)
+[tool dependency](https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module)
 to track the versions of the following executable packages:
 
 ```go


### PR DESCRIPTION
As #4321 and [#61940](https://github.com/golang/go/issues/61940) say, the wiki has been moved to [go.dev](https://go.dev/wiki). So we should update the url in the README.md as well.

This PR updates outdated url of wiki, from https://github.com/golang/go/wiki to https://go.dev/wiki