### PR TITLE
Fix build on 32bit systems

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -2654,13 +2654,13 @@ func TestValidateDefaultValueType(t *testing.T) {
 		},
 		{
 			"integer",
-			fmt.Sprint(math.MaxInt32 + 1),
+			fmt.Sprint(int64(math.MaxInt32) + 1),
 			"int32",
 			errors.New("the provided default value \"2147483648\" does not match provided format \"int32\""),
 		},
 		{
 			"integer",
-			fmt.Sprint(math.MaxInt64),
+			fmt.Sprint(int64(math.MaxInt64)),
 			"int64",
 			nil,
 		},


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Debian recently updated its packaging of this library to v2.20.0, and it fails to build on 32bit systems:

```
# github.com/grpc-ecosystem/grpc-gateway/protoc-gen-openapiv2/internal/genopenapi [github.com/grpc-ecosystem/grpc-gateway/protoc-gen-openapiv2/internal/genopenapi.test]
src/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-openapiv2/internal/genopenapi/template_test.go:2657:15: cannot use math.MaxInt32 + 1 (untyped int constant 2147483648) as int value in argument to fmt.Sprint (overflows)
src/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-openapiv2/internal/genopenapi/template_test.go:2663:15: cannot use math.MaxInt64 (untyped int constant 9223372036854775807) as int value in argument to fmt.Sprint (overflows)
FAIL	github.com/grpc-ecosystem/grpc-gateway/protoc-gen-openapiv2/internal/genopenapi [build failed]
```

(Full build log [available here](https://buildd.debian.org/status/fetch.php?pkg=golang-github-grpc-ecosystem-grpc-gateway&arch=i386&ver=2.20.0-1&stamp=1721907639&raw=0).)

Explicitly casting the two instances of `math.MaxInt{32,64}` to `int64` fixes the build. I've verified this change allows for successful building on both amd64 and i386 systems.