### PR TITLE
Remove noisy error log

### DIFF
--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -148,22 +148,20 @@ func DefaultHTTPErrorHandler(ctx context.Context, mux *ServeMux, marshaler Marsh
 	}
 
 	md, ok := ServerMetadataFromContext(ctx)
-	if !ok {
-		grpclog.Error("Failed to extract ServerMetadata from context")
-	}
+	if ok {
+		handleForwardResponseServerMetadata(w, mux, md)
 
-	handleForwardResponseServerMetadata(w, mux, md)
+		// RFC 7230 https://tools.ietf.org/html/rfc7230#section-4.1.2
+		// Unless the request includes a TE header field indicating "trailers"
+		// is acceptable, as described in Section 4.3, a server SHOULD NOT
+		// generate trailer fields that it believes are necessary for the user
+		// agent to receive.
+		doForwardTrailers := requestAcceptsTrailers(r)
 
-	// RFC 7230 https://tools.ietf.org/html/rfc7230#section-4.1.2
-	// Unless the request includes a TE header field indicating "trailers"
-	// is acceptable, as described in Section 4.3, a server SHOULD NOT
-	// generate trailer fields that it believes are necessary for the user
-	// agent to receive.
-	doForwardTrailers := requestAcceptsTrailers(r)
-
-	if doForwardTrailers {
-		handleForwardResponseTrailerHeader(w, mux, md)
-		w.Header().Set("Transfer-Encoding", "chunked")
+		if doForwardTrailers {
+			handleForwardResponseTrailerHeader(w, mux, md)
+			w.Header().Set("Transfer-Encoding", "chunked")
+		}
 	}
 
 	st := HTTPStatusFromCode(s.Code())
@@ -176,7 +174,7 @@ func DefaultHTTPErrorHandler(ctx context.Context, mux *ServeMux, marshaler Marsh
 		grpclog.Errorf("Failed to write response: %v", err)
 	}
 
-	if doForwardTrailers {
+	if ok && requestAcceptsTrailers(r) {
 		handleForwardResponseTrailer(w, mux, md)
 	}
 }

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -153,11 +153,9 @@ type responseBody interface {
 // ForwardResponseMessage forwards the message "resp" from gRPC server to REST client.
 func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marshaler, w http.ResponseWriter, req *http.Request, resp proto.Message, opts ...func(context.Context, http.ResponseWriter, proto.Message) error) {
 	md, ok := ServerMetadataFromContext(ctx)
-	if !ok {
-		grpclog.Error("Failed to extract ServerMetadata from context")
+	if ok {
+		handleForwardResponseServerMetadata(w, mux, md)
 	}
-
-	handleForwardResponseServerMetadata(w, mux, md)
 
 	// RFC 7230 https://tools.ietf.org/html/rfc7230#section-4.1.2
 	// Unless the request includes a TE header field indicating "trailers"
@@ -166,7 +164,7 @@ func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marsha
 	// agent to receive.
 	doForwardTrailers := requestAcceptsTrailers(req)
 
-	if doForwardTrailers {
+	if ok && doForwardTrailers {
 		handleForwardResponseTrailerHeader(w, mux, md)
 		w.Header().Set("Transfer-Encoding", "chunked")
 	}
@@ -204,7 +202,7 @@ func ForwardResponseMessage(ctx context.Context, mux *ServeMux, marshaler Marsha
 		grpclog.Errorf("Failed to write response: %v", err)
 	}
 
-	if doForwardTrailers {
+	if ok && doForwardTrailers {
 		handleForwardResponseTrailer(w, mux, md)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

Fixes #4605

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

Currently, an error is logged whenever a `ServerMetadata` cannot be extracted from the context, which happens frequently on valid cases like requests to undefined routes. This creates unnecessary noise in logs.

The changes reduce log noise while preserving all existing behavior.