### PR TITLE
fix(deps): Relax the minimum required go version further

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grpc-ecosystem/grpc-gateway/v2
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/antihax/optional v1.0.0


### PR DESCRIPTION
This is a continuation of https://github.com/grpc-ecosystem/grpc-gateway/pull/5022

It is mirroring grpc-go: https://github.com/grpc/grpc-go/pull/7831