### PR TITLE
fix: handle `X-Forwarded-*` headers correctly

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -148,6 +148,12 @@ func annotateContext(ctx context.Context, mux *ServeMux, req *http.Request, rpcM
 	var pairs []string
 	for key, vals := range req.Header {
 		key = textproto.CanonicalMIMEHeaderKey(key)
+		switch key {
+		case xForwardedFor, xForwardedHost:
+			// Handled separately below
+			continue
+		}
+
 		for _, val := range vals {
 			// For backwards-compatibility, pass through 'authorization' header with no prefix.
 			if key == "Authorization" {
@@ -181,14 +187,14 @@ func annotateContext(ctx context.Context, mux *ServeMux, req *http.Request, rpcM
 		pairs = append(pairs, strings.ToLower(xForwardedHost), req.Host)
 	}
 
+	xff := req.Header.Values(xForwardedFor)
 	if addr := req.RemoteAddr; addr != "" {
 		if remoteIP, _, err := net.SplitHostPort(addr); err == nil {
-			if fwd := req.Header.Get(xForwardedFor); fwd == "" {
-				pairs = append(pairs, strings.ToLower(xForwardedFor), remoteIP)
-			} else {
-				pairs = append(pairs, strings.ToLower(xForwardedFor), fmt.Sprintf("%s, %s", fwd, remoteIP))
-			}
+			xff = append(xff, remoteIP)
 		}
+	}
+	if len(xff) > 0 {
+		pairs = append(pairs, strings.ToLower(xForwardedFor), strings.Join(xff, ", "))
 	}
 
 	if timeout != 0 {


### PR DESCRIPTION

#### References to other Issues or PRs

Fixes #4320

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

This fixes the handling of `X-Forwarded-For` and `X-Forwarded-Host` headers in two ways:

1. They are only added to the metadata once, even if they are allowed by the incoming header matcher.
2. If multiple `X-Forwarded-For` headers are present, they are joined, with the remote IP from the request appended.