### PR TITLE
Add support for x-go-type flag

### DIFF
--- a/examples/internal/clients/unannotatedecho/api/swagger.yaml
+++ b/examples/internal/clients/unannotatedecho/api/swagger.yaml
@@ -448,6 +448,10 @@ definitions:
       note:
         type: "string"
     description: "Embedded represents a message embedded in SimpleMessage."
+    x-go-type:
+      import:
+        package: "github.com/grpc-ecosystem/grpc-gateway/v2/examples/internal/proto/examplepb"
+      type: "UnannotatedEmbedded"
   examplepbUnannotatedNestedMessage:
     type: "object"
     properties:
@@ -455,6 +459,10 @@ definitions:
         type: "string"
       val:
         type: "string"
+    x-go-type:
+      import:
+        package: "github.com/grpc-ecosystem/grpc-gateway/v2/examples/internal/proto/examplepb"
+      type: "UnannotatedNestedMessage"
   examplepbUnannotatedSimpleMessage:
     type: "object"
     required:
@@ -500,6 +508,10 @@ definitions:
       '@type':
         type: "string"
     additionalProperties: {}
+    x-go-type:
+      import:
+        package: "google.golang.org/protobuf/types/known/anypb"
+      type: "Any"
   rpcStatus:
     type: "object"
     properties:
@@ -512,6 +524,10 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/protobufAny"
+    x-go-type:
+      import:
+        package: "google.golang.org/genproto/googleapis/rpc/status"
+      type: "Status"
 externalDocs:
   description: "More about gRPC-Gateway"
   url: "https://github.com/grpc-ecosystem/grpc-gateway"

--- a/examples/internal/proto/examplepb/unannotated_echo_service.buf.gen.yaml
+++ b/examples/internal/proto/examplepb/unannotated_echo_service.buf.gen.yaml
@@ -10,3 +10,4 @@ plugins:
     opt:
       - grpc_api_configuration=examples/internal/proto/examplepb/unannotated_echo_service.yaml
       - openapi_configuration=examples/internal/proto/examplepb/unannotated_echo_service.swagger.yaml
+      - generate_x_go_type=true

--- a/examples/internal/proto/examplepb/unannotated_echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/unannotated_echo_service.swagger.json
@@ -502,7 +502,13 @@
           "type": "string"
         }
       },
-      "description": "Embedded represents a message embedded in SimpleMessage."
+      "description": "Embedded represents a message embedded in SimpleMessage.",
+      "x-go-type": {
+        "import": {
+          "package": "github.com/grpc-ecosystem/grpc-gateway/v2/examples/internal/proto/examplepb"
+        },
+        "type": "UnannotatedEmbedded"
+      }
     },
     "examplepbUnannotatedNestedMessage": {
       "type": "object",
@@ -513,6 +519,12 @@
         "val": {
           "type": "string"
         }
+      },
+      "x-go-type": {
+        "import": {
+          "package": "github.com/grpc-ecosystem/grpc-gateway/v2/examples/internal/proto/examplepb"
+        },
+        "type": "UnannotatedNestedMessage"
       }
     },
     "examplepbUnannotatedSimpleMessage": {
@@ -576,7 +588,13 @@
           "type": "string"
         }
       },
-      "additionalProperties": {}
+      "additionalProperties": {},
+      "x-go-type": {
+        "import": {
+          "package": "google.golang.org/protobuf/types/known/anypb"
+        },
+        "type": "Any"
+      }
     },
     "rpcStatus": {
       "type": "object",
@@ -595,6 +613,12 @@
             "$ref": "#/definitions/protobufAny"
           }
         }
+      },
+      "x-go-type": {
+        "import": {
+          "package": "google.golang.org/genproto/googleapis/rpc/status"
+        },
+        "type": "Status"
       }
     }
   },

--- a/internal/descriptor/registry.go
+++ b/internal/descriptor/registry.go
@@ -178,6 +178,9 @@ type Registry struct {
 	// This leads to more compliant and readable OpenAPI suitable for documentation, but may complicate client
 	// implementation if you want to pass the original "name" parameter.
 	expandSlashedPathPatterns bool
+
+	// generateXGoType is a global generator option for generating x-go-type annotations
+	generateXGoType bool
 }
 
 type repeatedFieldSeparator struct {
@@ -918,4 +921,12 @@ func (r *Registry) SetExpandSlashedPathPatterns(expandSlashedPathPatterns bool) 
 
 func (r *Registry) GetExpandSlashedPathPatterns() bool {
 	return r.expandSlashedPathPatterns
+}
+
+func (r *Registry) SetGenerateXGoType(generateXGoType bool) {
+	r.generateXGoType = generateXGoType
+}
+
+func (r *Registry) GetGenerateXGoType() bool {
+	return r.generateXGoType
 }

--- a/protoc-gen-openapiv2/defs.bzl
+++ b/protoc-gen-openapiv2/defs.bzl
@@ -77,7 +77,8 @@ def _run_proto_gen_openapi(
         disable_default_responses,
         enable_rpc_deprecation,
         expand_slashed_path_patterns,
-        preserve_rpc_order):
+        preserve_rpc_order,
+        generate_x_go_type):
     args = actions.args()
 
     args.add("--plugin", "protoc-gen-openapiv2=%s" % protoc_gen_openapiv2.path)
@@ -159,6 +160,8 @@ def _run_proto_gen_openapi(
 
     if preserve_rpc_order:
         args.add("--openapiv2_opt", "preserve_rpc_order=true")
+    if generate_x_go_type:
+        args.add("--openapiv2_opt", "generate_x_go_type=true")
 
     args.add("--openapiv2_opt", "repeated_path_param_separator=%s" % repeated_path_param_separator)
 
@@ -270,6 +273,7 @@ def _proto_gen_openapi_impl(ctx):
                     enable_rpc_deprecation = ctx.attr.enable_rpc_deprecation,
                     expand_slashed_path_patterns = ctx.attr.expand_slashed_path_patterns,
                     preserve_rpc_order = ctx.attr.preserve_rpc_order,
+                    generate_x_go_type = ctx.attr.generate_x_go_type,
                 ),
             ),
         ),
@@ -449,6 +453,11 @@ protoc_gen_openapiv2 = rule(
             mandatory = False,
             doc = "if set, uses proto3 field semantics for the OpenAPI schema." +
                   "  This means that fields are required by default.",
+        ),
+        "generate_x_go_type": attr.bool(
+            default = False,
+            mandatory = False,
+            doc = "Generate x-go-type extension using the go_package option from proto files",
         ),
         "_protoc": attr.label(
             default = "@com_google_protobuf//:protoc",

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -523,13 +523,16 @@ func renderMessageAsDefinition(msg *descriptor.Message, reg *descriptor.Registry
 		if schema.extensions == nil {
 			schema.extensions = []extension{}
 		}
+		goTypeName := msg.GetName()
+
+		goTypeName = casing.JSONCamelCase(goTypeName)
 		schema.extensions = append(schema.extensions, extension{
 			key: "x-go-type",
 			value: json.RawMessage(`{
                 "import": {
                     "package": "` + msg.File.GoPkg.Path + `"
                 },
-                "type": "` + msg.GetName() + `"
+                "type": "` + goTypeName + `"
             }`),
 		})
 	}

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -2,6 +2,7 @@ package genopenapi
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -517,6 +518,22 @@ func renderMessageAsDefinition(msg *descriptor.Message, reg *descriptor.Registry
 			Type: "object",
 		},
 	}
+
+	if reg.GetGenerateXGoType() && msg.File.GoPkg.Path != "" {
+		if schema.extensions == nil {
+			schema.extensions = []extension{}
+		}
+		schema.extensions = append(schema.extensions, extension{
+			key: "x-go-type",
+			value: json.RawMessage(`{
+                "import": {
+                    "package": "` + msg.File.GoPkg.Path + `"
+                },
+                "type": "` + msg.GetName() + `"
+            }`),
+		})
+	}
+
 	msgComments := protoComments(reg, msg.File, msg.Outers, "MessageType", int32(msg.Index))
 	if err := updateOpenAPIDataFromComments(reg, &schema, msg, msgComments, false); err != nil {
 		return openapiSchemaObject{}, err

--- a/protoc-gen-openapiv2/internal/genopenapi/testdata/generator/x_go_type.prototext
+++ b/protoc-gen-openapiv2/internal/genopenapi/testdata/generator/x_go_type.prototext
@@ -1,0 +1,32 @@
+file_to_generate: "test/service/v1/service.proto"
+proto_file: {
+  name: "test/service/v1/service.proto"
+  package: "test.service.v1"
+  message_type: {
+    name: "TestMessage"
+    field: {
+      name: "value"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "value"
+    }
+  }
+  service: {
+    name: "TestService"
+    method: {
+      name: "Test"
+      input_type: ".test.service.v1.TestMessage"
+      output_type: ".test.service.v1.TestMessage"
+      options: {
+        [google.api.http]: {
+          post: "/v1/test"
+          body: "*"
+        }
+      }
+    }
+  }
+  options: {
+    go_package: "github.com/grpc-ecosystem/grpc-gateway/v2/test/service/v1;servicev1"
+  }
+}

--- a/protoc-gen-openapiv2/internal/genopenapi/testdata/generator/x_go_type.swagger.yaml
+++ b/protoc-gen-openapiv2/internal/genopenapi/testdata/generator/x_go_type.swagger.yaml
@@ -1,0 +1,37 @@
+swagger: "2.0"
+info:
+  title: test/service/v1/service.proto
+  version: version not set
+tags:
+- name: TestService
+consumes:
+- application/json
+produces:
+- application/json
+paths:
+  /v1/test:
+    post:
+      operationId: TestService_Test
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1TestMessage'
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/v1TestMessage'
+      tags:
+      - TestService
+definitions:
+  v1TestMessage:
+    type: object
+    properties:
+      value:
+        type: string
+    x-go-type:
+      import:
+        package: "github.com/grpc-ecosystem/grpc-gateway/v2/test/service/v1"
+      type: "TestMessage"

--- a/protoc-gen-openapiv2/main.go
+++ b/protoc-gen-openapiv2/main.go
@@ -52,6 +52,7 @@ var (
 	enableRpcDeprecation           = flag.Bool("enable_rpc_deprecation", false, "whether to process grpc method's deprecated option.")
 	expandSlashedPathPatterns      = flag.Bool("expand_slashed_path_patterns", false, "if set, expands path parameters with URI sub-paths into the URI. For example, \"/v1/{name=projects/*}/resource\" becomes \"/v1/projects/{project}/resource\".")
 	useProto3FieldSemantics        = flag.Bool("use_proto3_field_semantics", false, "if set, uses proto3 field semantics for the OpenAPI schema. This means that fields are required by default.")
+	generateXGoType                = flag.Bool("generate_x_go_type", false, "if set, generates x-go-type extension using the go_package option from proto files")
 
 	_ = flag.Bool("logtostderr", false, "Legacy glog compatibility. This flag is a no-op, you can safely remove it")
 )
@@ -177,6 +178,7 @@ func main() {
 	reg.SetPreserveRPCOrder(*preserveRPCOrder)
 	reg.SetEnableRpcDeprecation(*enableRpcDeprecation)
 	reg.SetExpandSlashedPathPatterns(*expandSlashedPathPatterns)
+	reg.SetGenerateXGoType(*generateXGoType)
 
 	if err := reg.SetRepeatedPathParamSeparator(*repeatedPathParamSeparator); err != nil {
 		emitError(err)


### PR DESCRIPTION
**References to other Issues or PRs**

Resolves #4927

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

This pull request introduces support for the `x-go-type` extension in the generated OpenAPIv2 specifications. This extension allows tools such as go-swagger to reuse existing Go types rather than generating new ones.

**Other comments**
