### PR TITLE
feat: expose invalid argument error to clients in bidirectional streaming (#4795)

### DIFF
--- a/examples/internal/proto/examplepb/flow_combination.pb.gw.go
+++ b/examples/internal/proto/examplepb/flow_combination.pb.gw.go
@@ -1900,8 +1900,7 @@ func RegisterFlowCombinationHandlerClient(ctx context.Context, mux *runtime.Serv
 			return
 		}
 		go func() {
-			for {
-				err := <-reqErrChan
+			for err := range reqErrChan {
 				if err != nil {
 					runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 					if err := resp.CloseSend(); err != nil {

--- a/examples/internal/proto/examplepb/flow_combination.pb.gw.go
+++ b/examples/internal/proto/examplepb/flow_combination.pb.gw.go
@@ -116,6 +116,7 @@ func request_FlowCombination_StreamEmptyStream_0(ctx context.Context, marshaler 
 	stream, err := client.StreamEmptyStream(ctx)
 	if err != nil {
 		grpclog.Errorf("Failed to start streaming: %v", err)
+		close(errChan)
 		return nil, metadata, errChan, err
 	}
 	dec := marshaler.NewDecoder(req.Body)
@@ -142,6 +143,9 @@ func request_FlowCombination_StreamEmptyStream_0(ctx context.Context, marshaler 
 				errChan <- err
 				break
 			}
+		}
+		if err := stream.CloseSend(); err != nil {
+			grpclog.Errorf("Failed to terminate client stream: %v", err)
 		}
 	}()
 	header, err := stream.Header()
@@ -1905,9 +1909,6 @@ func RegisterFlowCombinationHandlerClient(ctx context.Context, mux *runtime.Serv
 				if err != nil && err != io.EOF {
 					runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 				}
-			}
-			if err := resp.CloseSend(); err != nil {
-				grpclog.Errorf("Failed to terminate client stream: %v", err)
 			}
 		}()
 

--- a/examples/internal/proto/examplepb/stream.pb.gw.go
+++ b/examples/internal/proto/examplepb/stream.pb.gw.go
@@ -130,13 +130,13 @@ func request_StreamService_BulkEcho_0(ctx context.Context, marshaler runtime.Mar
 		return nil
 	}
 	go func() {
+		defer close(errChan)
 		for {
 			if err := handleSend(); err != nil {
 				errChan <- err
 				break
 			}
 		}
-		close(errChan)
 	}()
 	header, err := stream.Header()
 	if err != nil {
@@ -314,9 +314,10 @@ func RegisterStreamServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 			return
 		}
 		go func() {
-			err := <-reqErrChan
-			if err != io.EOF {
-				runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			for err := range reqErrChan {
+				if err != nil && err != io.EOF {
+					runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+				}
 			}
 			if err := resp.CloseSend(); err != nil {
 				grpclog.Errorf("Failed to terminate client stream: %v", err)

--- a/examples/internal/proto/examplepb/stream.pb.gw.go
+++ b/examples/internal/proto/examplepb/stream.pb.gw.go
@@ -313,8 +313,7 @@ func RegisterStreamServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 			return
 		}
 		go func() {
-			for {
-				err := <-reqErrChan
+			for err := range reqErrChan {
 				if err != nil {
 					runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 					if err := resp.CloseSend(); err != nil {

--- a/protoc-gen-grpc-gateway/internal/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/internal/gengateway/template.go
@@ -465,13 +465,13 @@ var (
 		return nil
 	}
 	go func() {
+		defer close(errChan)
 		for {
 			if err := handleSend(); err != nil {
 				errChan <- err
 				break
 			}
 		}
-		close(errChan)
 	}()
 	header, err := stream.Header()
 	if err != nil {
@@ -741,9 +741,10 @@ func Register{{$svc.GetName}}{{$.RegisterFuncSuffix}}Client(ctx context.Context,
 		}
 		{{- if and $m.GetClientStreaming $m.GetServerStreaming }}
 		go func() {
-			err := <-reqErrChan
-			if err != io.EOF {
-				runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			for err := range reqErrChan {
+				if err != nil && err != io.EOF {
+					runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+				}
 			}
 			if err := resp.CloseSend(); err != nil {
 				grpclog.Errorf("Failed to terminate client stream: %v", err)

--- a/protoc-gen-grpc-gateway/internal/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/internal/gengateway/template.go
@@ -741,13 +741,12 @@ func Register{{$svc.GetName}}{{$.RegisterFuncSuffix}}Client(ctx context.Context,
 		}
 		{{- if and $m.GetClientStreaming $m.GetServerStreaming }}
 		go func() {
-			for err := range reqErrChan {
-				if err != io.EOF {
-					runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-				}
-				if err := resp.CloseSend(); err != nil {
-					grpclog.Errorf("Failed to terminate client stream: %v", err)
-				}
+			err := <-reqErrChan
+			if err != io.EOF {
+				runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			}
+			if err := resp.CloseSend(); err != nil {
+				grpclog.Errorf("Failed to terminate client stream: %v", err)
 			}
 		}()
 		{{- end }}

--- a/protoc-gen-grpc-gateway/internal/gengateway/template_test.go
+++ b/protoc-gen-grpc-gateway/internal/gengateway/template_test.go
@@ -316,7 +316,7 @@ func TestApplyTemplateRequestWithClientStreaming(t *testing.T) {
 		},
 		{
 			serverStreaming: true,
-			sigWant:         `func request_ExampleService_Echo_0(ctx context.Context, marshaler runtime.Marshaler, client ExampleServiceClient, req *http.Request, pathParams map[string]string) (ExampleService_EchoClient, runtime.ServerMetadata, error) {`,
+			sigWant:         `func request_ExampleService_Echo_0(ctx context.Context, marshaler runtime.Marshaler, client ExampleServiceClient, req *http.Request, pathParams map[string]string) (ExampleService_EchoClient, runtime.ServerMetadata, chan error, error) {`,
 		},
 	} {
 		meth.ServerStreaming = proto.Bool(spec.serverStreaming)


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

Fixes #4795

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

yes

#### Brief description of what is fixed or changed

For bidirectional streaming, allows request decoder to alert the clients of invalid requests.

#### Other comments
