### PR TITLE
docs: add example to fully override http responses

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -9,6 +9,7 @@ production users that have added themselves (in alphabetical order):
   API of [Chef Automate](https://automate.chef.io/). Furthermore, the generated
   OpenAPI data serves as the basis for its [API documentation](https://automate.chef.io/docs/api/).
   The code is Open Source, [see `github.com/chef/automate`](https://github.com/chef/automate).
+- [Cho Tot](https://careers.chotot.com/about-us/) utilizes gRPC Gateway to seamlessly integrate HTTP and gRPC services, enabling efficient communication for both legacy and modern systems.
 - [Conduit](https://github.com/ConduitIO/conduit), a data streaming tool written in Go,
   uses the gRPC-Gateway since its very beginning to provide an HTTP API in addition to its gRPC API. 
   This makes it easier to integrate with Conduit, and the generated OpenAPI data is used in the documentation.

--- a/docs/docs/mapping/customizing_your_gateway.md
+++ b/docs/docs/mapping/customizing_your_gateway.md
@@ -292,7 +292,7 @@ service Greeter {
 
 ### Fully Overriding Custom HTTP Responses
 
-To fully override custom HTTP responses, you can use both a Forward Response Option and a Custom Marshaller.
+To fully override custom HTTP responses, you can use both a Forward Response Option and a Custom Marshaler.
 
 For example with proto response message as:
 
@@ -302,7 +302,7 @@ message CreateUserResponse {
 }
 ```
 
-The desired HTTP response:
+The default HTTP response:
 
 ```json5
 HTTP 200 OK
@@ -342,11 +342,11 @@ func forwardResponse(ctx context.Context, w http.ResponseWriter, m protoreflect.
 }
 ```
 
-Create a custom marshaller to format the response data which utilizes the builtin JSON marshaller:
+Create a custom marshaler to format the response data which utilizes the `JSONPb` marshaler as a fallback:
 
 ```go
 type ResponseWrapper struct {
-  runtime.JSONBuiltin
+  runtime.JSONPb
 }
 
 func (c *ResponseWrapper) Marshal(data any) ([]byte, error) {
@@ -360,7 +360,7 @@ func (c *ResponseWrapper) Marshal(data any) ([]byte, error) {
     }
   }
   // otherwise, use the default JSON marshaller
-  return json.Marshal(resp)
+  return c.JSONPb.Marshal(resp)
 }
 ```
 

--- a/docs/docs/mapping/customizing_your_gateway.md
+++ b/docs/docs/mapping/customizing_your_gateway.md
@@ -292,7 +292,7 @@ service Greeter {
 
 ### Fully Overriding Custom HTTP Responses
 
-To fully override custom HTTP responses, you can use both a Forward Response Option and a custom marshaller.
+To fully override custom HTTP responses, you can use both a Forward Response Option and a Custom Marshaller.
 
 For example with proto response message as:
 

--- a/docs/docs/mapping/customizing_your_gateway.md
+++ b/docs/docs/mapping/customizing_your_gateway.md
@@ -290,6 +290,85 @@ service Greeter {
 }
 ```
 
+### Fully Overriding Custom HTTP Responses
+
+To fully override custom HTTP responses, you can use both a Forward Response Option and a custom marshaller.
+
+For example with proto response message as:
+
+```proto
+message CreateUserResponse {
+  string name = 1;
+}
+```
+
+The desired HTTP response:
+
+```json5
+HTTP 200 OK
+Content-Type: application/json
+
+{"name":"John Doe"}
+```
+
+But you want to return a `201 Created` status code along with a custom response structure:
+
+```json5
+HTTP 201 Created
+Content-Type: application/json
+
+{"success":true,"data":{"name":"John Doe"}}
+```
+
+First, set up the gRPC-Gateway with the custom options:
+
+```go
+mux := runtime.NewServeMux(
+  runtime.WithMarshalerOption(runtime.MIMEWildcard, &ResponseWrapper{}),
+  runtime.WithForwardResponseOption(forwardResponse),
+)
+```
+
+Define the `forwardResponse` function to handle specific response types:
+
+```go
+func forwardResponse(ctx context.Context, w http.ResponseWriter, m protoreflect.ProtoMessage) error {
+  switch v := m.(type) {
+  case *pb.CreateUserResponse:
+    w.WriteHeader(http.StatusCreated)
+  }
+  // keep default behavior
+  return nil
+}
+```
+
+Create a custom marshaller to format the response data which utilizes the builtin JSON marshaller:
+
+```go
+type ResponseWrapper struct {
+  runtime.JSONBuiltin
+}
+
+func (c *ResponseWrapper) Marshal(data any) ([]byte, error) {
+  resp := data
+  switch v := data.(type) {
+  case *pb.CreateUserResponse:
+    // wrap the response in a custom structure
+    resp = map[string]any{
+      "success": true,
+      "data":    data,
+    }
+  }
+  // otherwise, use the default JSON marshaller
+  return json.Marshal(resp)
+}
+```
+
+In this setup:
+
+- The `forwardResponse` function intercepts the response and formats it as needed.
+- The `CustomPB` marshaller ensures that specific types of responses are wrapped in a custom structure before being sent to the client.
+
 ## Error handler
 
 To override error handling for a `*runtime.ServeMux`, use the
@@ -385,7 +464,7 @@ This method is not used outside of the initial routing.
 
 ### Customizing Routing Errors
 
-If you want to retain HTTP `405 Method Not Allowed` instead of allowing it to be converted to the equivalent of the gRPC `12 UNIMPLEMENTED`, which is  HTTP `501 Not Implmented` you can use the following example:
+If you want to retain HTTP `405 Method Not Allowed` instead of allowing it to be converted to the equivalent of the gRPC `12 UNIMPLEMENTED`, which is HTTP `501 Not Implmented` you can use the following example:
 
 ```go
 func handleRoutingError(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.Marshaler, w http.ResponseWriter, r *http.Request, httpStatus int) {
@@ -405,6 +484,7 @@ func handleRoutingError(ctx context.Context, mux *runtime.ServeMux, marshaler ru
 ```
 
 To use this routing error handler, construct the mux as follows:
+
 ```go
 mux := runtime.NewServeMux(
 	runtime.WithRoutingErrorHandler(handleRoutingError),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

Updates the documentation to include an example of fully overriding custom HTTP responses using a Forward Response Option and a Custom Marshaller.


#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Not actually a fix, but a guide that partially supports #4483 

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

- Provided an example with CreateUserResponse proto message.
- Demonstrated setting up gRPC-Gateway with custom options.
- Included a forwardResponse function and a custom marshaller ResponseWrapper.

