### PR TITLE
stop printing error logs in handleForwardResponseOptions

### DIFF
--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/textproto"
@@ -201,8 +202,7 @@ func handleForwardResponseOptions(ctx context.Context, w http.ResponseWriter, re
 	}
 	for _, opt := range opts {
 		if err := opt(ctx, w, resp); err != nil {
-			grpclog.Errorf("Error handling ForwardResponseOptions: %v", err)
-			return err
+			return fmt.Errorf("error handling ForwardResponseOptions: %w", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes: https://github.com/grpc-ecosystem/grpc-gateway/issues/4568

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

✅ Done

#### Brief description of what is fixed or changed

This will stop printing error messages when [handleForwardResponseOptions](https://github.com/taichimaeda/grpc-gateway/blob/52698e52d9261b141d8b062b1bd60a84bb47fae2/runtime/handler.go#L199) fails, and instead wraps the error and lets the error handler deal with the printing, which should hopefully fix the issue around 304 status responses.

#### Other comments

My major concern is that [DefaultHTTPErrorHandler](https://github.com/taichimaeda/grpc-gateway/blob/52698e52d9261b141d8b062b1bd60a84bb47fae2/runtime/errors.go#L93) seems to use the `err` only for getting the error status, and not for printing its message (correct me if I'm wrong) - will consider other solutions if this is not okay.