### PR TITLE
Only write Content-Length if the runtime.WithWriteContentLength() option is specified

### DIFF
--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -196,7 +196,7 @@ func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marsha
 		return
 	}
 
-	if !doForwardTrailers {
+	if !doForwardTrailers && mux.writeContentLength {
 		w.Header().Set("Content-Length", strconv.Itoa(len(buf)))
 	}
 

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -71,6 +71,7 @@ type ServeMux struct {
 	routingErrorHandler       RoutingErrorHandlerFunc
 	disablePathLengthFallback bool
 	unescapingMode            UnescapingMode
+	writeContentLength        bool
 }
 
 // ServeMuxOption is an option that can be given to a ServeMux on construction.
@@ -255,6 +256,13 @@ func WithRoutingErrorHandler(fn RoutingErrorHandlerFunc) ServeMuxOption {
 func WithDisablePathLengthFallback() ServeMuxOption {
 	return func(serveMux *ServeMux) {
 		serveMux.disablePathLengthFallback = true
+	}
+}
+
+// WithWriteContentLength returns a ServeMuxOption to enable writing content length on non-streaming responses
+func WithWriteContentLength() ServeMuxOption {
+	return func(serveMux *ServeMux) {
+		serveMux.writeContentLength = true
 	}
 }
 


### PR DESCRIPTION
This fixes #4238