### PR TITLE
Set the pattern to the http.Request

### DIFF
--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -532,6 +532,7 @@ type handler struct {
 }
 
 func (s *ServeMux) handleHandler(h handler, w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+	r.Pattern = h.pat.GetPathPattern()
 	h.h(w, r.WithContext(withHTTPPattern(r.Context(), h.pat)), pathParams)
 }
 

--- a/runtime/pattern.go
+++ b/runtime/pattern.go
@@ -6,8 +6,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
 	"google.golang.org/grpc/grpclog"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
 )
 
 var (
@@ -254,6 +255,38 @@ func (p Pattern) String() string {
 		case utilities.OpCapture:
 			n := len(stack) - 1
 			stack[n] = fmt.Sprintf("{%s=%s}", p.vars[op.operand], stack[n])
+		}
+	}
+	segs := strings.Join(stack, "/")
+	if p.verb != "" {
+		return fmt.Sprintf("/%s:%s", segs, p.verb)
+	}
+	return "/" + segs
+}
+
+// GetPathPattern generates path pattern from the Pattern.
+// It does mostly the same as Pattern.String except it excludes
+// utilities.OpPush and utilities.OpPushM operands from the result.
+func (p Pattern) GetPathPattern() string {
+	var stack []string
+	for _, op := range p.ops {
+		switch op.code {
+		case utilities.OpNop:
+			continue
+		case utilities.OpPush:
+			stack = append(stack, "*")
+		case utilities.OpLitPush:
+			stack = append(stack, p.pool[op.operand])
+		case utilities.OpPushM:
+			stack = append(stack, "**")
+		case utilities.OpConcatN:
+			n := op.operand
+			l := len(stack) - n
+			stack = append(stack[:l], strings.Join(stack[l:], "/"))
+		case utilities.OpCapture:
+			n := len(stack) - 1
+			// just leave the operand and skip everything else
+			stack[n] = fmt.Sprintf("{%s}", p.vars[op.operand])
 		}
 	}
 	segs := strings.Join(stack, "/")

--- a/runtime/pattern.go
+++ b/runtime/pattern.go
@@ -6,9 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"google.golang.org/grpc/grpclog"
-
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
+	"google.golang.org/grpc/grpclog"
 )
 
 var (


### PR DESCRIPTION
#### References to other Issues or PRs

The PR is related to Issue #3700

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

Now `http.Request` has the `Pattern` field set. `httpServeMux` does this and other libraries make use of this value. Now `runtime.ServeMux` also populates this field.

#### Other comments

A bit more context in the [comment](https://github.com/grpc-ecosystem/grpc-gateway/issues/3700#issuecomment-2992238395)