### PR TITLE
fix(openapi): Convert path params after colon to `camelCase`

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -1089,18 +1089,18 @@ func templateToParts(path string, reg *descriptor.Registry, fields []*descriptor
 			buffer += string(char)
 		case ':':
 			if depth == 0 {
-				// As soon as we find a ":" outside a variable,
-				// everything following is a verb. But we need to continue processing
-				// the remaining path to handle parameter camelCase conversion.
-				parts = append(parts, buffer)
-				verbSegment := path[i:]
-
-				if reg.GetUseJSONNamesForFields() {
-					verbSegment = processParametersInSegment(verbSegment, fields, msgs)
+				// Only treat this as a verb if we're at the end of the path or
+				// if there are no more path segments (only more literals after the colon)
+				remainingPath := path[i:]
+				if !strings.Contains(remainingPath, "/") {
+					parts = append(parts, buffer)
+					verbSegment := remainingPath
+					if reg.GetUseJSONNamesForFields() {
+						verbSegment = processParametersInSegment(verbSegment, fields, msgs)
+					}
+					parts = append(parts, verbSegment)
+					return parts
 				}
-
-				parts = append(parts, verbSegment)
-				return parts
 			}
 			buffer += string(char)
 		default:

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -1059,7 +1059,6 @@ func templateToParts(path string, reg *descriptor.Registry, fields []*descriptor
 	var parts []string
 	depth := 0
 	buffer := ""
-pathLoop:
 	for i, char := range path {
 		switch char {
 		case '{':
@@ -1091,10 +1090,17 @@ pathLoop:
 		case ':':
 			if depth == 0 {
 				// As soon as we find a ":" outside a variable,
-				// everything following is a verb
+				// everything following is a verb. But we need to continue processing
+				// the remaining path to handle parameter camelCase conversion.
 				parts = append(parts, buffer)
-				buffer = path[i:]
-				break pathLoop
+				verbSegment := path[i:]
+
+				if reg.GetUseJSONNamesForFields() {
+					verbSegment = processParametersInSegment(verbSegment, fields, msgs)
+				}
+
+				parts = append(parts, verbSegment)
+				return parts
 			}
 			buffer += string(char)
 		default:
@@ -1106,6 +1112,42 @@ pathLoop:
 	parts = append(parts, buffer)
 
 	return parts
+}
+
+// processParametersInSegment processes a path segment (like ":verb/{param}") to convert
+// parameter names to camelCase while preserving the overall structure
+func processParametersInSegment(segment string, fields []*descriptor.Field, msgs []*descriptor.Message) string {
+	result := segment
+	depth := 0
+	var paramStart int
+
+	for i, char := range segment {
+		switch char {
+		case '{':
+			if depth == 0 {
+				paramStart = i
+			}
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				paramContent := segment[paramStart+1 : i]
+				paramNameProto := strings.SplitN(paramContent, "=", 2)[0]
+				paramNameCamelCase := lowerCamelCase(paramNameProto, fields, msgs)
+
+				oldParam := "{" + paramContent + "}"
+				newParam := "{" + paramNameCamelCase
+				if strings.Contains(paramContent, "=") {
+					newParam += paramContent[len(paramNameProto):]
+				}
+				newParam += "}"
+
+				result = strings.Replace(result, oldParam, newParam, 1)
+			}
+		}
+	}
+
+	return result
 }
 
 // partsToOpenAPIPath converts each path part of the form /path/{string_value=strprefix/*} which is defined in

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -1120,7 +1120,6 @@ func processParametersInSegment(segment string, fields []*descriptor.Field, msgs
 	result := segment
 	depth := 0
 	var paramStart int
-
 	for i, char := range segment {
 		switch char {
 		case '{':
@@ -1146,7 +1145,6 @@ func processParametersInSegment(segment string, fields []*descriptor.Field, msgs
 			}
 		}
 	}
-
 	return result
 }
 

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -4039,6 +4039,7 @@ func TestTemplateWithJsonCamelCase(t *testing.T) {
 		{"test/{ab_c}", "test/{abC}"},
 		{"test/{json_name}", "test/{jsonNAME}"},
 		{"test/{field_abc.field_newName}", "test/{fieldAbc.RESERVEDJSONNAME}"},
+		{"/item/search:item/{item_no_query}", "/item/search:item/{itemNoQuery}"},
 	}
 	reg := descriptor.NewRegistry()
 	reg.SetUseJSONNamesForFields(true)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

Fixes: #3517

`Core fix`: Process the verb segment for parameter `camelCase` conversion instead of ignoring it completely.

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

#### Other comments
