### PR TITLE
Remove extra $ to avoid copy-and-run failure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ import (
 Run `go mod tidy` to resolve the versions. Install by running
 
 ```sh
-$ go install \
+go install \
     github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway \
     github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2 \
     google.golang.org/protobuf/cmd/protoc-gen-go \


### PR DESCRIPTION
When copying `go install` command, there is an extra dollar sign, causing failure.

```
$ $ go install \
    github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway \
    github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2 \
    google.golang.org/protobuf/cmd/protoc-gen-go \
    google.golang.org/grpc/cmd/protoc-gen-go-grpc
zsh: command not found: $
```

