### PR TITLE
Fix slow test startup

### DIFF
--- a/examples/internal/gateway/BUILD.bazel
+++ b/examples/internal/gateway/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "@org_golang_google_grpc//connectivity",
         "@org_golang_google_grpc//credentials/insecure",
         "@org_golang_google_grpc//grpclog",
+        "@org_golang_google_protobuf//types/known/emptypb",
     ],
 )
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

Fixes https://github.com/grpc-ecosystem/grpc-gateway/issues/5244

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

The `waitForGateway` method waited 10 seconds in a loop for `healthzServer` to return StatusOK.
The `healthzServer` function returns StatusOK only if `conn.GetState()` is `connectivity.Ready` - but that never happened because connection stays idle before the first method call.
To resolve this, if we detect that the connection is idle, we call any method (in this case, we chose `"/grpc.health.v1.Health/Check"` as it seemed like an appropriate name) and ignore its result, just to get the connection started.

This fixes the test startup delay.

#### Other comments
