### PR TITLE
chore: use golangci-lint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,9 +125,10 @@ jobs:
         with:
           go-version: 1.23
           check-latest: true
-      - uses: dominikh/staticcheck-action@fe1dd0c3658873b46f8c9bb3291096a617310ca6 # v1.3.1
+      - uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6
         with:
-          install-go: false
+          args: --verbose
+          version: v1.62.0
   fuzz:
     runs-on: ubuntu-latest
     steps:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,13 @@
+issues:
+  exclude-dirs-use-default: false
+  exclude-generated: disable
+  exclude-rules:
+    - path: examples
+      linters:
+        - staticcheck
+  max-issues-per-linter: 0
+  max-same-issues: 0
+linters:
+  disable-all: true
+  enable:
+    - staticcheck

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -10784,7 +10784,7 @@ func TestEnumValueProtoComments(t *testing.T) {
 				Package: new(string),
 				SourceCodeInfo: &descriptorpb.SourceCodeInfo{
 					Location: []*descriptorpb.SourceCodeInfo_Location{
-						&descriptorpb.SourceCodeInfo_Location{
+						{
 							LeadingComments: &comments,
 						},
 					},


### PR DESCRIPTION
#### Description

This uses golangci/golangci-lint-action instead of dominikh/staticcheck-action and define golangci-lint configuration.

golangci-lint is here configured to apply staticcheck rules and also gofmt.

gosec and govet are disabled to make the linting pass but deserve a closer look
