### PR TITLE
Add the source archive to the release assets

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,4 +27,7 @@ builds:
 archives:
   - name_template: '{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{if eq .Arch "amd64"}}x86_64{{else}}{{ .Arch }}{{end}}'
     format: binary
+source:
+  enabled: true
+  name_template: '{{ .ProjectName }}-{{ .Tag }}'
 dist: _output


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

This PR is part of the work to publish `grpc-gateway` in [BCR](https://registry.bazel.build/), described in this [issue](https://github.com/grpc-ecosystem/grpc-gateway/issues/5183#issuecomment-2777176659).

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

Adding the source archive allows users to download the source code used to build the binaries, ensuring transparency and reproducibility.

A module in BCR [should](https://blog.bazel.build/2023/02/15/github-archive-checksum.html) be published using this source format.

GoReleaser was used to generate the [source archive](https://goreleaser.com/customization/source/) and provide checksum and audit features for the release process.

#### Other comments

To test that the source archive is generated as expected, I ran this command `goreleaser release --clean --snapshot`, which generated the source archive and its checksum string.
