### PR TITLE
fix: Use `summary/description` instead of title for field comments in OpenAPI generation

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -667,11 +667,8 @@ func renderFieldAsDefinition(f *descriptor.Field, reg *descriptor.Registry, refs
 		return openapiSchemaObject{}, err
 	}
 	comments := fieldProtoComments(reg, f.Message, f)
-	if len(comments) > 0 {
-		// Use title and description from field instead of nested message if present.
-		paragraphs := strings.Split(comments, paragraphDeliminator)
-		schema.Title = strings.TrimSpace(paragraphs[0])
-		schema.Description = strings.TrimSpace(strings.Join(paragraphs[1:], paragraphDeliminator))
+	if err := updateOpenAPIDataFromComments(reg, &schema, f, comments, false); err != nil {
+		return openapiSchemaObject{}, err
 	}
 
 	// to handle case where path param is present inside the field of descriptorpb.FieldDescriptorProto_TYPE_MESSAGE type


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

Fixes: ##3381

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

#### Other comments
