### PR TITLE
runtime/context: Fix context timeout cancellation in annotateContext

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -199,7 +199,9 @@ func annotateContext(ctx context.Context, mux *ServeMux, req *http.Request, rpcM
 	}
 
 	if timeout != 0 {
-		ctx, _ = context.WithTimeout(ctx, timeout)
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
 	}
 	if len(pairs) == 0 {
 		return ctx, nil, nil


### PR DESCRIPTION
Adds a deferred call to the cancel function returned by context.WithTimeout to ensure proper resource cleanup when a timeout is set in annotateContext.

resolves #5767