### PR TITLE
feat: add expand_slashed_path_patterns flag

### DIFF
--- a/docs/docs/mapping/customizing_openapi_output.md
+++ b/docs/docs/mapping/customizing_openapi_output.md
@@ -539,6 +539,52 @@ Note that path parameters in OpenAPI does not support values with `/`, as discus
 so tools as Swagger UI will URL encode any `/` provided as parameter value. A possible workaround for this is to write
 a custom post processor for your OAS file to replace any path parameter with `/` into multiple parameters.
 
+#### Expand path parameters containing sub-path segments
+
+Alternative to the above, you can enable the `expand_slashed_path_patterns` option to expand path parameters containing sub-path segments into the URI.
+
+For example, consider:
+```protobuf
+rpc GetBook(GetBookRequest) returns (Book) {
+  option (google.api.http) = {
+    get: "/v1/{name=publishers/*/books/*}"
+  };
+  option (google.api.method_signature) = "name";
+}
+```
+
+Where the `GetBook` has a path parameter `name` with a pattern `publishers/*/books/*`. When you enable the `expand_slashed_path_patterns=true` option all the path patterns with slashes are expanded into the URI and each wildcard in the pattern is transformed into new path parameter. For the previous protobuf definition, the generated schema is:
+
+```JSON
+{
+ "/v1/publishers/{publisher}/books/{book}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "publisher",
+            "in": "path",
+            "required": true,
+            "type": "string",
+          },
+          {
+            "name": "book",
+            "in": "path",
+            "required": true,
+            "type": "string",
+          }
+        ]
+      }
+    }
+}
+```
+
+The URI is now pretty descriptive and there are two path parameters `publisher` and `book` instead of one `name`. The name of the new parameters is derived from the path segment before the wildcard in the pattern.
+
+Caveats:
+
+- the fact that the original `name` parameter is missing might complicate the usage of the API if you intend to pass in the `name` parameters from the resources,
+- when the `expand_slashed_path_patterns` compiler flag is enabled, the [`path_param_name`](#path-parameters) field annotation is ignored.
+
 ### Output format
 
 By default the output format is JSON, but it is possible to configure it using the `output_format` option. Allowed values are: `json`, `yaml`. The output format will also change the extension of the output files.
@@ -1043,4 +1089,6 @@ definitions:
         type: string
 ```
 
+
 {% endraw %}
+

--- a/docs/docs/mapping/customizing_openapi_output.md
+++ b/docs/docs/mapping/customizing_openapi_output.md
@@ -541,7 +541,7 @@ a custom post processor for your OAS file to replace any path parameter with `/`
 
 #### Expand path parameters containing sub-path segments
 
-Alternative to the above, you can enable the `expand_slashed_path_patterns` option to expand path parameters containing sub-path segments into the URI.
+Alternative to the above, you can enable the `expand_slashed_path_patterns` compiler option to expand path parameters containing sub-path segments into the URI.
 
 For example, consider:
 ```protobuf
@@ -549,11 +549,10 @@ rpc GetBook(GetBookRequest) returns (Book) {
   option (google.api.http) = {
     get: "/v1/{name=publishers/*/books/*}"
   };
-  option (google.api.method_signature) = "name";
 }
 ```
 
-Where the `GetBook` has a path parameter `name` with a pattern `publishers/*/books/*`. When you enable the `expand_slashed_path_patterns=true` option all the path patterns with slashes are expanded into the URI and each wildcard in the pattern is transformed into new path parameter. For the previous protobuf definition, the generated schema is:
+Where the `GetBook` has a path parameter `name` with a pattern `publishers/*/books/*`. When you enable the `expand_slashed_path_patterns=true` option the path pattern is expanded into the URI and each wildcard in the pattern is transformed into new path parameter. The generated schema for previous protobuf is:
 
 ```JSON
 {

--- a/internal/descriptor/registry.go
+++ b/internal/descriptor/registry.go
@@ -164,7 +164,7 @@ type Registry struct {
 	// enableRpcDeprecation whether to process grpc method's deprecated option
 	enableRpcDeprecation bool
 
-	// expandSlashedPathPatterns, if true, for a path parameter carying a sub-path, described via parameter pattern (i.e.
+	// expandSlashedPathPatterns, if true, for a path parameter carrying a sub-path, described via parameter pattern (i.e.
 	// the pattern contains forward slashes), this will expand the _pattern_ into the URI and will _replace_ the parameter
 	// with new path parameters inferred from patterns wildcards.
 	//

--- a/internal/descriptor/registry.go
+++ b/internal/descriptor/registry.go
@@ -446,10 +446,6 @@ func (r *Registry) SetStandalone(standalone bool) {
 	r.standalone = standalone
 }
 
-func (r *Registry) GetStandalone() bool {
-	return r.standalone
-}
-
 // SetRecursiveDepth records the max recursion count
 func (r *Registry) SetRecursiveDepth(count int) {
 	r.recursiveDepth = count
@@ -904,12 +900,10 @@ func (r *Registry) GetEnableRpcDeprecation() bool {
 	return r.enableRpcDeprecation
 }
 
-// SetProto3OptionalNullable set proto3OtionalNullable
 func (r *Registry) SetExpandSlashedPathPatterns(expandSlashedPathPatterns bool) {
 	r.expandSlashedPathPatterns = expandSlashedPathPatterns
 }
 
-// SetProto3OptionalNullable set proto3OtionalNullable
 func (r *Registry) GetExpandSlashedPathPatterns() bool {
 	return r.expandSlashedPathPatterns
 }

--- a/internal/descriptor/registry.go
+++ b/internal/descriptor/registry.go
@@ -164,15 +164,16 @@ type Registry struct {
 	// enableRpcDeprecation whether to process grpc method's deprecated option
 	enableRpcDeprecation bool
 
-	// expandSlashedPathPatterns, if true, for a path parameter carying a sub-path, which is indicated via path parameter
-	// pattern (i.e. the parameter pattern contains forward slashes), this will expand the _pattern_ into the URI and will
-	// replace the parameter with wildcards from the _pattern_.
+	// expandSlashedPathPatterns, if true, for a path parameter carying a sub-path, described via parameter pattern (i.e.
+	// the pattern contains forward slashes), this will expand the _pattern_ into the URI and will _replace_ the parameter
+	// with new path parameters inferred from patterns wildcards.
 	//
-	// Example: let's have a Google AIP style path "/v1/{name=projects/*/locations/*}/datasets/{dataset_id}" with a "name"
-	// parameter that contains sub-path. With "expandSlashedPathPatterns" turned on, the generated URI will be
-	// "/v1/projects/{project}/locations/{location}/datasets/{dataset_id}". Note that the original "name" parameter is
-	// replaced with "project" and "location" parameters. This leads to more compliant and readable OpenAPI suitable for
-	// documentation purposes, but may complicate client implementation if you want to pass the original "name" parameter.
+	// Example: a Google AIP style path "/v1/{name=projects/*/locations/*}/datasets/{dataset}" with a "name" parameter
+	// containing sub-path will generate "/v1/projects/{project}/locations/{location}/datasets/{dataset}" path in OpenAPI.
+	// Note that the original "name" parameter is replaced with "project" and "location" parameters.
+	//
+	// This leads to more compliant and readable OpenAPI suitable for documentation, but may complicate client
+	// implementation if you want to pass the original "name" parameter.
 	expandSlashedPathPatterns bool
 }
 

--- a/internal/descriptor/registry.go
+++ b/internal/descriptor/registry.go
@@ -163,6 +163,17 @@ type Registry struct {
 
 	// enableRpcDeprecation whether to process grpc method's deprecated option
 	enableRpcDeprecation bool
+
+	// expandSlashedPathPatterns, if true, for a path parameter carying a sub-path, which is indicated via path parameter
+	// pattern (i.e. the parameter pattern contains forward slashes), this will expand the _pattern_ into the URI and will
+	// replace the parameter with wildcards from the _pattern_.
+	//
+	// Example: let's have a Google AIP style path "/v1/{name=projects/*/locations/*}/datasets/{dataset_id}" with a "name"
+	// parameter that contains sub-path. With "expandSlashedPathPatterns" turned on, the generated URI will be
+	// "/v1/projects/{project}/locations/{location}/datasets/{dataset_id}". Note that the original "name" parameter is
+	// replaced with "project" and "location" parameters. This leads to more compliant and readable OpenAPI suitable for
+	// documentation purposes, but may complicate client implementation if you want to pass the original "name" parameter.
+	expandSlashedPathPatterns bool
 }
 
 type repeatedFieldSeparator struct {
@@ -433,6 +444,10 @@ func (r *Registry) SetPrefix(prefix string) {
 // SetStandalone registers standalone flag to control package prefix
 func (r *Registry) SetStandalone(standalone bool) {
 	r.standalone = standalone
+}
+
+func (r *Registry) GetStandalone() bool {
+	return r.standalone
 }
 
 // SetRecursiveDepth records the max recursion count
@@ -887,4 +902,14 @@ func (r *Registry) SetEnableRpcDeprecation(enable bool) {
 // GetEnableRpcDeprecation returns enableRpcDeprecation
 func (r *Registry) GetEnableRpcDeprecation() bool {
 	return r.enableRpcDeprecation
+}
+
+// SetProto3OptionalNullable set proto3OtionalNullable
+func (r *Registry) SetExpandSlashedPathPatterns(expandSlashedPathPatterns bool) {
+	r.expandSlashedPathPatterns = expandSlashedPathPatterns
+}
+
+// SetProto3OptionalNullable set proto3OtionalNullable
+func (r *Registry) GetExpandSlashedPathPatterns() bool {
+	return r.expandSlashedPathPatterns
 }

--- a/protoc-gen-openapiv2/defs.bzl
+++ b/protoc-gen-openapiv2/defs.bzl
@@ -75,7 +75,8 @@ def _run_proto_gen_openapi(
         visibility_restriction_selectors,
         use_allof_for_refs,
         disable_default_responses,
-        enable_rpc_deprecation):
+        enable_rpc_deprecation,
+        expand_slashed_path_patterns):
     args = actions.args()
 
     args.add("--plugin", "protoc-gen-openapiv2=%s" % protoc_gen_openapiv2.path)
@@ -151,6 +152,9 @@ def _run_proto_gen_openapi(
 
     if enable_rpc_deprecation:
         args.add("--openapiv2_opt", "enable_rpc_deprecation=true")
+
+    if expand_slashed_path_patterns:
+        args.add("--openapiv2_opt", "expand_slashed_path_patterns=true")
 
     args.add("--openapiv2_opt", "repeated_path_param_separator=%s" % repeated_path_param_separator)
 
@@ -260,6 +264,7 @@ def _proto_gen_openapi_impl(ctx):
                     use_allof_for_refs = ctx.attr.use_allof_for_refs,
                     disable_default_responses = ctx.attr.disable_default_responses,
                     enable_rpc_deprecation = ctx.attr.enable_rpc_deprecation,
+                    expand_slashed_path_patterns = ctx.attr.expand_slashed_path_patterns,
                 ),
             ),
         ),
@@ -419,6 +424,13 @@ protoc_gen_openapiv2 = rule(
             default = False,
             mandatory = False,
             doc = "whether to process grpc method's deprecated option.",
+        ),
+        "expand_slashed_path_patterns": attr.bool(
+            default = False,
+            mandatory = False,
+            doc = "if set, expands path patterns containing slashes into URI." +
+                  " It also creates a new path parameter for each wildcard in " +
+                  " the path pattern.",
         ),
         "_protoc": attr.label(
             default = "@com_google_protobuf//:protoc",

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -1157,7 +1157,7 @@ func renderServiceTags(services []*descriptor.Service, reg *descriptor.Registry)
 // Returns:
 //
 //	The modified pathParts and pathParams slice.
-func expandPathPatterns(pathParts []string, pathParams []descriptor.Parameter) ([]string, []descriptor.Parameter) {
+func expandPathPatterns(pathParts []string, pathParams []descriptor.Parameter, reg *descriptor.Registry) ([]string, []descriptor.Parameter) {
 	expandedPathParts := []string{}
 	modifiedPathParams := pathParams
 	for _, pathPart := range pathParts {
@@ -1192,6 +1192,9 @@ func expandPathPatterns(pathParts []string, pathParams []descriptor.Parameter) (
 			}
 			lastPart := expandedPathParts[len(expandedPathParts)-1]
 			paramName := strings.TrimSuffix(lastPart, "s")
+			if reg.GetUseJSONNamesForFields() {
+				paramName = casing.JSONCamelCase(paramName)
+			}
 			expandedPathParts = append(expandedPathParts, "{"+paramName+"}")
 			newParam := descriptor.Parameter{
 				Target: &descriptor.Field{
@@ -1248,7 +1251,7 @@ func renderServices(services []*descriptor.Service, paths *openapiPathsObject, r
 				parts := templateToParts(b.PathTmpl.Template, reg, meth.RequestType.Fields, msgs)
 				pathParams := b.PathParams
 				if reg.GetExpandSlashedPathPatterns() {
-					parts, pathParams = expandPathPatterns(parts, pathParams)
+					parts, pathParams = expandPathPatterns(parts, pathParams, reg)
 				}
 				// extract any constraints specified in the path placeholders into ECMA regular expressions
 				pathParamRegexpMap := partsToRegexpMap(parts)

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -978,8 +978,18 @@ func resolveFullyQualifiedNameToOpenAPINames(messages []string, namingStrategy s
 
 var canRegexp = regexp.MustCompile("{([a-zA-Z][a-zA-Z0-9_.]*)([^}]*)}")
 
-// templateToParts will split a URL template as defined by https://github.com/googleapis/googleapis/blob/master/google/api/http.proto
-// into a string slice with each part as an element of the slice for use by `partsToOpenAPIPath` and `partsToRegexpMap`.
+// templateToParts splits a URL template into path segments for use by `partsToOpenAPIPath` and `partsToRegexpMap`.
+//
+// Parameters:
+//   - path:	The URL template as defined by https://github.com/googleapis/googleapis/blob/master/google/api/http.proto
+//   - reg:	The descriptor registry used to read compiler flags
+//   - fields:	The fields of the request message, only used when `useJSONNamesForFields` is true
+//   - msgs:	The Messages of the service binding, only used when `useJSONNamesForFields` is true
+//   - pathParams:	The path parameters of the service binding, only used when `expandSlashedPathPatterns` is true
+//
+// Returns:
+//
+//	The path segments of the URL template. When `expandSlashedPathPatterns` is true, also mutates the pathParams slice.
 func templateToParts(path string, reg *descriptor.Registry, fields []*descriptor.Field, msgs []*descriptor.Message, pathParams *[]descriptor.Parameter) []string {
 	// It seems like the right thing to do here is to just use
 	// strings.Split(path, "/") but that breaks badly when you hit a url like

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -1011,12 +1011,13 @@ pathLoop:
 			}
 			// Pop from the stack
 			depth--
-			buffer += string(char)
-			if reg.GetUseJSONNamesForFields() {
-				paramNameProto := strings.SplitN(buffer[1:], "=", 2)[0]
-				paramNameCamelCase := lowerCamelCase(paramNameProto, fields, msgs)
-				buffer = strings.Join([]string{"{", paramNameCamelCase, buffer[len(paramNameProto)+1:]}, "")
+			if !reg.GetUseJSONNamesForFields() {
+				buffer += string(char)
+				continue
 			}
+			paramNameProto := strings.SplitN(buffer[1:], "=", 2)[0]
+			paramNameCamelCase := lowerCamelCase(paramNameProto, fields, msgs)
+			buffer = strings.Join([]string{"{", paramNameCamelCase, buffer[len(paramNameProto)+1:], "}"}, "")
 		case '/':
 			if depth == 0 {
 				parts = append(parts, buffer)

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -4119,7 +4119,7 @@ func TestTemplateToOpenAPIPath(t *testing.T) {
 	}
 }
 
-func GetParameters(names []string) []descriptor.Parameter {
+func getParameters(names []string) []descriptor.Parameter {
 	params := make([]descriptor.Parameter, 0)
 	for _, name := range names {
 		params = append(params, descriptor.Parameter{
@@ -4149,11 +4149,11 @@ func TestTemplateToOpenAPIPathExpandSlashed(t *testing.T) {
 		expectedPathParams []string
 		useJSONNames       bool
 	}{
-		{"/v1/{name=projects/*/documents/*}:exportResults", "/v1/projects/{project}/documents/{document}:exportResults", GetParameters([]string{"name"}), []string{"project", "document"}, true},
-		{"/test/{name=*}", "/test/{name}", GetParameters([]string{"name"}), []string{"name"}, true},
-		{"/test/{name=*}/", "/test/{name}/", GetParameters([]string{"name"}), []string{"name"}, true},
-		{"/test/{name=test_cases/*}/", "/test/test_cases/{testCase}/", GetParameters([]string{"name"}), []string{"testCase"}, true},
-		{"/test/{name=test_cases/*}/", "/test/test_cases/{test_case}/", GetParameters([]string{"name"}), []string{"test_case"}, false},
+		{"/v1/{name=projects/*/documents/*}:exportResults", "/v1/projects/{project}/documents/{document}:exportResults", getParameters([]string{"name"}), []string{"project", "document"}, true},
+		{"/test/{name=*}", "/test/{name}", getParameters([]string{"name"}), []string{"name"}, true},
+		{"/test/{name=*}/", "/test/{name}/", getParameters([]string{"name"}), []string{"name"}, true},
+		{"/test/{name=test_cases/*}/", "/test/test_cases/{testCase}/", getParameters([]string{"name"}), []string{"testCase"}, true},
+		{"/test/{name=test_cases/*}/", "/test/test_cases/{test_case}/", getParameters([]string{"name"}), []string{"test_case"}, false},
 	}
 	reg := descriptor.NewRegistry()
 	reg.SetExpandSlashedPathPatterns(true)

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -4288,7 +4288,7 @@ func templateToRegexpMap(path string, reg *descriptor.Registry, fields []*descri
 }
 
 func templateToExpandedPath(path string, reg *descriptor.Registry, fields []*descriptor.Field, msgs []*descriptor.Message, pathParams []descriptor.Parameter) (string, []descriptor.Parameter) {
-	pathParts, pathParams := expandPathPatterns(templateToParts(path, reg, fields, msgs), pathParams)
+	pathParts, pathParams := expandPathPatterns(templateToParts(path, reg, fields, msgs), pathParams, reg)
 	return partsToOpenAPIPath(pathParts, make(map[string]string)), pathParams
 }
 

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -4159,12 +4159,12 @@ func TestTemplateToOpenAPIPathExpandSlashed(t *testing.T) {
 	reg.SetExpandSlashedPathPatterns(true)
 	for _, data := range tests {
 		reg.SetUseJSONNamesForFields(data.useJSONNames)
-		actual := templateToExpandedPath(data.input, reg, generateFieldsForJSONReservedName(), generateMsgsForJSONReservedName(), &data.pathParams)
-		if data.expected != actual {
-			t.Errorf("Expected templateToOpenAPIPath(%v) = %v, actual: %v", data.input, data.expected, actual)
+		actualParts, actualParams := templateToExpandedPath(data.input, reg, generateFieldsForJSONReservedName(), generateMsgsForJSONReservedName(), data.pathParams)
+		if data.expected != actualParts {
+			t.Errorf("Expected templateToOpenAPIPath(%v) = %v, actual: %v", data.input, data.expected, actualParts)
 		}
 		pathParamsNames := make([]string, 0)
-		for _, param := range data.pathParams {
+		for _, param := range actualParams {
 			pathParamsNames = append(pathParamsNames, param.FieldPath[0].Name)
 		}
 		if !reflect.DeepEqual(data.expectedPathParams, pathParamsNames) {
@@ -4287,8 +4287,9 @@ func templateToRegexpMap(path string, reg *descriptor.Registry, fields []*descri
 	return partsToRegexpMap(templateToParts(path, reg, fields, msgs))
 }
 
-func templateToExpandedPath(path string, reg *descriptor.Registry, fields []*descriptor.Field, msgs []*descriptor.Message, pathParams *[]descriptor.Parameter) string {
-	return partsToOpenAPIPath(expandPathPatterns(templateToParts(path, reg, fields, msgs), pathParams), make(map[string]string))
+func templateToExpandedPath(path string, reg *descriptor.Registry, fields []*descriptor.Field, msgs []*descriptor.Message, pathParams []descriptor.Parameter) (string, []descriptor.Parameter) {
+	pathParts, pathParams := expandPathPatterns(templateToParts(path, reg, fields, msgs), pathParams)
+	return partsToOpenAPIPath(pathParts, make(map[string]string)), pathParams
 }
 
 func TestFQMNToRegexpMap(t *testing.T) {

--- a/protoc-gen-openapiv2/main.go
+++ b/protoc-gen-openapiv2/main.go
@@ -50,6 +50,7 @@ var (
 	allowPatchFeature              = flag.Bool("allow_patch_feature", true, "whether to hide update_mask fields in PATCH requests from the generated swagger file.")
 	preserveRPCOrder               = flag.Bool("preserve_rpc_order", false, "if true, will ensure the order of paths emitted in openapi swagger files mirror the order of RPC methods found in proto files. If false, emitted paths will be ordered alphabetically.")
 	enableRpcDeprecation           = flag.Bool("enable_rpc_deprecation", false, "whether to process grpc method's deprecated option.")
+	expandSlashedPathPatterns      = flag.Bool("expand_slashed_path_patterns", false, "if set, expands path parameters with URI sub-paths into the URI. For example, \"/v1/{name=projects/*}/resource\" becomes \"/v1/projects/{project}/resource\".")
 
 	_ = flag.Bool("logtostderr", false, "Legacy glog compatibility. This flag is a no-op, you can safely remove it")
 )
@@ -173,6 +174,7 @@ func main() {
 	reg.SetAllowPatchFeature(*allowPatchFeature)
 	reg.SetPreserveRPCOrder(*preserveRPCOrder)
 	reg.SetEnableRpcDeprecation(*enableRpcDeprecation)
+	reg.SetExpandSlashedPathPatterns(*expandSlashedPathPatterns)
 
 	if err := reg.SetRepeatedPathParamSeparator(*repeatedPathParamSeparator); err != nil {
 		emitError(err)


### PR DESCRIPTION
#### References to other Issues or PRs

Closes #4784 - a feature request

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes 👍 

#### Brief description of what is fixed or changed

This adds an experimental flag into the OpenAPI generator, that expands path patterns containing URI sub-paths into the URI with new path parameters. This improves the readability and OpenAPI compatibility of protobuf APIs based on Google AIP. For more context read the [linked issue](https://github.com/grpc-ecosystem/grpc-gateway/issues/4784).
