### PR TITLE
fix: avoid unnecessary package prefixes in OpenAPI names

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -2043,6 +2043,61 @@ func applyTemplate(p param) (*openapiSwaggerObject, error) {
 	// Find all the service's messages and enumerations that are defined (recursively)
 	// and write request, response and other custom (but referenced) types out as definition objects.
 	findServicesMessagesAndEnumerations(p.Services, p.reg, messages, streamingMessages, enums, requestResponseRefs)
+
+	// Build a set of messages/enums that are actually referenced in this file
+	// we should only consider naming collisions for types that are actually used
+	referencedNames := make(map[string]bool)
+
+	// Add all messages that are referenced (iterate over values to get FQMN, not keys)
+	for _, msg := range messages {
+		referencedNames[msg.FQMN()] = true
+	}
+
+	// Add all enums that are referenced
+	for _, enum := range enums {
+		referencedNames[enum.FQEN()] = true
+	}
+
+	// Add all method names
+	for _, svc := range p.Services {
+		for _, meth := range svc.Methods {
+			referencedNames[meth.FQMN()] = true
+		}
+	}
+
+	// Get all names from the registry
+	allFQMNs := p.reg.GetAllFQMNs()
+	allFQENs := p.reg.GetAllFQENs()
+	allFQMethNs := p.reg.GetAllFQMethNs()
+	allNames := append(append(allFQMNs, allFQENs...), allFQMethNs...)
+
+	// Filter: EXCLUDE names that are from a DIFFERENT package AND are NOT referenced
+	// This way we keep all names from the current package, and all referenced names from other packages
+	// We also keep google.* packages since they are standard dependencies
+	currentPackage := p.File.GetPackage()
+	filteredNames := make([]string, 0, len(allNames))
+	for _, name := range allNames {
+		// Determine the package of this name
+		// Names are like ".package.Type" or ".package.subpackage.Type"
+		// We want to extract the top-level package
+		parts := strings.Split(strings.TrimPrefix(name, "."), ".")
+		if len(parts) == 0 {
+			continue
+		}
+		namePackage := parts[0]
+
+		// Include if: (1) from current package, OR (2) actually referenced, OR (3) from google.* packages
+		if namePackage == currentPackage || referencedNames[name] || namePackage == "google" {
+			filteredNames = append(filteredNames, name)
+		}
+	}
+
+	// Clear and recompute the naming cache based only on names that are actually in scope
+	registriesSeenMutex.Lock()
+	resolvedNames := resolveFullyQualifiedNameToOpenAPINames(filteredNames, p.reg.GetOpenAPINamingStrategy())
+	registriesSeen[p.reg] = resolvedNames
+	registriesSeenMutex.Unlock()
+
 	if err := renderMessagesAsDefinition(messages, s.Definitions, p.reg, customRefs, nil); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Fixes #5799

#### References to other Issues or PRs

Fixes #5799

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

Prevents unnecessary package prefixes in OpenAPI definition names when using `package` or `simple` naming strategies.

**Problem:** The generator was adding package prefixes (e.g., `foo.Foo`) even when no actual naming collision existed in the generated spec. This happened because collision detection used ALL messages from the registry, including unreferenced imports.

**Solution:** Filter the name set before collision detection to only include:
- All names from the current package
- Names from other packages that are actually referenced in the spec
- Standard `google.*` packages

This ensures only real collisions trigger prefixes while maintaining backward compatibility.

**Example:**
```protobuf
// foo.proto - references other.Other but NOT other.Foo
message Foo {
  other.Other other = 1;
}
```

Before: `"definitions": { "foo.Foo": {...} }`  
After: `"definitions": { "Foo": {...} }`

#### Other comments

- All existing tests pass
- No breaking changes - only affects cases with phantom collisions from unreferenced imports
- Tested with the reproduction case from the issue