### PR TITLE
fix(lint,gosec): explicitly ignore errors from discarded HTTP request…

### DIFF
--- a/examples/internal/helloworld/helloworld.pb.gw.go
+++ b/examples/internal/helloworld/helloworld.pb.gw.go
@@ -43,7 +43,7 @@ func request_Greeter_SayHello_0(ctx context.Context, marshaler runtime.Marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
@@ -94,7 +94,7 @@ func request_Greeter_SayHello_1(ctx context.Context, marshaler runtime.Marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["strVal"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "strVal")
@@ -145,7 +145,7 @@ func request_Greeter_SayHello_2(ctx context.Context, marshaler runtime.Marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["floatVal"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "floatVal")
@@ -196,7 +196,7 @@ func request_Greeter_SayHello_3(ctx context.Context, marshaler runtime.Marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["doubleVal"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "doubleVal")
@@ -247,7 +247,7 @@ func request_Greeter_SayHello_4(ctx context.Context, marshaler runtime.Marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["boolVal"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "boolVal")
@@ -298,7 +298,7 @@ func request_Greeter_SayHello_5(ctx context.Context, marshaler runtime.Marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["bytesVal"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "bytesVal")
@@ -349,7 +349,7 @@ func request_Greeter_SayHello_6(ctx context.Context, marshaler runtime.Marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["int32Val"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "int32Val")
@@ -400,7 +400,7 @@ func request_Greeter_SayHello_7(ctx context.Context, marshaler runtime.Marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["uint32Val"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "uint32Val")
@@ -451,7 +451,7 @@ func request_Greeter_SayHello_8(ctx context.Context, marshaler runtime.Marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["int64Val"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "int64Val")
@@ -502,7 +502,7 @@ func request_Greeter_SayHello_9(ctx context.Context, marshaler runtime.Marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["uint64Val"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "uint64Val")

--- a/examples/internal/proto/examplepb/a_bit_of_everything.pb.gw.go
+++ b/examples/internal/proto/examplepb/a_bit_of_everything.pb.gw.go
@@ -49,7 +49,7 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, marshaler run
 		e        int32
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["float_value"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "float_value")
@@ -556,7 +556,7 @@ func request_ABitOfEverythingService_Lookup_0(ctx context.Context, marshaler run
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["uuid"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
@@ -595,7 +595,7 @@ func request_ABitOfEverythingService_Custom_0(ctx context.Context, marshaler run
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["uuid"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
@@ -646,7 +646,7 @@ func request_ABitOfEverythingService_DoubleColon_0(ctx context.Context, marshale
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["uuid"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
@@ -917,7 +917,7 @@ func request_ABitOfEverythingService_Delete_0(ctx context.Context, marshaler run
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["uuid"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
@@ -956,7 +956,7 @@ func request_ABitOfEverythingService_GetQuery_0(ctx context.Context, marshaler r
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["uuid"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
@@ -1006,7 +1006,7 @@ func request_ABitOfEverythingService_GetRepeatedQuery_0(ctx context.Context, mar
 		es       []int32
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["path_repeated_float_value"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "path_repeated_float_value")
@@ -1294,7 +1294,7 @@ func request_ABitOfEverythingService_Echo_0(ctx context.Context, marshaler runti
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["value"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "value")
@@ -1357,7 +1357,7 @@ func request_ABitOfEverythingService_Echo_2(ctx context.Context, marshaler runti
 		protoReq sub.StringMessage
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -1431,7 +1431,7 @@ func request_ABitOfEverythingService_Timeout_0(ctx context.Context, marshaler ru
 		protoReq emptypb.Empty
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	msg, err := client.Timeout(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -1450,7 +1450,7 @@ func request_ABitOfEverythingService_ErrorWithDetails_0(ctx context.Context, mar
 		protoReq emptypb.Empty
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	msg, err := client.ErrorWithDetails(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -1558,7 +1558,7 @@ func request_ABitOfEverythingService_CheckGetQueryParams_0(ctx context.Context, 
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["single_nested.name"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "single_nested.name")
@@ -1610,7 +1610,7 @@ func request_ABitOfEverythingService_CheckNestedEnumGetQueryParams_0(ctx context
 		e        int32
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["single_nested.ok"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "single_nested.ok")
@@ -1751,7 +1751,7 @@ func request_ABitOfEverythingService_OverwriteResponseContentType_0(ctx context.
 		protoReq emptypb.Empty
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	msg, err := client.OverwriteResponseContentType(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -1772,7 +1772,7 @@ func request_ABitOfEverythingService_CheckExternalPathEnum_0(ctx context.Context
 		e        int32
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["value"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "value")
@@ -1813,7 +1813,7 @@ func request_ABitOfEverythingService_CheckExternalNestedPathEnum_0(ctx context.C
 		e        int32
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["value"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "value")
@@ -1852,7 +1852,7 @@ func request_ABitOfEverythingService_CheckStatus_0(ctx context.Context, marshale
 		protoReq emptypb.Empty
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	msg, err := client.CheckStatus(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -1874,7 +1874,7 @@ func request_ABitOfEverythingService_Exists_0(ctx context.Context, marshaler run
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["uuid"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
@@ -1925,7 +1925,7 @@ func request_ABitOfEverythingService_CustomOptionsRequest_0(ctx context.Context,
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["uuid"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
@@ -1976,7 +1976,7 @@ func request_ABitOfEverythingService_TraceRequest_0(ctx context.Context, marshal
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["uuid"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
@@ -2084,7 +2084,7 @@ func request_CamelCaseServiceName_Empty_0(ctx context.Context, marshaler runtime
 		protoReq emptypb.Empty
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	msg, err := client.Empty(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -2105,7 +2105,7 @@ func request_SnakeEnumService_SnakeEnum_0(ctx context.Context, marshaler runtime
 		e        int32
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["who"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "who")

--- a/examples/internal/proto/examplepb/echo_service.pb.gw.go
+++ b/examples/internal/proto/examplepb/echo_service.pb.gw.go
@@ -43,7 +43,7 @@ func request_EchoService_Echo_0(ctx context.Context, marshaler runtime.Marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
@@ -94,7 +94,7 @@ func request_EchoService_Echo_1(ctx context.Context, marshaler runtime.Marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
@@ -161,7 +161,7 @@ func request_EchoService_Echo_2(ctx context.Context, marshaler runtime.Marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
@@ -254,7 +254,7 @@ func request_EchoService_Echo_3(ctx context.Context, marshaler runtime.Marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
@@ -347,7 +347,7 @@ func request_EchoService_Echo_4(ctx context.Context, marshaler runtime.Marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["no.note"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "no.note")
@@ -398,7 +398,7 @@ func request_EchoService_Echo_5(ctx context.Context, marshaler runtime.Marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["resource_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "resource_id")
@@ -449,7 +449,7 @@ func request_EchoService_Echo_6(ctx context.Context, marshaler runtime.Marshaler
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["n_id.n_id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "n_id.n_id")
@@ -591,7 +591,7 @@ func request_EchoService_EchoDelete_0(ctx context.Context, marshaler runtime.Mar
 		protoReq SimpleMessage
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -685,7 +685,7 @@ func request_EchoService_EchoUnauthorized_0(ctx context.Context, marshaler runti
 		protoReq SimpleMessage
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}

--- a/examples/internal/proto/examplepb/excess_body.pb.gw.go
+++ b/examples/internal/proto/examplepb/excess_body.pb.gw.go
@@ -41,7 +41,7 @@ func request_ExcessBodyService_NoBodyRpc_0(ctx context.Context, marshaler runtim
 		protoReq emptypb.Empty
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	msg, err := client.NoBodyRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -60,7 +60,7 @@ func request_ExcessBodyService_NoBodyServerStream_0(ctx context.Context, marshal
 		protoReq emptypb.Empty
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	stream, err := client.NoBodyServerStream(ctx, &protoReq)
 	if err != nil {
 		return nil, metadata, err

--- a/examples/internal/proto/examplepb/flow_combination.pb.gw.go
+++ b/examples/internal/proto/examplepb/flow_combination.pb.gw.go
@@ -40,7 +40,7 @@ func request_FlowCombination_RpcEmptyRpc_0(ctx context.Context, marshaler runtim
 		protoReq EmptyProto
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	msg, err := client.RpcEmptyRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
@@ -59,7 +59,7 @@ func request_FlowCombination_RpcEmptyStream_0(ctx context.Context, marshaler run
 		protoReq EmptyProto
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	stream, err := client.RpcEmptyStream(ctx, &protoReq)
 	if err != nil {
 		return nil, metadata, err
@@ -187,7 +187,7 @@ func request_FlowCombination_RpcBodyRpc_1(ctx context.Context, marshaler runtime
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["a"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
@@ -257,7 +257,7 @@ func request_FlowCombination_RpcBodyRpc_2(ctx context.Context, marshaler runtime
 		protoReq NonEmptyProto
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -446,7 +446,7 @@ func request_FlowCombination_RpcBodyRpc_6(ctx context.Context, marshaler runtime
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["a"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
@@ -497,7 +497,7 @@ func request_FlowCombination_RpcPathSingleNestedRpc_0(ctx context.Context, marsh
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["a.str"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
@@ -621,7 +621,7 @@ func request_FlowCombination_RpcPathNestedRpc_1(ctx context.Context, marshaler r
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["a.str"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
@@ -748,7 +748,7 @@ func request_FlowCombination_RpcBodyStream_1(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["a"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
@@ -792,7 +792,7 @@ func request_FlowCombination_RpcBodyStream_2(ctx context.Context, marshaler runt
 		protoReq NonEmptyProto
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -924,7 +924,7 @@ func request_FlowCombination_RpcBodyStream_6(ctx context.Context, marshaler runt
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["a"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
@@ -959,7 +959,7 @@ func request_FlowCombination_RpcPathSingleNestedStream_0(ctx context.Context, ma
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["a.str"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
@@ -1040,7 +1040,7 @@ func request_FlowCombination_RpcPathNestedStream_1(ctx context.Context, marshale
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["a.str"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")

--- a/examples/internal/proto/examplepb/response_body_service.pb.gw.go
+++ b/examples/internal/proto/examplepb/response_body_service.pb.gw.go
@@ -41,7 +41,7 @@ func request_ResponseBodyService_GetResponseBody_0(ctx context.Context, marshale
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["data"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "data")
@@ -78,7 +78,7 @@ func request_ResponseBodyService_ListResponseBodies_0(ctx context.Context, marsh
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["data"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "data")
@@ -115,7 +115,7 @@ func request_ResponseBodyService_ListResponseStrings_0(ctx context.Context, mars
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["data"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "data")
@@ -152,7 +152,7 @@ func request_ResponseBodyService_GetResponseBodyStream_0(ctx context.Context, ma
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["data"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "data")
@@ -179,7 +179,7 @@ func request_ResponseBodyService_GetResponseBodySameName_0(ctx context.Context, 
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["data"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "data")

--- a/examples/internal/proto/examplepb/stream.pb.gw.go
+++ b/examples/internal/proto/examplepb/stream.pb.gw.go
@@ -85,7 +85,7 @@ func request_StreamService_List_0(ctx context.Context, marshaler runtime.Marshal
 		protoReq Options
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -197,7 +197,7 @@ func request_StreamService_Download_0(ctx context.Context, marshaler runtime.Mar
 		protoReq Options
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}

--- a/examples/internal/proto/examplepb/unannotated_echo_service.pb.gw.go
+++ b/examples/internal/proto/examplepb/unannotated_echo_service.pb.gw.go
@@ -43,7 +43,7 @@ func request_UnannotatedEchoService_Echo_0(ctx context.Context, marshaler runtim
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
@@ -94,7 +94,7 @@ func request_UnannotatedEchoService_Echo_1(ctx context.Context, marshaler runtim
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
@@ -185,7 +185,7 @@ func request_UnannotatedEchoService_EchoDelete_0(ctx context.Context, marshaler 
 		protoReq UnannotatedSimpleMessage
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}

--- a/examples/internal/proto/examplepb/visibility_rule_echo_service.pb.gw.go
+++ b/examples/internal/proto/examplepb/visibility_rule_echo_service.pb.gw.go
@@ -43,7 +43,7 @@ func request_VisibilityRuleEchoService_Echo_0(ctx context.Context, marshaler run
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
@@ -93,7 +93,7 @@ func request_VisibilityRuleEchoService_EchoInternal_0(ctx context.Context, marsh
 		protoReq VisibilityRuleSimpleMessage
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -126,7 +126,7 @@ func request_VisibilityRuleEchoService_EchoPreview_0(ctx context.Context, marsha
 		protoReq VisibilityRuleSimpleMessage
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -159,7 +159,7 @@ func request_VisibilityRuleEchoService_EchoInternalAndPreview_0(ctx context.Cont
 		protoReq VisibilityRuleSimpleMessage
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -193,7 +193,7 @@ func request_VisibilityRuleInternalEchoService_Echo_0(ctx context.Context, marsh
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")

--- a/examples/internal/proto/standalone/unannotated_echo_service.pb.gw.go
+++ b/examples/internal/proto/standalone/unannotated_echo_service.pb.gw.go
@@ -44,7 +44,7 @@ func request_UnannotatedEchoService_Echo_0(ctx context.Context, marshaler runtim
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
@@ -95,7 +95,7 @@ func request_UnannotatedEchoService_Echo_1(ctx context.Context, marshaler runtim
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
@@ -162,7 +162,7 @@ func request_UnannotatedEchoService_Echo_2(ctx context.Context, marshaler runtim
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
@@ -255,7 +255,7 @@ func request_UnannotatedEchoService_Echo_3(ctx context.Context, marshaler runtim
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["id"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
@@ -348,7 +348,7 @@ func request_UnannotatedEchoService_Echo_4(ctx context.Context, marshaler runtim
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["no.note"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "no.note")
@@ -423,7 +423,7 @@ func request_UnannotatedEchoService_EchoDelete_0(ctx context.Context, marshaler 
 		protoReq extExamplepb.UnannotatedSimpleMessage
 		metadata runtime.ServerMetadata
 	)
-	io.Copy(io.Discard, req.Body)
+	_, _ = io.Copy(io.Discard, req.Body)
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}

--- a/protoc-gen-grpc-gateway/internal/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/internal/gengateway/template.go
@@ -384,7 +384,7 @@ var filter_{{ .Method.Service.GetName }}_{{ .Method.GetName }}_{{ .Index }} = {{
 	}
 	{{- end }}
 {{- else }}
-	io.Copy(io.Discard, req.Body)
+	_, _  = io.Copy(io.Discard, req.Body)
 {{- end }}
 {{- if .PathParams }}
 	{{- $binding := . }}


### PR DESCRIPTION
… body

Without this change, if the generated code uses Gosec, it may flag with a message similar to:

```
G104 (CWE-703): Errors unhandled (Confidence: HIGH, Severity: LOW)
    77: 	)
  > 78: 	io.Copy(io.Discard, req.Body)
    79: 	if err := req.ParseForm(); err != nil {
```

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes. I have regenerated some files following the instructions.

I did have to inject `export GOFLAGS=-buildvcs=false &&` into the bash command run in the first Docker command to avoid an error.

#### Brief description of what is fixed or changed

When [Gosec](https://github.com/securego/gosec) is used, the generated code generated a warning G104 due to the implicitly ignored error from `io.Copy`. This seems relatively harmless (aside from potentially ignoring errors from reading the request body), so making the ignore explicit to placate the security checker.

#### Other comments
