### PR TITLE
chore(deps): compatibility with at least two major versions of Go

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.0
+FROM golang:1.23.6
 
 ENV NVM_DIR="/usr/local/share/nvm"
 ENV NVM_SYMLINK_CURRENT=true \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           ./node_modules/.bin/gulp
   generate:
     container:
-      image: ghcr.io/grpc-ecosystem/grpc-gateway/build-env:1.24
+      image: ghcr.io/grpc-ecosystem/grpc-gateway/build-env:1.23
       options: "--user root"
       credentials:
         username: ${{ github.actor }}
@@ -59,7 +59,7 @@ jobs:
       - run: git diff --exit-code
   bazel:
     container:
-      image: ghcr.io/grpc-ecosystem/grpc-gateway/build-env:1.24
+      image: ghcr.io/grpc-ecosystem/grpc-gateway/build-env:1.23
       options: "--user root"
       credentials:
         username: ${{ github.actor }}
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5
         with:
-          go-version: 1.24
+          go-version: 1.23
           check-latest: true
       - run: go run golang.org/x/exp/cmd/gorelease@latest -base=v2.26.2
   proto_lint:
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5
         with:
-          go-version: 1.24
+          go-version: 1.23
           check-latest: true
       - uses: dominikh/staticcheck-action@fe1dd0c3658873b46f8c9bb3291096a617310ca6 # v1.3.1
         with:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,7 +8,7 @@ name: renovate
 jobs:
   update_repositoriesbzl:
     container:
-      image: ghcr.io/grpc-ecosystem/grpc-gateway/build-env:1.24
+      image: ghcr.io/grpc-ecosystem/grpc-gateway/build-env:1.23
       options: "--user root"
       credentials:
         username: ${{ github.actor }}
@@ -49,7 +49,7 @@ jobs:
           fi
   regenerate:
     container:
-      image: ghcr.io/grpc-ecosystem/grpc-gateway/build-env:1.24
+      image: ghcr.io/grpc-ecosystem/grpc-gateway/build-env:1.23
       options: "--user root"
       credentials:
         username: ${{ github.actor }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,12 +11,12 @@ All submissions, including submissions by project members, require review.
 It should be as simple as this (run from the root of the repository):
 
 ```bash
-docker run -v $(pwd):/grpc-gateway -w /grpc-gateway --rm ghcr.io/grpc-ecosystem/grpc-gateway/build-env:1.24 \
+docker run -v $(pwd):/grpc-gateway -w /grpc-gateway --rm ghcr.io/grpc-ecosystem/grpc-gateway/build-env:1.23 \
     /bin/bash -c 'make install && \
         make clean && \
         make generate'
 docker run -itv $(pwd):/grpc-gateway -w /grpc-gateway --entrypoint /bin/bash --rm \
-    ghcr.io/grpc-ecosystem/grpc-gateway/build-env:1.24 -c '\
+    ghcr.io/grpc-ecosystem/grpc-gateway/build-env:1.23 -c '\
         bazel run :gazelle -- update-repos -from_file=go.mod -to_macro=repositories.bzl%go_repositories && \
         bazel run :gazelle && \
         bazel run :buildifier'

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ bazel_dep(name = "googleapis", version = "0.0.0-20241220-5e258e33")
 bazel_dep(name = "rules_rust", version = "0.58.0")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.24.0")
+go_sdk.download(version = "1.23.6")
 
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = ":go.mod")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -98,7 +98,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.24.0")
+go_register_toolchains(version = "1.23.6")
 
 http_archive(
     name = "bazel_gazelle",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grpc-ecosystem/grpc-gateway/v2
 
-go 1.24
+go 1.23.0
 
 require (
 	github.com/antihax/optional v1.0.0


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Revert #5265, maintain compatibility with at least two major versions of Go.

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

I think a module that is so widely used should be compatible with at least two major versions of Go, not just the last one.

thank you.

#### Other comments
