### PR TITLE
Add metadata and configuration templates for publishing to BCR

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,13 @@
+{
+  "homepage": "https://github.com/grpc-ecosystem/grpc-gateway",
+  "maintainers": [
+    {
+      "name": "Johan Brandhorst-Satzkorn",
+      "email": "johan.brandhorst@gmail.com",
+      "github": "johanbrandhorst"
+    }
+  ],
+  "repository": ["github:grpc-ecosystem/grpc-gateway"],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,14 @@
+bcr_test_module:
+  module_path: "MODULE.bazel"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [6.x, 7.x, 8.x]
+  tasks:
+    run_tests:
+      name: "Build and test grpc-gateway module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//..."
+      test_targets:
+        - "//..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

This PR is part of the work to publish grpc-gateway in [BCR](https://registry.bazel.build/), described in this [issue](https://github.com/grpc-ecosystem/grpc-gateway/issues/5183).

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

This PR seeks to add the required files for the [publish-to-bcr](https://github.com/bazel-contrib/publish-to-bcr/tree/main) plugin, which will publish the gRPC Gateway project as a module in the [Bazel Central Registry](https://registry.bazel.build/).

The plugin aims to eliminate a manual publishing process for the module and initiate the process when a release is created.

The configuration consists of three files placed in the `.bcr` directory:

* `.bcr/metadata.template.json`: that describes the repository and maintainers' information.
* `.bcr/presubmit.yml`: describes the targets that will be built and tested on specific platforms and bazel versions to test the module. 
* `.bcr/source.template.json`: that will automatically substitute values for the repository, owner, and tag based on the repository and release data.

The final result of this process is the creation of a PR in the BCR repository to publish the released version.

#### Other comments

Once this configuration is added to the repo, the `publish-to-bcr` should be configured as described [here](https://github.com/bazel-contrib/publish-to-bcr/tree/main?tab=readme-ov-file#how-it-works).

___

CC: @AlejoAsd for awareness.
