### PR TITLE
feat: Use version info from runtime/debug:BuildInfo when installed by go build

### DIFF
--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -13,6 +13,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"strings"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/codegenerator"
@@ -50,6 +51,21 @@ func main() {
 	flag.Parse()
 
 	if *versionFlag {
+		if commit == "unknown" {
+			buildInfo, ok := debug.ReadBuildInfo()
+			if ok {
+				for _, setting := range buildInfo.Settings {
+					if setting.Key == "vcs.revision" {
+						commit = setting.Value
+					}
+					if setting.Key == "vcs.time" {
+						date = setting.Value
+					}
+				}
+				fmt.Printf("commit %v, built at %v\n", commit, date)
+				os.Exit(0)
+			}
+		}
 		fmt.Printf("Version %v, commit %v, built at %v\n", version, commit, date)
 		os.Exit(0)
 	}

--- a/protoc-gen-openapiv2/main.go
+++ b/protoc-gen-openapiv2/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"strings"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/codegenerator"
@@ -63,6 +64,21 @@ func main() {
 	flag.Parse()
 
 	if *versionFlag {
+		if commit == "unknown" {
+			buildInfo, ok := debug.ReadBuildInfo()
+			if ok {
+				for _, setting := range buildInfo.Settings {
+					if setting.Key == "vcs.revision" {
+						commit = setting.Value
+					}
+					if setting.Key == "vcs.time" {
+						date = setting.Value
+					}
+				}
+				fmt.Printf("commit %v, built at %v\n", commit, date)
+				os.Exit(0)
+			}
+		}
 		fmt.Printf("Version %v, commit %v, built at %v\n", version, commit, date)
 		os.Exit(0)
 	}


### PR DESCRIPTION
Implement of #4358 