### PR TITLE
feat: skip calling http Write method when response is of empty type

### DIFF
--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 // ForwardResponseStream forwards the stream from gRPC server to REST client.
@@ -194,8 +195,10 @@ func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marsha
 		w.Header().Set("Content-Length", strconv.Itoa(len(buf)))
 	}
 
-	if _, err = w.Write(buf); err != nil {
-		grpclog.Errorf("Failed to write response: %v", err)
+	if _, ok := resp.(*emptypb.Empty); !ok {
+		if _, err = w.Write(buf); err != nil {
+			grpclog.Errorf("Failed to write response: %v", err)
+		}
 	}
 
 	if doForwardTrailers {

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -15,7 +15,6 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 // ForwardResponseStream forwards the stream from gRPC server to REST client.
@@ -195,10 +194,8 @@ func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marsha
 		w.Header().Set("Content-Length", strconv.Itoa(len(buf)))
 	}
 
-	if _, ok := resp.(*emptypb.Empty); !ok {
-		if _, err = w.Write(buf); err != nil {
-			grpclog.Errorf("Failed to write response: %v", err)
-		}
+	if _, err = w.Write(buf); err != nil && !errors.Is(err, http.ErrBodyNotAllowed) {
+		grpclog.Errorf("Failed to write response: %v", err)
 	}
 
 	if doForwardTrailers {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs
https://github.com/grpc-ecosystem/grpc-gateway/issues/4901
https://github.com/grpc-ecosystem/grpc-gateway/issues/240

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?
Yes

#### Brief description of what is fixed or changed

Skip calling the `Write()` method on the HTTP response writer when the response is empty. This is to avoid code from keep printing the error message below. 

```
2024/11/04 10:49:00 ERROR: Failed to write response: http: request method or response status code does not allow body
```

#### Other comments
