### PR TITLE
Add note about Authorization header forwarding

### DIFF
--- a/docs/docs/mapping/customizing_your_gateway.md
+++ b/docs/docs/mapping/customizing_your_gateway.md
@@ -102,7 +102,7 @@ mux := runtime.NewServeMux(
 )
 ```
 
-Note: The incoming `Authorization` HTTP header can not be removed or overwritten. It will always be forwarded in the gRPC metadata under the `authorization` key.
+Note: The incoming `Authorization` HTTP header can not be removed or overwritten. It will always be forwarded in the gRPC metadata under the `authorization` key. However, values can be appended.
 
 ## Mapping from HTTP request headers to gRPC client metadata
 


### PR DESCRIPTION
#### Brief description of what is fixed or changed

A note was added to the documentation explaining that the incoming `Authorization` HTTP header can not be removed or overwritten. It will always be forwarded in the gRPC metadata under the `authorization` key.

[Source code link](https://github.com/grpc-ecosystem/grpc-gateway/blob/e82fdffab96891c29e9db808cd82381bde5f439f/runtime/context.go#L159-L162)