### PR TITLE
fix(runtime): annotate context even if no incoming headers

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -201,12 +201,12 @@ func annotateContext(ctx context.Context, mux *ServeMux, req *http.Request, rpcM
 	if timeout != 0 {
 		ctx, _ = context.WithTimeout(ctx, timeout)
 	}
-	if len(pairs) == 0 {
-		return ctx, nil, nil
-	}
 	md := metadata.Pairs(pairs...)
 	for _, mda := range mux.metadataAnnotators {
 		md = metadata.Join(md, mda(ctx, req))
+	}
+	if len(md) == 0 {
+		return ctx, nil, nil
 	}
 	return ctx, md, nil
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

Fixes #5885

#### Brief description of what is fixed or changed

Metadata annotator was not called when no incoming headers. In practice it's not happening in production since most requests will contain some sort of header. But it happens in some unit tests.

#### Other comments
