### PR TITLE
Feature: Add strict URL pattern validation to prevent routing issues

### DIFF
--- a/internal/httprule/parse.go
+++ b/internal/httprule/parse.go
@@ -21,6 +21,12 @@ func Parse(tmpl string) (Compiler, error) {
 	if !strings.HasPrefix(tmpl, "/") {
 		return template{}, InvalidTemplateError{tmpl: tmpl, msg: "no leading /"}
 	}
+
+	// Validate URL pattern will prevent invalid patterns issues
+	if err := ValidateTemplate(tmpl); err != nil {
+		return template{}, InvalidTemplateError{tmpl: tmpl, msg: err.Error()}
+	}
+
 	tokens, verb := tokenize(tmpl[1:])
 
 	p := parser{tokens: tokens}

--- a/internal/httprule/url_validator.go
+++ b/internal/httprule/url_validator.go
@@ -1,0 +1,190 @@
+package httprule
+
+import (
+	"fmt"
+	"strings"
+)
+
+// validation is enabled by default
+var (
+	validationEnabled = true // Always enabled ---> only disable for exceptional cases
+	defaultMaxStatic  = 4    // Conservative limit ---> only increase for exceptional cases
+)
+
+// URLPatternValidator validates URL patterns to prevent routing issues
+type URLPatternValidator struct {
+	MaxStaticSegmentsAtStart int
+	AllowConsecutiveStatics  bool
+}
+
+// ValidationError represents a URL pattern validation error
+type ValidationError struct {
+	Message string
+	Pattern string
+}
+
+func (e ValidationError) Error() string {
+	return fmt.Sprintf("invalid URL pattern: %s (pattern: %s)", e.Message, e.Pattern)
+}
+
+// SetURLValidationEnabled allows disabling validation only for exceptional cases
+// All patterns should follow the validation rules
+func SetURLValidationEnabled(enabled bool) {
+	validationEnabled = enabled
+}
+
+// SetMaxStaticSegments allows increasing the limit only for exceptional cases
+// Note: The default limit of 4 prevents routing issues ---> only increase if absolutely necessary
+func SetMaxStaticSegments(max int) {
+	defaultMaxStatic = max
+}
+
+// ValidateTemplate validates a URL template ---> always enforced by default
+// This prevents routing issues
+// Maximum 4 static segments at the beginning
+// No consecutive static segments after dynamic segments
+func ValidateTemplate(template string) error {
+	if !validationEnabled {
+		// Only allowed for exceptional cases
+		return nil
+	}
+
+	validator := &URLPatternValidator{
+		MaxStaticSegmentsAtStart: defaultMaxStatic,
+		AllowConsecutiveStatics:  false,
+	}
+	return validator.ValidateURLPattern(template)
+}
+
+// ValidateURLPattern validates a URL pattern according to the configured rules
+func (v *URLPatternValidator) ValidateURLPattern(pattern string) error {
+	if pattern == "" {
+		return ValidationError{
+			Message: "empty URL template",
+			Pattern: pattern,
+		}
+	}
+
+	if !strings.HasPrefix(pattern, "/") {
+		return ValidationError{
+			Message: "URL template must start with '/'",
+			Pattern: pattern,
+		}
+	}
+
+	// Remove leading slash and any verb suffix for analysis
+	pathOnly := strings.TrimPrefix(pattern, "/")
+	if colonIdx := strings.LastIndex(pathOnly, ":"); colonIdx > 0 {
+		// Check if this colon is part of a verb (not inside a variable)
+		if !strings.Contains(pathOnly[colonIdx:], "{") {
+			pathOnly = pathOnly[:colonIdx]
+		}
+	}
+
+	if pathOnly == "" {
+		// Root path "/" is valid
+		return nil
+	}
+
+	segments := v.parseSegments(pathOnly)
+	return v.validateSegments(segments, pattern)
+}
+
+// parseSegments properly parses path segments, handling complex variable definitions
+func (v *URLPatternValidator) parseSegments(path string) []string {
+	var segments []string
+	var current strings.Builder
+	braceCount := 0
+
+	for _, r := range path {
+		if r == '{' {
+			braceCount++
+		} else if r == '}' {
+			braceCount--
+		}
+
+		if r == '/' && braceCount == 0 {
+			// Only split on '/' when we're not inside braces
+			if current.Len() > 0 {
+				segments = append(segments, current.String())
+				current.Reset()
+			}
+		} else {
+			current.WriteRune(r)
+		}
+	}
+
+	// Add the last segment
+	if current.Len() > 0 {
+		segments = append(segments, current.String())
+	}
+
+	return segments
+}
+
+// validateSegments validates the sequence of path segments
+func (v *URLPatternValidator) validateSegments(segments []string, originalPattern string) error {
+	staticCount := 0
+	foundDynamic := false
+	lastWasStatic := false
+
+	for i, segment := range segments {
+		isStatic := v.isStaticSegment(segment)
+
+		if isStatic {
+			// Count consecutive static segments at the beginning
+			if !foundDynamic {
+				staticCount++
+			}
+
+			// Check for consecutive static segments after dynamic ones
+			if foundDynamic && lastWasStatic && !v.AllowConsecutiveStatics {
+				return ValidationError{
+					Message: fmt.Sprintf("static segment '%s' followed by static segment '%s' at positions %d-%d",
+						segments[i-1], segment, i, i+1),
+					Pattern: originalPattern,
+				}
+			}
+
+			lastWasStatic = true
+		} else {
+			foundDynamic = true
+			lastWasStatic = false
+		}
+	}
+
+	// Check if we exceed the maximum static segments at the start
+	if staticCount > v.MaxStaticSegmentsAtStart {
+		return ValidationError{
+			Message: fmt.Sprintf("more than %d static segments at the beginning: found %d",
+				v.MaxStaticSegmentsAtStart, staticCount),
+			Pattern: originalPattern,
+		}
+	}
+
+	return nil
+}
+
+// isStaticSegment determines if a segment is static (not a variable or wildcard)
+func (v *URLPatternValidator) isStaticSegment(segment string) bool {
+	// Handle special wildcards
+	if segment == "*" || segment == "**" {
+		return false
+	}
+	// Check if it's a variable ( is enclosed with these brackets ---> {} )
+	if strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}") {
+		return false
+	}
+
+	return true
+}
+
+// IsValidURLPattern is a convenience function to check if a URL pattern is valid
+func IsValidURLPattern(pattern string) bool {
+	return ValidateTemplate(pattern) == nil
+}
+
+// GetValidationConfig returns the current global validation configuration
+func GetValidationConfig() (enabled bool, maxStatic int) {
+	return validationEnabled, defaultMaxStatic
+}

--- a/internal/httprule/url_validator_test.go
+++ b/internal/httprule/url_validator_test.go
@@ -1,0 +1,295 @@
+package httprule
+
+import (
+	"testing"
+)
+
+func TestURLPatternValidator_ValidateURLPattern(t *testing.T) {
+	validator := &URLPatternValidator{
+		MaxStaticSegmentsAtStart: 4,
+		AllowConsecutiveStatics:  false,
+	}
+
+	testCases := []struct {
+		name        string
+		pattern     string
+		expectError bool
+		errorMsg    string
+	}{
+		// Valid patterns
+		{
+			name:        "Root path",
+			pattern:     "/",
+			expectError: false,
+		},
+		{
+			name:        "Simple dynamic pattern",
+			pattern:     "/{id}",
+			expectError: false,
+		},
+		{
+			name:        "Valid pattern with 4 static segments",
+			pattern:     "/api/compute/v1/instances/{instance_id}",
+			expectError: false,
+		},
+		{
+			name:        "Valid pattern with mixed segments",
+			pattern:     "/api/{service}/v1/{resource}",
+			expectError: false,
+		},
+		{
+			name:        "Valid pattern with wildcards",
+			pattern:     "/api/*/v1/{resource}",
+			expectError: false,
+		},
+		{
+			name:        "Valid pattern with deep wildcards",
+			pattern:     "/api/**/resources",
+			expectError: false,
+		},
+		{
+			name:        "Valid pattern with verb",
+			pattern:     "/api/compute/v1/{instance}:start",
+			expectError: false,
+		},
+		{
+			name:        "Dynamic followed by static",
+			pattern:     "/{service}/static/{resource}",
+			expectError: false,
+		},
+		{
+			name:        "Exactly 4 static segments at start",
+			pattern:     "/a/b/c/d/{dynamic}",
+			expectError: false,
+		},
+
+		// Invalid patterns - empty or malformed
+		{
+			name:        "Empty pattern",
+			pattern:     "",
+			expectError: true,
+			errorMsg:    "empty URL template",
+		},
+		{
+			name:        "No leading slash",
+			pattern:     "api/compute",
+			expectError: true,
+			errorMsg:    "URL template must start with '/'",
+		},
+
+		// Invalid patterns - too many static segments at start
+		{
+			name:        "5 static segments at beginning",
+			pattern:     "/api/mytenant/v1/idp/types/{type_id}",
+			expectError: true,
+			errorMsg:    "more than 4 static segments at the beginning: found 5",
+		},
+		{
+			name:        "6 static segments at beginning",
+			pattern:     "/a/b/c/d/e/f/{dynamic}",
+			expectError: true,
+			errorMsg:    "more than 4 static segments at the beginning: found 6",
+		},
+
+		// Invalid patterns - consecutive static segments after dynamic
+		{
+			name:        "Consecutive static after dynamic",
+			pattern:     "/api/{service}/static1/static2/{resource}",
+			expectError: true,
+			errorMsg:    "static segment 'static1' followed by static segment 'static2' at positions 3-4",
+		},
+		{
+			name:        "Multiple consecutive static after dynamic",
+			pattern:     "/{service}/a/b/c/{resource}",
+			expectError: true,
+			errorMsg:    "static segment 'a' followed by static segment 'b' at positions 2-3",
+		},
+
+		// Edge cases with verbs
+		{
+			name:        "Invalid pattern with verb - too many statics",
+			pattern:     "/api/mytenant/v1/idp/types/{type}:action",
+			expectError: true,
+			errorMsg:    "more than 4 static segments at the beginning: found 5",
+		},
+		{
+			name:        "Valid complex pattern with variables and verb",
+			pattern:     "/api/{service}/v1/{resource=projects/*/instances/*}:update",
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validator.ValidateURLPattern(tc.pattern)
+			
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected error for pattern %q, but got none", tc.pattern)
+					return
+				}
+				if tc.errorMsg != "" && !contains(err.Error(), tc.errorMsg) {
+					t.Errorf("Expected error message to contain %q, but got %q", tc.errorMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for pattern %q: %v", tc.pattern, err)
+				}
+			}
+		})
+	}
+}
+
+func TestURLPatternValidator_AllowConsecutiveStatics(t *testing.T) {
+	// Test validator that allows consecutive static segments
+	validator := &URLPatternValidator{
+		MaxStaticSegmentsAtStart: 4,
+		AllowConsecutiveStatics:  true,
+	}
+
+	testCases := []struct {
+		name        string
+		pattern     string
+		expectError bool
+	}{
+		{
+			name:        "Consecutive static after dynamic - allowed",
+			pattern:     "/api/{service}/static1/static2/{resource}",
+			expectError: false,
+		},
+		{
+			name:        "Multiple consecutive static - allowed",
+			pattern:     "/{service}/a/b/c/{resource}",
+			expectError: false,
+		},
+		{
+			name:        "Still fails on too many static at start",
+			pattern:     "/a/b/c/d/e/{dynamic}",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validator.ValidateURLPattern(tc.pattern)
+			
+			if tc.expectError && err == nil {
+				t.Errorf("Expected error for pattern %q, but got none", tc.pattern)
+			} else if !tc.expectError && err != nil {
+				t.Errorf("Unexpected error for pattern %q: %v", tc.pattern, err)
+			}
+		})
+	}
+}
+
+func TestValidateTemplate_GlobalConfiguration(t *testing.T) {
+	// Save original configuration
+	originalEnabled, originalMaxStatic := GetValidationConfig()
+	defer func() {
+		SetURLValidationEnabled(originalEnabled)
+		SetMaxStaticSegments(originalMaxStatic)
+	}()
+
+	// Test with validation disabled (should only be used for exceptional cases)
+	SetURLValidationEnabled(false)
+	err := ValidateTemplate("/a/b/c/d/e/f/{dynamic}")
+	if err != nil {
+		t.Errorf("Expected no error when validation disabled (exceptional case), got: %v", err)
+	}
+
+	// Test with validation enabled and custom max static (exceptional case)
+	SetURLValidationEnabled(true)
+	SetMaxStaticSegments(2)
+	
+	err = ValidateTemplate("/a/b/c/{dynamic}")
+	if err == nil {
+		t.Error("Expected error with max static segments = 2, but got none")
+	}
+
+	err = ValidateTemplate("/a/b/{dynamic}")
+	if err != nil {
+		t.Errorf("Unexpected error with valid pattern: %v", err)
+	}
+}
+
+func TestIsValidURLPattern(t *testing.T) {
+	testCases := []struct {
+		pattern string
+		valid   bool
+	}{
+		{"/api/compute/v1/{instance}", true},
+		{"/api/mytenant/v1/idp/types/{type}", false},
+		{"", false},
+		{"/", true},
+		{"/api/{service}/static1/static2/{resource}", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.pattern, func(t *testing.T) {
+			result := IsValidURLPattern(tc.pattern)
+			if result != tc.valid {
+				t.Errorf("Expected IsValidURLPattern(%q) = %v, got %v", tc.pattern, tc.valid, result)
+			}
+		})
+	}
+}
+
+func TestValidationError_Error(t *testing.T) {
+	err := ValidationError{
+		Message: "too many static segments",
+		Pattern: "/a/b/c/d/e/{id}",
+	}
+
+	expected := "invalid URL pattern: too many static segments (pattern: /a/b/c/d/e/{id})"
+	if err.Error() != expected {
+		t.Errorf("Expected error message %q, got %q", expected, err.Error())
+	}
+}
+
+func TestGetValidationConfig(t *testing.T) {
+	// Save original configuration
+	originalEnabled, originalMaxStatic := GetValidationConfig()
+	defer func() {
+		SetURLValidationEnabled(originalEnabled)
+		SetMaxStaticSegments(originalMaxStatic)
+	}()
+
+	// Test setting and getting configuration
+	SetURLValidationEnabled(false)
+	SetMaxStaticSegments(10)
+
+	enabled, maxStatic := GetValidationConfig()
+	if enabled != false || maxStatic != 10 {
+		t.Errorf("Expected config (enabled=false, maxStatic=10), got (enabled=%v, maxStatic=%v)", enabled, maxStatic)
+	}
+}
+
+// Helper function to check if a string contains a substring
+func contains(s, substr string) bool {
+	return len(substr) == 0 || (len(s) >= len(substr) && findSubstring(s, substr))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+// Benchmark tests
+func BenchmarkValidateTemplate(b *testing.B) {
+	patterns := []string{
+		"/api/compute/v1/{instance}",
+		"/api/mytenant/v1/idp/types/{type}",
+		"/api/{service}/v1/{resource}",
+		"/{service}/static1/static2/{resource}",
+	}
+
+	for i := 0; i < b.N; i++ {
+		for _, pattern := range patterns {
+			ValidateTemplate(pattern)
+		}
+	}
+}


### PR DESCRIPTION
Implement comprehensive URL pattern validation in grpc-gateway to prevent common routing conflicts and performance issues. Validation is enabled by default with strict enforcement to ensure API reliability.

Key features:
- Validates maximum 4 static segments at URL pattern start
- Prevents consecutive static segments after dynamic segments
- Fails compilation on invalid patterns with clear error messages

The validator integrates into the HTTP rule parsing pipeline and validates patterns during protobuf code generation. Invalid patterns cause compilation to fail, forcing developers to use proper URL design patterns.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

#### Other comments
