### PR TITLE
Fix marshaler interface function name in examples in docs

### DIFF
--- a/docs/docs/mapping/custom_marshalers.md
+++ b/docs/docs/mapping/custom_marshalers.md
@@ -27,7 +27,7 @@ type YourMarshaler struct {
 
 // ...
 
-func (*YourMarshaler) Delimited() []byte {
+func (*YourMarshaler) Delimiter() []byte {
   return []byte("|")
 }
 ```
@@ -59,7 +59,7 @@ type CustomJSONPb struct {
   runtime.JSONPb
 }
 
-func (*CustomJSONPb) Delimited() []byte {
+func (*CustomJSONPb) Delimiter() []byte {
   // Strictly speaking this is already the default delimiter for JSONPb, but
   // providing it here for completeness with an NDJSON marshaler all in one
   // place.


### PR DESCRIPTION
It is actually:
```go
// Delimited defines the streaming delimiter.
type Delimited interface {
	// Delimiter returns the record separator for the stream.
	Delimiter() []byte
}
```