### PR TITLE
feat: use buildInfo.Main.Version as version when installed by go install

### DIFF
--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -54,6 +54,7 @@ func main() {
 		if commit == "unknown" {
 			buildInfo, ok := debug.ReadBuildInfo()
 			if ok {
+				version = buildInfo.Main.Version
 				for _, setting := range buildInfo.Settings {
 					if setting.Key == "vcs.revision" {
 						commit = setting.Value
@@ -62,8 +63,6 @@ func main() {
 						date = setting.Value
 					}
 				}
-				fmt.Printf("commit %v, built at %v\n", commit, date)
-				os.Exit(0)
 			}
 		}
 		fmt.Printf("Version %v, commit %v, built at %v\n", version, commit, date)

--- a/protoc-gen-openapiv2/main.go
+++ b/protoc-gen-openapiv2/main.go
@@ -67,6 +67,7 @@ func main() {
 		if commit == "unknown" {
 			buildInfo, ok := debug.ReadBuildInfo()
 			if ok {
+				version = buildInfo.Main.Version
 				for _, setting := range buildInfo.Settings {
 					if setting.Key == "vcs.revision" {
 						commit = setting.Value
@@ -75,8 +76,6 @@ func main() {
 						date = setting.Value
 					}
 				}
-				fmt.Printf("commit %v, built at %v\n", commit, date)
-				os.Exit(0)
 			}
 		}
 		fmt.Printf("Version %v, commit %v, built at %v\n", version, commit, date)


### PR DESCRIPTION
implements #4358 

According to [seankhliao](https://github.com/seankhliao)'s [suggestion](https://github.com/golang/go/issues/67745#issuecomment-2142214415), we could use `runtime/debug.BuildInfo.Main.Version` as the binary's version instead of `buildInfo.Settings`, because: 

> in general, downloading a module strips any vcs info


----

And then check if it works:

### install by default

```bash
➜  go install github.com/makdon/grpc-gateway/v2/protoc-gen-grpc-gateway 
➜  protoc-gen-grpc-gateway --version
Version v2.20.2, commit unknown, built at unknown
```

### install by version

```bash
➜  go install github.com/makdon/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.20.2
go: downloading github.com/makdon/grpc-gateway/v2 v2.20.2
➜  protoc-gen-grpc-gateway --version
Version v2.20.2, commit unknown, built at unknown
```


### install by branch(with untag commit attached)

```bash
➜  go install github.com/makdon/grpc-gateway/v2/protoc-gen-grpc-gateway@main
go: downloading github.com/makdon/grpc-gateway/v2 v2.20.3-0.20240531160330-01066bb5aab7
➜  protoc-gen-grpc-gateway --version
Version v2.20.3-0.20240531160330-01066bb5aab7, commit unknown, built at unknown
```

I wonder if we need to parse `v2.20.3-0.20240531160330-01066bb5aab7` into version, commit, and commit time.

Which should be awared is that `v2.20.3` is a [pseudo version](https://go.dev/doc/modules/version-numbers) that version `v2.20.3` is not ready exists. So i prefer to keep it unparsed as `v2.20.3-0.20240531160330-01066bb5aab7` for it is not the real `v2.20.3`

