### PR TITLE
fix: path parametrs of type number

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -1208,6 +1208,7 @@ func expandPathPatterns(pathParts []string, pathParams []descriptor.Parameter, r
 				Target: &descriptor.Field{
 					FieldDescriptorProto: &descriptorpb.FieldDescriptorProto{
 						Name: proto.String(paramName),
+						Type: descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
 					},
 					Message:           pathParam.Target.Message,
 					FieldMessage:      pathParam.Target.FieldMessage,


### PR DESCRIPTION
path parameters generated with `expand_slashed_path_patterns` are of type `number`, should be a `string`



#### References to other Issues or PRs

Closes https://github.com/grpc-ecosystem/grpc-gateway/issues/4865
Relates https://github.com/grpc-ecosystem/grpc-gateway/issues/4784

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

All path parameters generated with `expand_slashed_path_patterns` have a type `string`.

#### Other comments

I fixed that by explicitly setting the type of the newly generated parameter to `string`. I tested that manually with my real API. I tried to write a test for this, but it turned out to be quite complicated
