### PR TITLE
Errors on valid timestamps

### DIFF
--- a/runtime/query.go
+++ b/runtime/query.go
@@ -291,7 +291,11 @@ func parseMessage(msgDescriptor protoreflect.MessageDescriptor, value string) (p
 		if err != nil {
 			return protoreflect.Value{}, err
 		}
-		msg = timestamppb.New(t)
+		timestamp := timestamppb.New(t)
+		if ok := timestamp.IsValid(); !ok {
+			return protoreflect.Value{}, fmt.Errorf("%s is not a valid timestamp", value)
+		}
+		msg = timestamp
 	case "google.protobuf.Duration":
 		d, err := time.ParseDuration(value)
 		if err != nil {

--- a/runtime/query.go
+++ b/runtime/query.go
@@ -293,7 +293,7 @@ func parseMessage(msgDescriptor protoreflect.MessageDescriptor, value string) (p
 		}
 		timestamp := timestamppb.New(t)
 		if ok := timestamp.IsValid(); !ok {
-			return protoreflect.Value{}, fmt.Errorf("%s is not a valid timestamp", value)
+			return protoreflect.Value{}, fmt.Errorf("%s before 0001-01-01", value)
 		}
 		msg = timestamp
 	case "google.protobuf.Duration":

--- a/runtime/query_test.go
+++ b/runtime/query_test.go
@@ -495,6 +495,14 @@ func TestPopulateParameters(t *testing.T) {
 			want:    &examplepb.Proto3Message{},
 			wanterr: errors.New("invalid path: \"repeated_message\" is not a message"),
 		},
+		{
+			values: url.Values{
+				"timestampValue": {"0000-01-01T00:00:00.00Z"},
+			},
+			filter: utilities.NewDoubleArray(nil),
+			want:    &examplepb.Proto3Message{},
+			wanterr: errors.New(`parsing field "timestamp_value": 0000-01-01T00:00:00.00Z is not a valid timestamp`),
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			msg := spec.want.ProtoReflect().New().Interface()

--- a/runtime/query_test.go
+++ b/runtime/query_test.go
@@ -501,7 +501,7 @@ func TestPopulateParameters(t *testing.T) {
 			},
 			filter: utilities.NewDoubleArray(nil),
 			want:    &examplepb.Proto3Message{},
-			wanterr: errors.New(`parsing field "timestamp_value": 0000-01-01T00:00:00.00Z is not a valid timestamp`),
+			wanterr: errors.New(`parsing field "timestamp_value": 0000-01-01T00:00:00.00Z before 0001-01-01`),
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #4967

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)? Yes

#### Brief description of what is fixed or changed

Fixes acceptance of invalid timestamps as query parameters

#### Other comments
