### PR TITLE
Optional specification of stream content type

### DIFF
--- a/docs/docs/mapping/custom_marshalers.md
+++ b/docs/docs/mapping/custom_marshalers.md
@@ -1,0 +1,72 @@
+---
+layout: default
+title: Custom marshalers
+nav_order: 6
+parent: Mapping
+---
+
+# Custom marshalers
+
+[`Marshaler`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime?tab=doc#Marshaler)
+implementations can implement optional additional methods to customize their
+behaviour beyond the methods required by the core interface.
+
+## Stream delimiters
+
+By default, a streamed response delimits each response body with a single
+newline (`"\n"`). You can change this delimiter by having your marshaler
+implement
+[`Delimited`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime#Delimited).
+
+For example, to separate each entry with a pipe (`"|"`) instead:
+
+```go
+type YourMarshaler struct {
+  // ...
+}
+
+// ...
+
+func (*YourMarshaler) Delimited() []byte {
+  return []byte("|")
+}
+```
+
+## Stream content type
+
+By default, a streamed response emits a `Content-Type` header that is the same
+for a unary response, from the `ContentType()` method of the
+[`Marshaler`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime?tab=doc#Marshaler)
+interface.
+
+If you require the server to declare a distinct content type for stream
+responses versus unary responses, the marshaler must implement
+[`StreamContentType`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime#StreamContentType).
+This provides the MIME type when specifically responding to a streaming
+response.
+
+For example, by default the
+[`JSONPb`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime#JSONPb)
+marshaler results in `application/json` for its `Content-Type` response header,
+irrespective of unary versus streaming. This can be changed for streaming
+endpoints by wrapping the marshaler with a custom marshaler that implements
+[`StreamContentType`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime#StreamContentType)
+to return the [NDJSON](https://github.com/ndjson/ndjson-spec) MIME type for
+streaming response endpoints:
+
+```go
+type CustomJSONPb struct {
+  runtime.JSONPb
+}
+
+func (*CustomJSONPb) Delimited() []byte {
+  // Strictly speaking this is already the default delimiter for JSONPb, but
+  // providing it here for completeness with an NDJSON marshaler all in one
+  // place.
+  return []byte("\n")
+}
+
+func (*CustomJSONPb) StreamContentType(interface{}) string {
+  return "application/x-ndjson"
+}
+```

--- a/docs/docs/mapping/customizing_your_gateway.md
+++ b/docs/docs/mapping/customizing_your_gateway.md
@@ -13,7 +13,10 @@ parent: Mapping
 
 You might want to serialize request/response messages in MessagePack instead of JSON, for example:
 
-1. Write a custom implementation of [`Marshaler`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime?tab=doc#Marshaler).
+1. Write a custom implementation of
+   [`Marshaler`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime?tab=doc#Marshaler).
+   See [Custom marshalers](custom_marshalers.md) for some additional
+   customization options.
 
 2. Register your marshaler with [`WithMarshalerOption`](https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/runtime?tab=doc#WithMarshalerOption).
 

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -64,7 +64,13 @@ func ForwardResponseStream(ctx context.Context, mux *ServeMux, marshaler Marshal
 		}
 
 		if !wroteHeader {
-			w.Header().Set("Content-Type", marshaler.ContentType(respRw))
+			var contentType string
+			if sct, ok := marshaler.(StreamContentType); ok {
+				contentType = sct.StreamContentType(respRw)
+			} else {
+				contentType = marshaler.ContentType(respRw)
+			}
+			w.Header().Set("Content-Type", contentType)
 		}
 
 		var buf []byte

--- a/runtime/marshaler.go
+++ b/runtime/marshaler.go
@@ -48,3 +48,11 @@ type Delimited interface {
 	// Delimiter returns the record separator for the stream.
 	Delimiter() []byte
 }
+
+// StreamContentType defines the streaming content type.
+type StreamContentType interface {
+	// StreamContentType returns the content type for a stream. This shares the
+	// same behaviour as for `Marshaler.ContentType`, but is called, if present,
+	// in the case of a streamed response.
+	StreamContentType(v interface{}) string
+}


### PR DESCRIPTION
We have grpc-gateway based services that include both unary and streamed responses, using `JSONPb` as the marshaler. There is a niggle where the response type for the streamed response is `application/json`, but we'd like it to be `application/x-ndjson` in the streamed response case.

#### References to other Issues or PRs

This looks like it would have provided a solution for at least one comment on #581 (https://github.com/grpc-ecosystem/grpc-gateway/issues/581#issuecomment-423053891 in particular).

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes. This does not appear to need file regeneration.

#### Brief description of what is fixed or changed

Support specifying streamed response content types, without changing the existing behaviour of grpc-gateway unless consumers opt in by providing their own `Marshaler` to set the stream content type.

#### Other comments
