### PR TITLE
feat(bazel): surface --preserve_rpc_order in rule def

### DIFF
--- a/protoc-gen-openapiv2/defs.bzl
+++ b/protoc-gen-openapiv2/defs.bzl
@@ -76,7 +76,8 @@ def _run_proto_gen_openapi(
         use_allof_for_refs,
         disable_default_responses,
         enable_rpc_deprecation,
-        expand_slashed_path_patterns):
+        expand_slashed_path_patterns,
+        preserve_rpc_order):
     args = actions.args()
 
     args.add("--plugin", "protoc-gen-openapiv2=%s" % protoc_gen_openapiv2.path)
@@ -155,6 +156,9 @@ def _run_proto_gen_openapi(
 
     if expand_slashed_path_patterns:
         args.add("--openapiv2_opt", "expand_slashed_path_patterns=true")
+
+    if preserve_rpc_order:
+        args.add("--openapiv2_opt", "preserve_rpc_order=true")
 
     args.add("--openapiv2_opt", "repeated_path_param_separator=%s" % repeated_path_param_separator)
 
@@ -265,6 +269,7 @@ def _proto_gen_openapi_impl(ctx):
                     disable_default_responses = ctx.attr.disable_default_responses,
                     enable_rpc_deprecation = ctx.attr.enable_rpc_deprecation,
                     expand_slashed_path_patterns = ctx.attr.expand_slashed_path_patterns,
+                    preserve_rpc_order = ctx.attr.preserve_rpc_order,
                 ),
             ),
         ),
@@ -431,6 +436,13 @@ protoc_gen_openapiv2 = rule(
             doc = "if set, expands path patterns containing slashes into URI." +
                   " It also creates a new path parameter for each wildcard in " +
                   " the path pattern.",
+        ),
+        "preserve_rpc_order": attr.bool(
+            default = False,
+            mandatory = False,
+            doc = "if set, ensures the order of paths emitted in OpenAPI files" +
+                  " mirrors the order of RPC methods found in proto files." +
+                  " If false, emitted paths will be ordered alphabetically.",
         ),
         "use_proto3_field_semantics": attr.bool(
             default = False,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes https://github.com/grpc-ecosystem/grpc-gateway/issues/5349

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)? 

Yes

#### Brief description of what is fixed or changed
This change surfaces the `--preserve_rpc_order` flag for the OpenAPI spec generator in the `protoc_gen_openapiv2` Bazel rule.

#### Other comments
The `--preserve_rpc_order` flag was implemented in https://github.com/grpc-ecosystem/grpc-gateway/pull/3500

https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/customizing_openapi_output/#preserve-rpc-path-order
