### PR TITLE
fix: annotate healthz endpoint handler

### DIFF
--- a/runtime/BUILD.bazel
+++ b/runtime/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//internal/httprule",
         "//utilities",
         "@org_golang_google_genproto_googleapis_api//httpbody",
+        "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//grpclog",
         "@org_golang_google_grpc//health/grpc_health_v1",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

- https://github.com/grpc-ecosystem/grpc-gateway/pull/2319
- https://github.com/grpc-ecosystem/grpc-gateway/pull/2587

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed


# Enhanced Context Annotation for Health Check Endpoint

## What's Changed
Added proper context annotation to the health check endpoint handler, including:
- GRPC method name annotation (`grpc_health_v1.Health_Check_FullMethodName`)
- HTTP path pattern information
- Server metadata handling for GRPC headers and trailers

## Why
The current implementation passes the raw context directly to the health check client without any GRPC Gateway-specific annotations. This means:
1. Observability tools and middleware can't properly trace the GRPC method being called
2. The HTTP endpoint information is not propagated through the context
3. GRPC metadata (headers/trailers) are not being handled

## Benefits
- Improved observability: Tracing and monitoring tools can now see the full request path from HTTP to GRPC
- Consistent behavior: The health endpoint now follows the same context annotation pattern as other endpoints
- Better debugging: Full context information available throughout the request lifecycle
- Proper metadata handling: GRPC headers and trailers are now properly managed

## Testing
The changes maintain existing functionality while adding context enrichment. All existing health check behaviors remain unchanged.



#### Other comments
