### PR TITLE
fix(gengateway): correct body field decoding in opaque API mode

### DIFF
--- a/examples/internal/proto/examplepb/opaque.pb.go
+++ b/examples/internal/proto/examplepb/opaque.pb.go
@@ -1160,6 +1160,352 @@ func (b0 OpaqueSearchProductsResponse_builder) Build() *OpaqueSearchProductsResp
 	return m0
 }
 
+// OpaqueCreateProductRequest represents a request to create a product
+type OpaqueCreateProductRequest struct {
+	state                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_ProductId   *string                `protobuf:"bytes,1,opt,name=product_id,json=productId"`
+	xxx_hidden_Product     *OpaqueProduct         `protobuf:"bytes,2,opt,name=product"`
+	XXX_raceDetectHookData protoimpl.RaceDetectHookData
+	XXX_presence           [1]uint32
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *OpaqueCreateProductRequest) Reset() {
+	*x = OpaqueCreateProductRequest{}
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OpaqueCreateProductRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OpaqueCreateProductRequest) ProtoMessage() {}
+
+func (x *OpaqueCreateProductRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *OpaqueCreateProductRequest) GetProductId() string {
+	if x != nil {
+		if x.xxx_hidden_ProductId != nil {
+			return *x.xxx_hidden_ProductId
+		}
+		return ""
+	}
+	return ""
+}
+
+func (x *OpaqueCreateProductRequest) GetProduct() *OpaqueProduct {
+	if x != nil {
+		return x.xxx_hidden_Product
+	}
+	return nil
+}
+
+func (x *OpaqueCreateProductRequest) SetProductId(v string) {
+	x.xxx_hidden_ProductId = &v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 2)
+}
+
+func (x *OpaqueCreateProductRequest) SetProduct(v *OpaqueProduct) {
+	x.xxx_hidden_Product = v
+}
+
+func (x *OpaqueCreateProductRequest) HasProductId() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 0)
+}
+
+func (x *OpaqueCreateProductRequest) HasProduct() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Product != nil
+}
+
+func (x *OpaqueCreateProductRequest) ClearProductId() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
+	x.xxx_hidden_ProductId = nil
+}
+
+func (x *OpaqueCreateProductRequest) ClearProduct() {
+	x.xxx_hidden_Product = nil
+}
+
+type OpaqueCreateProductRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	ProductId *string
+	Product   *OpaqueProduct
+}
+
+func (b0 OpaqueCreateProductRequest_builder) Build() *OpaqueCreateProductRequest {
+	m0 := &OpaqueCreateProductRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	if b.ProductId != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 2)
+		x.xxx_hidden_ProductId = b.ProductId
+	}
+	x.xxx_hidden_Product = b.Product
+	return m0
+}
+
+// OpaqueCreateProductResponse represents the created product
+type OpaqueCreateProductResponse struct {
+	state              protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Product *OpaqueProduct         `protobuf:"bytes,1,opt,name=product"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *OpaqueCreateProductResponse) Reset() {
+	*x = OpaqueCreateProductResponse{}
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OpaqueCreateProductResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OpaqueCreateProductResponse) ProtoMessage() {}
+
+func (x *OpaqueCreateProductResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *OpaqueCreateProductResponse) GetProduct() *OpaqueProduct {
+	if x != nil {
+		return x.xxx_hidden_Product
+	}
+	return nil
+}
+
+func (x *OpaqueCreateProductResponse) SetProduct(v *OpaqueProduct) {
+	x.xxx_hidden_Product = v
+}
+
+func (x *OpaqueCreateProductResponse) HasProduct() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Product != nil
+}
+
+func (x *OpaqueCreateProductResponse) ClearProduct() {
+	x.xxx_hidden_Product = nil
+}
+
+type OpaqueCreateProductResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Product *OpaqueProduct
+}
+
+func (b0 OpaqueCreateProductResponse_builder) Build() *OpaqueCreateProductResponse {
+	m0 := &OpaqueCreateProductResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Product = b.Product
+	return m0
+}
+
+// OpaqueCreateProductFieldRequest represents a request to create a product
+type OpaqueCreateProductFieldRequest struct {
+	state                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_ProductId   *string                `protobuf:"bytes,1,opt,name=product_id,json=productId"`
+	xxx_hidden_Product     *OpaqueProduct         `protobuf:"bytes,2,opt,name=product"`
+	XXX_raceDetectHookData protoimpl.RaceDetectHookData
+	XXX_presence           [1]uint32
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *OpaqueCreateProductFieldRequest) Reset() {
+	*x = OpaqueCreateProductFieldRequest{}
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OpaqueCreateProductFieldRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OpaqueCreateProductFieldRequest) ProtoMessage() {}
+
+func (x *OpaqueCreateProductFieldRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *OpaqueCreateProductFieldRequest) GetProductId() string {
+	if x != nil {
+		if x.xxx_hidden_ProductId != nil {
+			return *x.xxx_hidden_ProductId
+		}
+		return ""
+	}
+	return ""
+}
+
+func (x *OpaqueCreateProductFieldRequest) GetProduct() *OpaqueProduct {
+	if x != nil {
+		return x.xxx_hidden_Product
+	}
+	return nil
+}
+
+func (x *OpaqueCreateProductFieldRequest) SetProductId(v string) {
+	x.xxx_hidden_ProductId = &v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 2)
+}
+
+func (x *OpaqueCreateProductFieldRequest) SetProduct(v *OpaqueProduct) {
+	x.xxx_hidden_Product = v
+}
+
+func (x *OpaqueCreateProductFieldRequest) HasProductId() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 0)
+}
+
+func (x *OpaqueCreateProductFieldRequest) HasProduct() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Product != nil
+}
+
+func (x *OpaqueCreateProductFieldRequest) ClearProductId() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
+	x.xxx_hidden_ProductId = nil
+}
+
+func (x *OpaqueCreateProductFieldRequest) ClearProduct() {
+	x.xxx_hidden_Product = nil
+}
+
+type OpaqueCreateProductFieldRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	ProductId *string
+	Product   *OpaqueProduct
+}
+
+func (b0 OpaqueCreateProductFieldRequest_builder) Build() *OpaqueCreateProductFieldRequest {
+	m0 := &OpaqueCreateProductFieldRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	if b.ProductId != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 2)
+		x.xxx_hidden_ProductId = b.ProductId
+	}
+	x.xxx_hidden_Product = b.Product
+	return m0
+}
+
+// OpaqueCreateProductFieldResponse represents the created product
+type OpaqueCreateProductFieldResponse struct {
+	state              protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Product *OpaqueProduct         `protobuf:"bytes,1,opt,name=product"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *OpaqueCreateProductFieldResponse) Reset() {
+	*x = OpaqueCreateProductFieldResponse{}
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OpaqueCreateProductFieldResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OpaqueCreateProductFieldResponse) ProtoMessage() {}
+
+func (x *OpaqueCreateProductFieldResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *OpaqueCreateProductFieldResponse) GetProduct() *OpaqueProduct {
+	if x != nil {
+		return x.xxx_hidden_Product
+	}
+	return nil
+}
+
+func (x *OpaqueCreateProductFieldResponse) SetProduct(v *OpaqueProduct) {
+	x.xxx_hidden_Product = v
+}
+
+func (x *OpaqueCreateProductFieldResponse) HasProduct() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Product != nil
+}
+
+func (x *OpaqueCreateProductFieldResponse) ClearProduct() {
+	x.xxx_hidden_Product = nil
+}
+
+type OpaqueCreateProductFieldResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Product *OpaqueProduct
+}
+
+func (b0 OpaqueCreateProductFieldResponse_builder) Build() *OpaqueCreateProductFieldResponse {
+	m0 := &OpaqueCreateProductFieldResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Product = b.Product
+	return m0
+}
+
 // OpaqueProcessOrdersRequest represents a request to process order
 type OpaqueProcessOrdersRequest struct {
 	state            protoimpl.MessageState `protogen:"opaque.v1"`
@@ -1170,7 +1516,7 @@ type OpaqueProcessOrdersRequest struct {
 
 func (x *OpaqueProcessOrdersRequest) Reset() {
 	*x = OpaqueProcessOrdersRequest{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[4]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1182,7 +1528,7 @@ func (x *OpaqueProcessOrdersRequest) String() string {
 func (*OpaqueProcessOrdersRequest) ProtoMessage() {}
 
 func (x *OpaqueProcessOrdersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[4]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1239,7 +1585,7 @@ type OpaqueProcessOrdersResponse struct {
 
 func (x *OpaqueProcessOrdersResponse) Reset() {
 	*x = OpaqueProcessOrdersResponse{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[5]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1251,7 +1597,7 @@ func (x *OpaqueProcessOrdersResponse) String() string {
 func (*OpaqueProcessOrdersResponse) ProtoMessage() {}
 
 func (x *OpaqueProcessOrdersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[5]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1308,7 +1654,7 @@ type OpaqueStreamCustomerActivityRequest struct {
 
 func (x *OpaqueStreamCustomerActivityRequest) Reset() {
 	*x = OpaqueStreamCustomerActivityRequest{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[6]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1320,7 +1666,7 @@ func (x *OpaqueStreamCustomerActivityRequest) String() string {
 func (*OpaqueStreamCustomerActivityRequest) ProtoMessage() {}
 
 func (x *OpaqueStreamCustomerActivityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[6]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1377,7 +1723,7 @@ type OpaqueStreamCustomerActivityResponse struct {
 
 func (x *OpaqueStreamCustomerActivityResponse) Reset() {
 	*x = OpaqueStreamCustomerActivityResponse{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[7]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1389,7 +1735,7 @@ func (x *OpaqueStreamCustomerActivityResponse) String() string {
 func (*OpaqueStreamCustomerActivityResponse) ProtoMessage() {}
 
 func (x *OpaqueStreamCustomerActivityResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[7]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1456,7 +1802,7 @@ type OpaqueAddress struct {
 
 func (x *OpaqueAddress) Reset() {
 	*x = OpaqueAddress{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[8]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1468,7 +1814,7 @@ func (x *OpaqueAddress) String() string {
 func (*OpaqueAddress) ProtoMessage() {}
 
 func (x *OpaqueAddress) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[8]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1767,7 +2113,7 @@ type OpaquePrice struct {
 
 func (x *OpaquePrice) Reset() {
 	*x = OpaquePrice{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[9]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1779,7 +2125,7 @@ func (x *OpaquePrice) String() string {
 func (*OpaquePrice) ProtoMessage() {}
 
 func (x *OpaquePrice) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[9]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1958,7 +2304,7 @@ type OpaqueProductCategory struct {
 
 func (x *OpaqueProductCategory) Reset() {
 	*x = OpaqueProductCategory{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[10]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1970,7 +2316,7 @@ func (x *OpaqueProductCategory) String() string {
 func (*OpaqueProductCategory) ProtoMessage() {}
 
 func (x *OpaqueProductCategory) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[10]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2195,7 +2541,7 @@ type OpaqueProductVariant struct {
 
 func (x *OpaqueProductVariant) Reset() {
 	*x = OpaqueProductVariant{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[11]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2207,7 +2553,7 @@ func (x *OpaqueProductVariant) String() string {
 func (*OpaqueProductVariant) ProtoMessage() {}
 
 func (x *OpaqueProductVariant) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[11]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2557,7 +2903,7 @@ func (b0 OpaqueProductVariant_builder) Build() *OpaqueProductVariant {
 type case_OpaqueProductVariant_DiscountInfo protoreflect.FieldNumber
 
 func (x case_OpaqueProductVariant_DiscountInfo) String() string {
-	md := file_examples_internal_proto_examplepb_opaque_proto_msgTypes[11].Descriptor()
+	md := file_examples_internal_proto_examplepb_opaque_proto_msgTypes[15].Descriptor()
 	if x == 0 {
 		return "not set"
 	}
@@ -2610,7 +2956,7 @@ type OpaqueProduct struct {
 
 func (x *OpaqueProduct) Reset() {
 	*x = OpaqueProduct{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[12]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2622,7 +2968,7 @@ func (x *OpaqueProduct) String() string {
 func (*OpaqueProduct) ProtoMessage() {}
 
 func (x *OpaqueProduct) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[12]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3180,7 +3526,7 @@ func (b0 OpaqueProduct_builder) Build() *OpaqueProduct {
 type case_OpaqueProduct_TaxInfo protoreflect.FieldNumber
 
 func (x case_OpaqueProduct_TaxInfo) String() string {
-	md := file_examples_internal_proto_examplepb_opaque_proto_msgTypes[12].Descriptor()
+	md := file_examples_internal_proto_examplepb_opaque_proto_msgTypes[16].Descriptor()
 	if x == 0 {
 		return "not set"
 	}
@@ -3226,7 +3572,7 @@ type OpaqueCustomer struct {
 
 func (x *OpaqueCustomer) Reset() {
 	*x = OpaqueCustomer{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[13]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3238,7 +3584,7 @@ func (x *OpaqueCustomer) String() string {
 func (*OpaqueCustomer) ProtoMessage() {}
 
 func (x *OpaqueCustomer) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[13]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3587,7 +3933,7 @@ type OpaqueOrderItem struct {
 
 func (x *OpaqueOrderItem) Reset() {
 	*x = OpaqueOrderItem{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[14]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3599,7 +3945,7 @@ func (x *OpaqueOrderItem) String() string {
 func (*OpaqueOrderItem) ProtoMessage() {}
 
 func (x *OpaqueOrderItem) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[14]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3894,7 +4240,7 @@ type OpaqueOrder struct {
 
 func (x *OpaqueOrder) Reset() {
 	*x = OpaqueOrder{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[15]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3906,7 +4252,7 @@ func (x *OpaqueOrder) String() string {
 func (*OpaqueOrder) ProtoMessage() {}
 
 func (x *OpaqueOrder) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[15]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4476,7 +4822,7 @@ func (b0 OpaqueOrder_builder) Build() *OpaqueOrder {
 type case_OpaqueOrder_DiscountApplied protoreflect.FieldNumber
 
 func (x case_OpaqueOrder_DiscountApplied) String() string {
-	md := file_examples_internal_proto_examplepb_opaque_proto_msgTypes[15].Descriptor()
+	md := file_examples_internal_proto_examplepb_opaque_proto_msgTypes[19].Descriptor()
 	if x == 0 {
 		return "not set"
 	}
@@ -4518,7 +4864,7 @@ type OpaqueOrderSummary struct {
 
 func (x *OpaqueOrderSummary) Reset() {
 	*x = OpaqueOrderSummary{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[16]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4530,7 +4876,7 @@ func (x *OpaqueOrderSummary) String() string {
 func (*OpaqueOrderSummary) ProtoMessage() {}
 
 func (x *OpaqueOrderSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[16]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4753,7 +5099,7 @@ type OpaqueCustomerEvent struct {
 
 func (x *OpaqueCustomerEvent) Reset() {
 	*x = OpaqueCustomerEvent{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[17]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4765,7 +5111,7 @@ func (x *OpaqueCustomerEvent) String() string {
 func (*OpaqueCustomerEvent) ProtoMessage() {}
 
 func (x *OpaqueCustomerEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[17]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5198,7 +5544,7 @@ type OpaqueActivityUpdate struct {
 
 func (x *OpaqueActivityUpdate) Reset() {
 	*x = OpaqueActivityUpdate{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[18]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5210,7 +5556,7 @@ func (x *OpaqueActivityUpdate) String() string {
 func (*OpaqueActivityUpdate) ProtoMessage() {}
 
 func (x *OpaqueActivityUpdate) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[18]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5673,7 +6019,7 @@ func (b0 OpaqueActivityUpdate_builder) Build() *OpaqueActivityUpdate {
 type case_OpaqueActivityUpdate_ActionData protoreflect.FieldNumber
 
 func (x case_OpaqueActivityUpdate_ActionData) String() string {
-	md := file_examples_internal_proto_examplepb_opaque_proto_msgTypes[18].Descriptor()
+	md := file_examples_internal_proto_examplepb_opaque_proto_msgTypes[22].Descriptor()
 	if x == 0 {
 		return "not set"
 	}
@@ -5711,7 +6057,7 @@ type OpaqueProduct_OpaqueProductDimensions struct {
 
 func (x *OpaqueProduct_OpaqueProductDimensions) Reset() {
 	*x = OpaqueProduct_OpaqueProductDimensions{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[24]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5723,7 +6069,7 @@ func (x *OpaqueProduct_OpaqueProductDimensions) String() string {
 func (*OpaqueProduct_OpaqueProductDimensions) ProtoMessage() {}
 
 func (x *OpaqueProduct_OpaqueProductDimensions) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[24]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5907,7 +6253,7 @@ type OpaqueCustomer_OpaqueLoyaltyInfo struct {
 
 func (x *OpaqueCustomer_OpaqueLoyaltyInfo) Reset() {
 	*x = OpaqueCustomer_OpaqueLoyaltyInfo{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[25]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5919,7 +6265,7 @@ func (x *OpaqueCustomer_OpaqueLoyaltyInfo) String() string {
 func (*OpaqueCustomer_OpaqueLoyaltyInfo) ProtoMessage() {}
 
 func (x *OpaqueCustomer_OpaqueLoyaltyInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[25]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6056,7 +6402,7 @@ type OpaqueCustomer_OpaquePaymentMethod struct {
 
 func (x *OpaqueCustomer_OpaquePaymentMethod) Reset() {
 	*x = OpaqueCustomer_OpaquePaymentMethod{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[27]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6068,7 +6414,7 @@ func (x *OpaqueCustomer_OpaquePaymentMethod) String() string {
 func (*OpaqueCustomer_OpaquePaymentMethod) ProtoMessage() {}
 
 func (x *OpaqueCustomer_OpaquePaymentMethod) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[27]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6286,7 +6632,7 @@ type OpaqueOrder_OpaqueShippingInfo struct {
 
 func (x *OpaqueOrder_OpaqueShippingInfo) Reset() {
 	*x = OpaqueOrder_OpaqueShippingInfo{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[29]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6298,7 +6644,7 @@ func (x *OpaqueOrder_OpaqueShippingInfo) String() string {
 func (*OpaqueOrder_OpaqueShippingInfo) ProtoMessage() {}
 
 func (x *OpaqueOrder_OpaqueShippingInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[29]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6435,7 +6781,7 @@ type OpaqueOrderSummary_OpaqueOrderError struct {
 
 func (x *OpaqueOrderSummary_OpaqueOrderError) Reset() {
 	*x = OpaqueOrderSummary_OpaqueOrderError{}
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[32]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6447,7 +6793,7 @@ func (x *OpaqueOrderSummary_OpaqueOrderError) String() string {
 func (*OpaqueOrderSummary_OpaqueOrderError) ProtoMessage() {}
 
 func (x *OpaqueOrderSummary_OpaqueOrderError) ProtoReflect() protoreflect.Message {
-	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[32]
+	mi := &file_examples_internal_proto_examplepb_opaque_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6608,6 +6954,18 @@ const file_examples_internal_proto_examplepb_opaque_proto_rawDesc = "" +
 	"\x18OPAQUE_SORT_ORDER_RATING\x10\x05\x12 \n" +
 	"\x1cOPAQUE_SORT_ORDER_POPULARITY\x10\x06\"w\n" +
 	"\x1cOpaqueSearchProductsResponse\x12W\n" +
+	"\aproduct\x18\x01 \x01(\v2=.grpc.gateway.examples.internal.proto.examplepb.OpaqueProductR\aproduct\"\x94\x01\n" +
+	"\x1aOpaqueCreateProductRequest\x12\x1d\n" +
+	"\n" +
+	"product_id\x18\x01 \x01(\tR\tproductId\x12W\n" +
+	"\aproduct\x18\x02 \x01(\v2=.grpc.gateway.examples.internal.proto.examplepb.OpaqueProductR\aproduct\"v\n" +
+	"\x1bOpaqueCreateProductResponse\x12W\n" +
+	"\aproduct\x18\x01 \x01(\v2=.grpc.gateway.examples.internal.proto.examplepb.OpaqueProductR\aproduct\"\x99\x01\n" +
+	"\x1fOpaqueCreateProductFieldRequest\x12\x1d\n" +
+	"\n" +
+	"product_id\x18\x01 \x01(\tR\tproductId\x12W\n" +
+	"\aproduct\x18\x02 \x01(\v2=.grpc.gateway.examples.internal.proto.examplepb.OpaqueProductR\aproduct\"{\n" +
+	" OpaqueCreateProductFieldResponse\x12W\n" +
 	"\aproduct\x18\x01 \x01(\v2=.grpc.gateway.examples.internal.proto.examplepb.OpaqueProductR\aproduct\"o\n" +
 	"\x1aOpaqueProcessOrdersRequest\x12Q\n" +
 	"\x05order\x18\x01 \x01(\v2;.grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderR\x05order\"{\n" +
@@ -6925,15 +7283,18 @@ const file_examples_internal_proto_examplepb_opaque_proto_rawDesc = "" +
 	"#OPAQUE_UPDATE_TYPE_INVENTORY_UPDATE\x10\x04\x12#\n" +
 	"\x1fOPAQUE_UPDATE_TYPE_PRICE_CHANGE\x10\x05\x12$\n" +
 	" OPAQUE_UPDATE_TYPE_CART_REMINDER\x10\x06B\r\n" +
-	"\vaction_data2\xfa\x06\n" +
+	"\vaction_data2\xa8\n" +
+	"\n" +
 	"\x16OpaqueEcommerceService\x12\xc8\x01\n" +
 	"\x10OpaqueGetProduct\x12G.grpc.gateway.examples.internal.proto.examplepb.OpaqueGetProductRequest\x1aH.grpc.gateway.examples.internal.proto.examplepb.OpaqueGetProductResponse\"!\x82\xd3\xe4\x93\x02\x1b\x12\x19/v1/products/{product_id}\x12\xd0\x01\n" +
-	"\x14OpaqueSearchProducts\x12K.grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest\x1aL.grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsResponse\"\x1b\x82\xd3\xe4\x93\x02\x15\x12\x13/v1/products/search0\x01\x12\xcf\x01\n" +
+	"\x14OpaqueSearchProducts\x12K.grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest\x1aL.grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsResponse\"\x1b\x82\xd3\xe4\x93\x02\x15\x12\x13/v1/products/search0\x01\x12\xc7\x01\n" +
+	"\x13OpaqueCreateProduct\x12J.grpc.gateway.examples.internal.proto.examplepb.OpaqueCreateProductRequest\x1aK.grpc.gateway.examples.internal.proto.examplepb.OpaqueCreateProductResponse\"\x17\x82\xd3\xe4\x93\x02\x11:\x01*\"\f/v1/products\x12\xe1\x01\n" +
+	"\x18OpaqueCreateProductField\x12O.grpc.gateway.examples.internal.proto.examplepb.OpaqueCreateProductFieldRequest\x1aP.grpc.gateway.examples.internal.proto.examplepb.OpaqueCreateProductFieldResponse\"\"\x82\xd3\xe4\x93\x02\x1c:\aproduct\"\x11/v1/productsField\x12\xcf\x01\n" +
 	"\x13OpaqueProcessOrders\x12J.grpc.gateway.examples.internal.proto.examplepb.OpaqueProcessOrdersRequest\x1aK.grpc.gateway.examples.internal.proto.examplepb.OpaqueProcessOrdersResponse\"\x1d\x82\xd3\xe4\x93\x02\x17:\x01*\"\x12/v1/orders/process(\x01\x12\xef\x01\n" +
 	"\x1cOpaqueStreamCustomerActivity\x12S.grpc.gateway.examples.internal.proto.examplepb.OpaqueStreamCustomerActivityRequest\x1aT.grpc.gateway.examples.internal.proto.examplepb.OpaqueStreamCustomerActivityResponse\" \x82\xd3\xe4\x93\x02\x1a:\x01*\"\x15/v1/customer/activity(\x010\x01BMZKgithub.com/grpc-ecosystem/grpc-gateway/v2/examples/internal/proto/examplepbb\beditionsp\xe8\a"
 
 var file_examples_internal_proto_examplepb_opaque_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_examples_internal_proto_examplepb_opaque_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
+var file_examples_internal_proto_examplepb_opaque_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
 var file_examples_internal_proto_examplepb_opaque_proto_goTypes = []any{
 	(OpaqueSearchProductsRequest_OpaqueSortOrder)(0),      // 0: grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest.OpaqueSortOrder
 	(OpaqueAddress_OpaqueAddressType)(0),                  // 1: grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress.OpaqueAddressType
@@ -6947,132 +7308,144 @@ var file_examples_internal_proto_examplepb_opaque_proto_goTypes = []any{
 	(*OpaqueGetProductResponse)(nil),                      // 9: grpc.gateway.examples.internal.proto.examplepb.OpaqueGetProductResponse
 	(*OpaqueSearchProductsRequest)(nil),                   // 10: grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest
 	(*OpaqueSearchProductsResponse)(nil),                  // 11: grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsResponse
-	(*OpaqueProcessOrdersRequest)(nil),                    // 12: grpc.gateway.examples.internal.proto.examplepb.OpaqueProcessOrdersRequest
-	(*OpaqueProcessOrdersResponse)(nil),                   // 13: grpc.gateway.examples.internal.proto.examplepb.OpaqueProcessOrdersResponse
-	(*OpaqueStreamCustomerActivityRequest)(nil),           // 14: grpc.gateway.examples.internal.proto.examplepb.OpaqueStreamCustomerActivityRequest
-	(*OpaqueStreamCustomerActivityResponse)(nil),          // 15: grpc.gateway.examples.internal.proto.examplepb.OpaqueStreamCustomerActivityResponse
-	(*OpaqueAddress)(nil),                                 // 16: grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress
-	(*OpaquePrice)(nil),                                   // 17: grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
-	(*OpaqueProductCategory)(nil),                         // 18: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductCategory
-	(*OpaqueProductVariant)(nil),                          // 19: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductVariant
-	(*OpaqueProduct)(nil),                                 // 20: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct
-	(*OpaqueCustomer)(nil),                                // 21: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer
-	(*OpaqueOrderItem)(nil),                               // 22: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderItem
-	(*OpaqueOrder)(nil),                                   // 23: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder
-	(*OpaqueOrderSummary)(nil),                            // 24: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary
-	(*OpaqueCustomerEvent)(nil),                           // 25: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomerEvent
-	(*OpaqueActivityUpdate)(nil),                          // 26: grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate
-	nil,                                                   // 27: grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest.FiltersEntry
-	nil,                                                   // 28: grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress.MetadataEntry
-	nil,                                                   // 29: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductVariant.AttributesEntry
-	nil,                                                   // 30: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.MetadataEntry
-	nil,                                                   // 31: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.RegionalPricesEntry
-	(*OpaqueProduct_OpaqueProductDimensions)(nil),         // 32: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.OpaqueProductDimensions
-	(*OpaqueCustomer_OpaqueLoyaltyInfo)(nil),              // 33: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.OpaqueLoyaltyInfo
-	nil,                                                   // 34: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.PreferencesEntry
-	(*OpaqueCustomer_OpaquePaymentMethod)(nil),            // 35: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.OpaquePaymentMethod
-	nil,                                    // 36: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderItem.SelectedAttributesEntry
-	(*OpaqueOrder_OpaqueShippingInfo)(nil), // 37: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.OpaqueShippingInfo
-	nil,                                    // 38: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.MetadataEntry
-	nil,                                    // 39: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary.ErrorDetailsEntry
-	(*OpaqueOrderSummary_OpaqueOrderError)(nil), // 40: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary.OpaqueOrderError
-	nil,                            // 41: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomerEvent.EventDataEntry
-	nil,                            // 42: grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate.UpdateDataEntry
-	(*fieldmaskpb.FieldMask)(nil),  // 43: google.protobuf.FieldMask
-	(*wrapperspb.BoolValue)(nil),   // 44: google.protobuf.BoolValue
-	(*wrapperspb.DoubleValue)(nil), // 45: google.protobuf.DoubleValue
-	(*timestamppb.Timestamp)(nil),  // 46: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),    // 47: google.protobuf.Duration
+	(*OpaqueCreateProductRequest)(nil),                    // 12: grpc.gateway.examples.internal.proto.examplepb.OpaqueCreateProductRequest
+	(*OpaqueCreateProductResponse)(nil),                   // 13: grpc.gateway.examples.internal.proto.examplepb.OpaqueCreateProductResponse
+	(*OpaqueCreateProductFieldRequest)(nil),               // 14: grpc.gateway.examples.internal.proto.examplepb.OpaqueCreateProductFieldRequest
+	(*OpaqueCreateProductFieldResponse)(nil),              // 15: grpc.gateway.examples.internal.proto.examplepb.OpaqueCreateProductFieldResponse
+	(*OpaqueProcessOrdersRequest)(nil),                    // 16: grpc.gateway.examples.internal.proto.examplepb.OpaqueProcessOrdersRequest
+	(*OpaqueProcessOrdersResponse)(nil),                   // 17: grpc.gateway.examples.internal.proto.examplepb.OpaqueProcessOrdersResponse
+	(*OpaqueStreamCustomerActivityRequest)(nil),           // 18: grpc.gateway.examples.internal.proto.examplepb.OpaqueStreamCustomerActivityRequest
+	(*OpaqueStreamCustomerActivityResponse)(nil),          // 19: grpc.gateway.examples.internal.proto.examplepb.OpaqueStreamCustomerActivityResponse
+	(*OpaqueAddress)(nil),                                 // 20: grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress
+	(*OpaquePrice)(nil),                                   // 21: grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
+	(*OpaqueProductCategory)(nil),                         // 22: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductCategory
+	(*OpaqueProductVariant)(nil),                          // 23: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductVariant
+	(*OpaqueProduct)(nil),                                 // 24: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct
+	(*OpaqueCustomer)(nil),                                // 25: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer
+	(*OpaqueOrderItem)(nil),                               // 26: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderItem
+	(*OpaqueOrder)(nil),                                   // 27: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder
+	(*OpaqueOrderSummary)(nil),                            // 28: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary
+	(*OpaqueCustomerEvent)(nil),                           // 29: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomerEvent
+	(*OpaqueActivityUpdate)(nil),                          // 30: grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate
+	nil,                                                   // 31: grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest.FiltersEntry
+	nil,                                                   // 32: grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress.MetadataEntry
+	nil,                                                   // 33: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductVariant.AttributesEntry
+	nil,                                                   // 34: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.MetadataEntry
+	nil,                                                   // 35: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.RegionalPricesEntry
+	(*OpaqueProduct_OpaqueProductDimensions)(nil),         // 36: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.OpaqueProductDimensions
+	(*OpaqueCustomer_OpaqueLoyaltyInfo)(nil),              // 37: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.OpaqueLoyaltyInfo
+	nil,                                                   // 38: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.PreferencesEntry
+	(*OpaqueCustomer_OpaquePaymentMethod)(nil),            // 39: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.OpaquePaymentMethod
+	nil,                                    // 40: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderItem.SelectedAttributesEntry
+	(*OpaqueOrder_OpaqueShippingInfo)(nil), // 41: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.OpaqueShippingInfo
+	nil,                                    // 42: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.MetadataEntry
+	nil,                                    // 43: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary.ErrorDetailsEntry
+	(*OpaqueOrderSummary_OpaqueOrderError)(nil), // 44: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary.OpaqueOrderError
+	nil,                            // 45: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomerEvent.EventDataEntry
+	nil,                            // 46: grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate.UpdateDataEntry
+	(*fieldmaskpb.FieldMask)(nil),  // 47: google.protobuf.FieldMask
+	(*wrapperspb.BoolValue)(nil),   // 48: google.protobuf.BoolValue
+	(*wrapperspb.DoubleValue)(nil), // 49: google.protobuf.DoubleValue
+	(*timestamppb.Timestamp)(nil),  // 50: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),    // 51: google.protobuf.Duration
 }
 var file_examples_internal_proto_examplepb_opaque_proto_depIdxs = []int32{
-	20, // 0: grpc.gateway.examples.internal.proto.examplepb.OpaqueGetProductResponse.product:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct
-	17, // 1: grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest.min_price:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
-	17, // 2: grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest.max_price:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
+	24, // 0: grpc.gateway.examples.internal.proto.examplepb.OpaqueGetProductResponse.product:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct
+	21, // 1: grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest.min_price:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
+	21, // 2: grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest.max_price:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
 	0,  // 3: grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest.sort_by:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest.OpaqueSortOrder
-	43, // 4: grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest.field_mask:type_name -> google.protobuf.FieldMask
-	27, // 5: grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest.filters:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest.FiltersEntry
-	20, // 6: grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsResponse.product:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct
-	23, // 7: grpc.gateway.examples.internal.proto.examplepb.OpaqueProcessOrdersRequest.order:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder
-	24, // 8: grpc.gateway.examples.internal.proto.examplepb.OpaqueProcessOrdersResponse.summary:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary
-	25, // 9: grpc.gateway.examples.internal.proto.examplepb.OpaqueStreamCustomerActivityRequest.event:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomerEvent
-	26, // 10: grpc.gateway.examples.internal.proto.examplepb.OpaqueStreamCustomerActivityResponse.event:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate
-	1,  // 11: grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress.address_type:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress.OpaqueAddressType
-	44, // 12: grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress.is_default:type_name -> google.protobuf.BoolValue
-	28, // 13: grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress.metadata:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress.MetadataEntry
-	45, // 14: grpc.gateway.examples.internal.proto.examplepb.OpaquePrice.original_amount:type_name -> google.protobuf.DoubleValue
-	46, // 15: grpc.gateway.examples.internal.proto.examplepb.OpaquePrice.price_valid_until:type_name -> google.protobuf.Timestamp
-	18, // 16: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductCategory.parent_category:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProductCategory
-	46, // 17: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductCategory.created_at:type_name -> google.protobuf.Timestamp
-	46, // 18: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductCategory.updated_at:type_name -> google.protobuf.Timestamp
-	17, // 19: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductVariant.price:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
-	29, // 20: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductVariant.attributes:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProductVariant.AttributesEntry
-	44, // 21: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductVariant.is_available:type_name -> google.protobuf.BoolValue
-	17, // 22: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.base_price:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
-	18, // 23: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.category:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProductCategory
-	19, // 24: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.variants:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProductVariant
-	44, // 25: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.is_featured:type_name -> google.protobuf.BoolValue
-	46, // 26: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.created_at:type_name -> google.protobuf.Timestamp
-	46, // 27: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.updated_at:type_name -> google.protobuf.Timestamp
-	47, // 28: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.average_shipping_time:type_name -> google.protobuf.Duration
-	2,  // 29: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.status:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.OpaqueProductStatus
-	30, // 30: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.metadata:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.MetadataEntry
-	31, // 31: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.regional_prices:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.RegionalPricesEntry
-	32, // 32: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.dimensions:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.OpaqueProductDimensions
-	16, // 33: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.addresses:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress
-	46, // 34: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.created_at:type_name -> google.protobuf.Timestamp
-	46, // 35: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.last_login:type_name -> google.protobuf.Timestamp
-	4,  // 36: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.status:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.OpaqueCustomerStatus
-	33, // 37: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.loyalty_info:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.OpaqueLoyaltyInfo
-	34, // 38: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.preferences:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.PreferencesEntry
-	35, // 39: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.payment_methods:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.OpaquePaymentMethod
-	17, // 40: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderItem.unit_price:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
-	17, // 41: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderItem.total_price:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
-	36, // 42: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderItem.selected_attributes:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderItem.SelectedAttributesEntry
-	44, // 43: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderItem.gift_wrapped:type_name -> google.protobuf.BoolValue
-	22, // 44: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.items:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderItem
-	17, // 45: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.subtotal:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
-	17, // 46: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.tax:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
-	17, // 47: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.shipping:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
-	17, // 48: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.total:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
-	16, // 49: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.shipping_address:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress
-	16, // 50: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.billing_address:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress
-	5,  // 51: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.status:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.OpaqueOrderStatus
-	46, // 52: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.created_at:type_name -> google.protobuf.Timestamp
-	46, // 53: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.updated_at:type_name -> google.protobuf.Timestamp
-	46, // 54: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.shipped_at:type_name -> google.protobuf.Timestamp
-	46, // 55: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.delivered_at:type_name -> google.protobuf.Timestamp
-	37, // 56: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.shipping_info:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.OpaqueShippingInfo
-	38, // 57: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.metadata:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.MetadataEntry
-	17, // 58: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary.total_value:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
-	39, // 59: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary.error_details:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary.ErrorDetailsEntry
-	46, // 60: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary.processing_time:type_name -> google.protobuf.Timestamp
-	40, // 61: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary.errors:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary.OpaqueOrderError
-	6,  // 62: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomerEvent.event_type:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomerEvent.OpaqueEventType
-	46, // 63: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomerEvent.timestamp:type_name -> google.protobuf.Timestamp
-	41, // 64: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomerEvent.event_data:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomerEvent.EventDataEntry
-	7,  // 65: grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate.update_type:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate.OpaqueUpdateType
-	46, // 66: grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate.timestamp:type_name -> google.protobuf.Timestamp
-	17, // 67: grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate.price_update:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
-	47, // 68: grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate.offer_expiry:type_name -> google.protobuf.Duration
-	42, // 69: grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate.update_data:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate.UpdateDataEntry
-	17, // 70: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.RegionalPricesEntry.value:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
-	3,  // 71: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.OpaqueProductDimensions.unit:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.OpaqueProductDimensions.OpaqueUnit
-	46, // 72: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.OpaqueLoyaltyInfo.tier_expiry:type_name -> google.protobuf.Timestamp
-	46, // 73: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.OpaquePaymentMethod.expires_at:type_name -> google.protobuf.Timestamp
-	47, // 74: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.OpaqueShippingInfo.estimated_delivery_time:type_name -> google.protobuf.Duration
-	8,  // 75: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueGetProduct:input_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueGetProductRequest
-	10, // 76: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueSearchProducts:input_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest
-	12, // 77: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueProcessOrders:input_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProcessOrdersRequest
-	14, // 78: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueStreamCustomerActivity:input_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueStreamCustomerActivityRequest
-	9,  // 79: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueGetProduct:output_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueGetProductResponse
-	11, // 80: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueSearchProducts:output_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsResponse
-	13, // 81: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueProcessOrders:output_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProcessOrdersResponse
-	15, // 82: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueStreamCustomerActivity:output_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueStreamCustomerActivityResponse
-	79, // [79:83] is the sub-list for method output_type
-	75, // [75:79] is the sub-list for method input_type
-	75, // [75:75] is the sub-list for extension type_name
-	75, // [75:75] is the sub-list for extension extendee
-	0,  // [0:75] is the sub-list for field type_name
+	47, // 4: grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest.field_mask:type_name -> google.protobuf.FieldMask
+	31, // 5: grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest.filters:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest.FiltersEntry
+	24, // 6: grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsResponse.product:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct
+	24, // 7: grpc.gateway.examples.internal.proto.examplepb.OpaqueCreateProductRequest.product:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct
+	24, // 8: grpc.gateway.examples.internal.proto.examplepb.OpaqueCreateProductResponse.product:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct
+	24, // 9: grpc.gateway.examples.internal.proto.examplepb.OpaqueCreateProductFieldRequest.product:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct
+	24, // 10: grpc.gateway.examples.internal.proto.examplepb.OpaqueCreateProductFieldResponse.product:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct
+	27, // 11: grpc.gateway.examples.internal.proto.examplepb.OpaqueProcessOrdersRequest.order:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder
+	28, // 12: grpc.gateway.examples.internal.proto.examplepb.OpaqueProcessOrdersResponse.summary:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary
+	29, // 13: grpc.gateway.examples.internal.proto.examplepb.OpaqueStreamCustomerActivityRequest.event:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomerEvent
+	30, // 14: grpc.gateway.examples.internal.proto.examplepb.OpaqueStreamCustomerActivityResponse.event:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate
+	1,  // 15: grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress.address_type:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress.OpaqueAddressType
+	48, // 16: grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress.is_default:type_name -> google.protobuf.BoolValue
+	32, // 17: grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress.metadata:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress.MetadataEntry
+	49, // 18: grpc.gateway.examples.internal.proto.examplepb.OpaquePrice.original_amount:type_name -> google.protobuf.DoubleValue
+	50, // 19: grpc.gateway.examples.internal.proto.examplepb.OpaquePrice.price_valid_until:type_name -> google.protobuf.Timestamp
+	22, // 20: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductCategory.parent_category:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProductCategory
+	50, // 21: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductCategory.created_at:type_name -> google.protobuf.Timestamp
+	50, // 22: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductCategory.updated_at:type_name -> google.protobuf.Timestamp
+	21, // 23: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductVariant.price:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
+	33, // 24: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductVariant.attributes:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProductVariant.AttributesEntry
+	48, // 25: grpc.gateway.examples.internal.proto.examplepb.OpaqueProductVariant.is_available:type_name -> google.protobuf.BoolValue
+	21, // 26: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.base_price:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
+	22, // 27: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.category:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProductCategory
+	23, // 28: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.variants:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProductVariant
+	48, // 29: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.is_featured:type_name -> google.protobuf.BoolValue
+	50, // 30: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.created_at:type_name -> google.protobuf.Timestamp
+	50, // 31: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.updated_at:type_name -> google.protobuf.Timestamp
+	51, // 32: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.average_shipping_time:type_name -> google.protobuf.Duration
+	2,  // 33: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.status:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.OpaqueProductStatus
+	34, // 34: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.metadata:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.MetadataEntry
+	35, // 35: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.regional_prices:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.RegionalPricesEntry
+	36, // 36: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.dimensions:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.OpaqueProductDimensions
+	20, // 37: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.addresses:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress
+	50, // 38: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.created_at:type_name -> google.protobuf.Timestamp
+	50, // 39: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.last_login:type_name -> google.protobuf.Timestamp
+	4,  // 40: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.status:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.OpaqueCustomerStatus
+	37, // 41: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.loyalty_info:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.OpaqueLoyaltyInfo
+	38, // 42: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.preferences:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.PreferencesEntry
+	39, // 43: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.payment_methods:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.OpaquePaymentMethod
+	21, // 44: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderItem.unit_price:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
+	21, // 45: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderItem.total_price:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
+	40, // 46: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderItem.selected_attributes:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderItem.SelectedAttributesEntry
+	48, // 47: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderItem.gift_wrapped:type_name -> google.protobuf.BoolValue
+	26, // 48: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.items:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderItem
+	21, // 49: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.subtotal:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
+	21, // 50: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.tax:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
+	21, // 51: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.shipping:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
+	21, // 52: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.total:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
+	20, // 53: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.shipping_address:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress
+	20, // 54: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.billing_address:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueAddress
+	5,  // 55: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.status:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.OpaqueOrderStatus
+	50, // 56: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.created_at:type_name -> google.protobuf.Timestamp
+	50, // 57: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.updated_at:type_name -> google.protobuf.Timestamp
+	50, // 58: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.shipped_at:type_name -> google.protobuf.Timestamp
+	50, // 59: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.delivered_at:type_name -> google.protobuf.Timestamp
+	41, // 60: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.shipping_info:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.OpaqueShippingInfo
+	42, // 61: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.metadata:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.MetadataEntry
+	21, // 62: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary.total_value:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
+	43, // 63: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary.error_details:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary.ErrorDetailsEntry
+	50, // 64: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary.processing_time:type_name -> google.protobuf.Timestamp
+	44, // 65: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary.errors:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueOrderSummary.OpaqueOrderError
+	6,  // 66: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomerEvent.event_type:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomerEvent.OpaqueEventType
+	50, // 67: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomerEvent.timestamp:type_name -> google.protobuf.Timestamp
+	45, // 68: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomerEvent.event_data:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomerEvent.EventDataEntry
+	7,  // 69: grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate.update_type:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate.OpaqueUpdateType
+	50, // 70: grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate.timestamp:type_name -> google.protobuf.Timestamp
+	21, // 71: grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate.price_update:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
+	51, // 72: grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate.offer_expiry:type_name -> google.protobuf.Duration
+	46, // 73: grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate.update_data:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueActivityUpdate.UpdateDataEntry
+	21, // 74: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.RegionalPricesEntry.value:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaquePrice
+	3,  // 75: grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.OpaqueProductDimensions.unit:type_name -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProduct.OpaqueProductDimensions.OpaqueUnit
+	50, // 76: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.OpaqueLoyaltyInfo.tier_expiry:type_name -> google.protobuf.Timestamp
+	50, // 77: grpc.gateway.examples.internal.proto.examplepb.OpaqueCustomer.OpaquePaymentMethod.expires_at:type_name -> google.protobuf.Timestamp
+	51, // 78: grpc.gateway.examples.internal.proto.examplepb.OpaqueOrder.OpaqueShippingInfo.estimated_delivery_time:type_name -> google.protobuf.Duration
+	8,  // 79: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueGetProduct:input_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueGetProductRequest
+	10, // 80: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueSearchProducts:input_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsRequest
+	12, // 81: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueCreateProduct:input_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCreateProductRequest
+	14, // 82: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueCreateProductField:input_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCreateProductFieldRequest
+	16, // 83: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueProcessOrders:input_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProcessOrdersRequest
+	18, // 84: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueStreamCustomerActivity:input_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueStreamCustomerActivityRequest
+	9,  // 85: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueGetProduct:output_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueGetProductResponse
+	11, // 86: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueSearchProducts:output_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueSearchProductsResponse
+	13, // 87: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueCreateProduct:output_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCreateProductResponse
+	15, // 88: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueCreateProductField:output_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueCreateProductFieldResponse
+	17, // 89: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueProcessOrders:output_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueProcessOrdersResponse
+	19, // 90: grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService.OpaqueStreamCustomerActivity:output_type -> grpc.gateway.examples.internal.proto.examplepb.OpaqueStreamCustomerActivityResponse
+	85, // [85:91] is the sub-list for method output_type
+	79, // [79:85] is the sub-list for method input_type
+	79, // [79:79] is the sub-list for extension type_name
+	79, // [79:79] is the sub-list for extension extendee
+	0,  // [0:79] is the sub-list for field type_name
 }
 
 func init() { file_examples_internal_proto_examplepb_opaque_proto_init() }
@@ -7080,19 +7453,19 @@ func file_examples_internal_proto_examplepb_opaque_proto_init() {
 	if File_examples_internal_proto_examplepb_opaque_proto != nil {
 		return
 	}
-	file_examples_internal_proto_examplepb_opaque_proto_msgTypes[11].OneofWrappers = []any{
+	file_examples_internal_proto_examplepb_opaque_proto_msgTypes[15].OneofWrappers = []any{
 		(*opaqueProductVariant_PercentageOff)(nil),
 		(*opaqueProductVariant_FixedAmountOff)(nil),
 	}
-	file_examples_internal_proto_examplepb_opaque_proto_msgTypes[12].OneofWrappers = []any{
+	file_examples_internal_proto_examplepb_opaque_proto_msgTypes[16].OneofWrappers = []any{
 		(*opaqueProduct_TaxPercentage)(nil),
 		(*opaqueProduct_TaxExempt)(nil),
 	}
-	file_examples_internal_proto_examplepb_opaque_proto_msgTypes[15].OneofWrappers = []any{
+	file_examples_internal_proto_examplepb_opaque_proto_msgTypes[19].OneofWrappers = []any{
 		(*opaqueOrder_CouponCode)(nil),
 		(*opaqueOrder_PromotionId)(nil),
 	}
-	file_examples_internal_proto_examplepb_opaque_proto_msgTypes[18].OneofWrappers = []any{
+	file_examples_internal_proto_examplepb_opaque_proto_msgTypes[22].OneofWrappers = []any{
 		(*opaqueActivityUpdate_RedirectUrl)(nil),
 		(*opaqueActivityUpdate_NotificationId)(nil),
 	}
@@ -7102,7 +7475,7 @@ func file_examples_internal_proto_examplepb_opaque_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_examples_internal_proto_examplepb_opaque_proto_rawDesc), len(file_examples_internal_proto_examplepb_opaque_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   35,
+			NumMessages:   39,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/examples/internal/proto/examplepb/opaque.pb.gw.go
+++ b/examples/internal/proto/examplepb/opaque.pb.gw.go
@@ -118,6 +118,82 @@ func request_OpaqueEcommerceService_OpaqueSearchProducts_0(ctx context.Context, 
 	return stream, metadata, nil
 }
 
+func request_OpaqueEcommerceService_OpaqueCreateProduct_0(ctx context.Context, marshaler runtime.Marshaler, client OpaqueEcommerceServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq OpaqueCreateProductRequest
+		metadata runtime.ServerMetadata
+	)
+	var bodyData OpaqueCreateProductRequest
+	if err := marshaler.NewDecoder(req.Body).Decode(&bodyData); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	protoReq = bodyData
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.OpaqueCreateProduct(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_OpaqueEcommerceService_OpaqueCreateProduct_0(ctx context.Context, marshaler runtime.Marshaler, server OpaqueEcommerceServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq OpaqueCreateProductRequest
+		metadata runtime.ServerMetadata
+	)
+	var bodyData OpaqueCreateProductRequest
+	if err := marshaler.NewDecoder(req.Body).Decode(&bodyData); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	protoReq = bodyData
+	msg, err := server.OpaqueCreateProduct(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+var filter_OpaqueEcommerceService_OpaqueCreateProductField_0 = &utilities.DoubleArray{Encoding: map[string]int{"product": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+
+func request_OpaqueEcommerceService_OpaqueCreateProductField_0(ctx context.Context, marshaler runtime.Marshaler, client OpaqueEcommerceServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq OpaqueCreateProductFieldRequest
+		metadata runtime.ServerMetadata
+	)
+	bodyData := &OpaqueProduct{}
+	if err := marshaler.NewDecoder(req.Body).Decode(bodyData); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	protoReq.SetProduct(bodyData)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_OpaqueEcommerceService_OpaqueCreateProductField_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.OpaqueCreateProductField(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_OpaqueEcommerceService_OpaqueCreateProductField_0(ctx context.Context, marshaler runtime.Marshaler, server OpaqueEcommerceServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq OpaqueCreateProductFieldRequest
+		metadata runtime.ServerMetadata
+	)
+	bodyData := &OpaqueProduct{}
+	if err := marshaler.NewDecoder(req.Body).Decode(bodyData); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	protoReq.SetProduct(bodyData)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_OpaqueEcommerceService_OpaqueCreateProductField_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.OpaqueCreateProductField(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_OpaqueEcommerceService_OpaqueProcessOrders_0(ctx context.Context, marshaler runtime.Marshaler, client OpaqueEcommerceServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var metadata runtime.ServerMetadata
 	stream, err := client.OpaqueProcessOrders(ctx)
@@ -235,6 +311,46 @@ func RegisterOpaqueEcommerceServiceHandlerServer(ctx context.Context, mux *runti
 		runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 		return
 	})
+	mux.Handle(http.MethodPost, pattern_OpaqueEcommerceService_OpaqueCreateProduct_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService/OpaqueCreateProduct", runtime.WithHTTPPathPattern("/v1/products"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_OpaqueEcommerceService_OpaqueCreateProduct_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_OpaqueEcommerceService_OpaqueCreateProduct_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_OpaqueEcommerceService_OpaqueCreateProductField_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService/OpaqueCreateProductField", runtime.WithHTTPPathPattern("/v1/productsField"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_OpaqueEcommerceService_OpaqueCreateProductField_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_OpaqueEcommerceService_OpaqueCreateProductField_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 
 	mux.Handle(http.MethodPost, pattern_OpaqueEcommerceService_OpaqueProcessOrders_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		err := status.Error(codes.Unimplemented, "streaming calls are not yet supported in the in-process transport")
@@ -323,6 +439,40 @@ func RegisterOpaqueEcommerceServiceHandlerClient(ctx context.Context, mux *runti
 		}
 		forward_OpaqueEcommerceService_OpaqueSearchProducts_0(annotatedContext, mux, outboundMarshaler, w, req, func() (proto.Message, error) { return resp.Recv() }, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_OpaqueEcommerceService_OpaqueCreateProduct_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService/OpaqueCreateProduct", runtime.WithHTTPPathPattern("/v1/products"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_OpaqueEcommerceService_OpaqueCreateProduct_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_OpaqueEcommerceService_OpaqueCreateProduct_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_OpaqueEcommerceService_OpaqueCreateProductField_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService/OpaqueCreateProductField", runtime.WithHTTPPathPattern("/v1/productsField"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_OpaqueEcommerceService_OpaqueCreateProductField_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_OpaqueEcommerceService_OpaqueCreateProductField_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_OpaqueEcommerceService_OpaqueProcessOrders_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -363,6 +513,8 @@ func RegisterOpaqueEcommerceServiceHandlerClient(ctx context.Context, mux *runti
 var (
 	pattern_OpaqueEcommerceService_OpaqueGetProduct_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "products", "product_id"}, ""))
 	pattern_OpaqueEcommerceService_OpaqueSearchProducts_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "products", "search"}, ""))
+	pattern_OpaqueEcommerceService_OpaqueCreateProduct_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "products"}, ""))
+	pattern_OpaqueEcommerceService_OpaqueCreateProductField_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "productsField"}, ""))
 	pattern_OpaqueEcommerceService_OpaqueProcessOrders_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "orders", "process"}, ""))
 	pattern_OpaqueEcommerceService_OpaqueStreamCustomerActivity_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "customer", "activity"}, ""))
 )
@@ -370,6 +522,8 @@ var (
 var (
 	forward_OpaqueEcommerceService_OpaqueGetProduct_0             = runtime.ForwardResponseMessage
 	forward_OpaqueEcommerceService_OpaqueSearchProducts_0         = runtime.ForwardResponseStream
+	forward_OpaqueEcommerceService_OpaqueCreateProduct_0          = runtime.ForwardResponseMessage
+	forward_OpaqueEcommerceService_OpaqueCreateProductField_0     = runtime.ForwardResponseMessage
 	forward_OpaqueEcommerceService_OpaqueProcessOrders_0          = runtime.ForwardResponseMessage
 	forward_OpaqueEcommerceService_OpaqueStreamCustomerActivity_0 = runtime.ForwardResponseStream
 )

--- a/examples/internal/proto/examplepb/opaque.proto
+++ b/examples/internal/proto/examplepb/opaque.proto
@@ -24,6 +24,23 @@ service OpaqueEcommerceService {
     option (google.api.http) = {get: "/v1/products/search"};
   }
 
+  // OpaqueCreateProduct - Unary request with body field, unary response
+  // Creates a new product with the product details in the body
+  rpc OpaqueCreateProduct(OpaqueCreateProductRequest) returns (OpaqueCreateProductResponse) {
+    option (google.api.http) = {
+      post: "/v1/products"
+      body: "*"
+    };
+  }
+
+  // OpaqueCreateProductField - same as above, but with body field mapping.
+  rpc OpaqueCreateProductField(OpaqueCreateProductFieldRequest) returns (OpaqueCreateProductFieldResponse) {
+    option (google.api.http) = {
+      post: "/v1/productsField"
+      body: "product"
+    };
+  }
+
   // OpaqueProcessOrders - Stream request, unary response
   // Processes multiple orders in a batch and returns a summary
   rpc OpaqueProcessOrders(stream OpaqueProcessOrdersRequest) returns (OpaqueProcessOrdersResponse) {
@@ -87,6 +104,28 @@ message OpaqueSearchProductsRequest {
 
 // OpaqueSearchProductsResponse represents a single product in search results
 message OpaqueSearchProductsResponse {
+  OpaqueProduct product = 1;
+}
+
+// OpaqueCreateProductRequest represents a request to create a product
+message OpaqueCreateProductRequest {
+  string product_id = 1;
+  OpaqueProduct product = 2;
+}
+
+// OpaqueCreateProductResponse represents the created product
+message OpaqueCreateProductResponse {
+  OpaqueProduct product = 1;
+}
+
+// OpaqueCreateProductFieldRequest represents a request to create a product
+message OpaqueCreateProductFieldRequest {
+  string product_id = 1;
+  OpaqueProduct product = 2;
+}
+
+// OpaqueCreateProductFieldResponse represents the created product
+message OpaqueCreateProductFieldResponse {
   OpaqueProduct product = 1;
 }
 

--- a/examples/internal/proto/examplepb/opaque.swagger.json
+++ b/examples/internal/proto/examplepb/opaque.swagger.json
@@ -93,6 +93,39 @@
         ]
       }
     },
+    "/v1/products": {
+      "post": {
+        "summary": "OpaqueCreateProduct - Unary request with body field, unary response\nCreates a new product with the product details in the body",
+        "operationId": "OpaqueEcommerceService_OpaqueCreateProduct",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/examplepbOpaqueCreateProductResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/examplepbOpaqueCreateProductRequest"
+            }
+          }
+        ],
+        "tags": [
+          "OpaqueEcommerceService"
+        ]
+      }
+    },
     "/v1/products/search": {
       "get": {
         "summary": "OpaqueSearchProducts - Unary request, stream response\nSearches for products based on criteria and streams results back",
@@ -328,6 +361,45 @@
           },
           {
             "name": "currencyCode",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "OpaqueEcommerceService"
+        ]
+      }
+    },
+    "/v1/productsField": {
+      "post": {
+        "summary": "OpaqueCreateProductField - same as above, but with body field mapping.",
+        "operationId": "OpaqueEcommerceService_OpaqueCreateProductField",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/examplepbOpaqueCreateProductFieldResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "product",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/examplepbOpaqueProduct"
+            }
+          },
+          {
+            "name": "productId",
             "in": "query",
             "required": false,
             "type": "string"
@@ -579,6 +651,36 @@
         }
       },
       "title": "OpaqueAddress represents a physical address"
+    },
+    "examplepbOpaqueCreateProductFieldResponse": {
+      "type": "object",
+      "properties": {
+        "product": {
+          "$ref": "#/definitions/examplepbOpaqueProduct"
+        }
+      },
+      "title": "OpaqueCreateProductFieldResponse represents the created product"
+    },
+    "examplepbOpaqueCreateProductRequest": {
+      "type": "object",
+      "properties": {
+        "productId": {
+          "type": "string"
+        },
+        "product": {
+          "$ref": "#/definitions/examplepbOpaqueProduct"
+        }
+      },
+      "title": "OpaqueCreateProductRequest represents a request to create a product"
+    },
+    "examplepbOpaqueCreateProductResponse": {
+      "type": "object",
+      "properties": {
+        "product": {
+          "$ref": "#/definitions/examplepbOpaqueProduct"
+        }
+      },
+      "title": "OpaqueCreateProductResponse represents the created product"
     },
     "examplepbOpaqueCustomerEvent": {
       "type": "object",

--- a/examples/internal/proto/examplepb/opaque_grpc.pb.go
+++ b/examples/internal/proto/examplepb/opaque_grpc.pb.go
@@ -21,6 +21,8 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	OpaqueEcommerceService_OpaqueGetProduct_FullMethodName             = "/grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService/OpaqueGetProduct"
 	OpaqueEcommerceService_OpaqueSearchProducts_FullMethodName         = "/grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService/OpaqueSearchProducts"
+	OpaqueEcommerceService_OpaqueCreateProduct_FullMethodName          = "/grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService/OpaqueCreateProduct"
+	OpaqueEcommerceService_OpaqueCreateProductField_FullMethodName     = "/grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService/OpaqueCreateProductField"
 	OpaqueEcommerceService_OpaqueProcessOrders_FullMethodName          = "/grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService/OpaqueProcessOrders"
 	OpaqueEcommerceService_OpaqueStreamCustomerActivity_FullMethodName = "/grpc.gateway.examples.internal.proto.examplepb.OpaqueEcommerceService/OpaqueStreamCustomerActivity"
 )
@@ -37,6 +39,11 @@ type OpaqueEcommerceServiceClient interface {
 	// OpaqueSearchProducts - Unary request, stream response
 	// Searches for products based on criteria and streams results back
 	OpaqueSearchProducts(ctx context.Context, in *OpaqueSearchProductsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[OpaqueSearchProductsResponse], error)
+	// OpaqueCreateProduct - Unary request with body field, unary response
+	// Creates a new product with the product details in the body
+	OpaqueCreateProduct(ctx context.Context, in *OpaqueCreateProductRequest, opts ...grpc.CallOption) (*OpaqueCreateProductResponse, error)
+	// OpaqueCreateProductField - same as above, but with body field mapping.
+	OpaqueCreateProductField(ctx context.Context, in *OpaqueCreateProductFieldRequest, opts ...grpc.CallOption) (*OpaqueCreateProductFieldResponse, error)
 	// OpaqueProcessOrders - Stream request, unary response
 	// Processes multiple orders in a batch and returns a summary
 	OpaqueProcessOrders(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[OpaqueProcessOrdersRequest, OpaqueProcessOrdersResponse], error)
@@ -82,6 +89,26 @@ func (c *opaqueEcommerceServiceClient) OpaqueSearchProducts(ctx context.Context,
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type OpaqueEcommerceService_OpaqueSearchProductsClient = grpc.ServerStreamingClient[OpaqueSearchProductsResponse]
 
+func (c *opaqueEcommerceServiceClient) OpaqueCreateProduct(ctx context.Context, in *OpaqueCreateProductRequest, opts ...grpc.CallOption) (*OpaqueCreateProductResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(OpaqueCreateProductResponse)
+	err := c.cc.Invoke(ctx, OpaqueEcommerceService_OpaqueCreateProduct_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *opaqueEcommerceServiceClient) OpaqueCreateProductField(ctx context.Context, in *OpaqueCreateProductFieldRequest, opts ...grpc.CallOption) (*OpaqueCreateProductFieldResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(OpaqueCreateProductFieldResponse)
+	err := c.cc.Invoke(ctx, OpaqueEcommerceService_OpaqueCreateProductField_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *opaqueEcommerceServiceClient) OpaqueProcessOrders(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[OpaqueProcessOrdersRequest, OpaqueProcessOrdersResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &OpaqueEcommerceService_ServiceDesc.Streams[1], OpaqueEcommerceService_OpaqueProcessOrders_FullMethodName, cOpts...)
@@ -120,6 +147,11 @@ type OpaqueEcommerceServiceServer interface {
 	// OpaqueSearchProducts - Unary request, stream response
 	// Searches for products based on criteria and streams results back
 	OpaqueSearchProducts(*OpaqueSearchProductsRequest, grpc.ServerStreamingServer[OpaqueSearchProductsResponse]) error
+	// OpaqueCreateProduct - Unary request with body field, unary response
+	// Creates a new product with the product details in the body
+	OpaqueCreateProduct(context.Context, *OpaqueCreateProductRequest) (*OpaqueCreateProductResponse, error)
+	// OpaqueCreateProductField - same as above, but with body field mapping.
+	OpaqueCreateProductField(context.Context, *OpaqueCreateProductFieldRequest) (*OpaqueCreateProductFieldResponse, error)
 	// OpaqueProcessOrders - Stream request, unary response
 	// Processes multiple orders in a batch and returns a summary
 	OpaqueProcessOrders(grpc.ClientStreamingServer[OpaqueProcessOrdersRequest, OpaqueProcessOrdersResponse]) error
@@ -140,6 +172,12 @@ func (UnimplementedOpaqueEcommerceServiceServer) OpaqueGetProduct(context.Contex
 }
 func (UnimplementedOpaqueEcommerceServiceServer) OpaqueSearchProducts(*OpaqueSearchProductsRequest, grpc.ServerStreamingServer[OpaqueSearchProductsResponse]) error {
 	return status.Errorf(codes.Unimplemented, "method OpaqueSearchProducts not implemented")
+}
+func (UnimplementedOpaqueEcommerceServiceServer) OpaqueCreateProduct(context.Context, *OpaqueCreateProductRequest) (*OpaqueCreateProductResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method OpaqueCreateProduct not implemented")
+}
+func (UnimplementedOpaqueEcommerceServiceServer) OpaqueCreateProductField(context.Context, *OpaqueCreateProductFieldRequest) (*OpaqueCreateProductFieldResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method OpaqueCreateProductField not implemented")
 }
 func (UnimplementedOpaqueEcommerceServiceServer) OpaqueProcessOrders(grpc.ClientStreamingServer[OpaqueProcessOrdersRequest, OpaqueProcessOrdersResponse]) error {
 	return status.Errorf(codes.Unimplemented, "method OpaqueProcessOrders not implemented")
@@ -196,6 +234,42 @@ func _OpaqueEcommerceService_OpaqueSearchProducts_Handler(srv interface{}, strea
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type OpaqueEcommerceService_OpaqueSearchProductsServer = grpc.ServerStreamingServer[OpaqueSearchProductsResponse]
 
+func _OpaqueEcommerceService_OpaqueCreateProduct_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(OpaqueCreateProductRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OpaqueEcommerceServiceServer).OpaqueCreateProduct(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OpaqueEcommerceService_OpaqueCreateProduct_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OpaqueEcommerceServiceServer).OpaqueCreateProduct(ctx, req.(*OpaqueCreateProductRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _OpaqueEcommerceService_OpaqueCreateProductField_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(OpaqueCreateProductFieldRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OpaqueEcommerceServiceServer).OpaqueCreateProductField(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OpaqueEcommerceService_OpaqueCreateProductField_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OpaqueEcommerceServiceServer).OpaqueCreateProductField(ctx, req.(*OpaqueCreateProductFieldRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _OpaqueEcommerceService_OpaqueProcessOrders_Handler(srv interface{}, stream grpc.ServerStream) error {
 	return srv.(OpaqueEcommerceServiceServer).OpaqueProcessOrders(&grpc.GenericServerStream[OpaqueProcessOrdersRequest, OpaqueProcessOrdersResponse]{ServerStream: stream})
 }
@@ -220,6 +294,14 @@ var OpaqueEcommerceService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "OpaqueGetProduct",
 			Handler:    _OpaqueEcommerceService_OpaqueGetProduct_Handler,
+		},
+		{
+			MethodName: "OpaqueCreateProduct",
+			Handler:    _OpaqueEcommerceService_OpaqueCreateProduct_Handler,
+		},
+		{
+			MethodName: "OpaqueCreateProductField",
+			Handler:    _OpaqueEcommerceService_OpaqueCreateProductField_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/protoc-gen-grpc-gateway/internal/gengateway/BUILD.bazel
+++ b/protoc-gen-grpc-gateway/internal/gengateway/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//utilities",
         "@org_golang_google_grpc//grpclog",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//types/descriptorpb",
         "@org_golang_google_protobuf//types/pluginpb",
     ],
 )


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #6189

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

When `use_opaque_api` is enabled with a body field mapping (e.g., `body: "field_name"`), the generated code was incorrectly decoding the HTTP request body as the full request message type instead of the specific field's message type.

This fix:
- Adds GetBodyFieldType() helper to determine the body field's type
- Updates template to decode into the field type and pass it directly to the setter method

#### Other comments

I added `OpaqueCreateProduct` and `OpaqueCreateProductField` to `opaque.proto` to act as a test case.

Generated code shows the difference. Note `var bodyData OpaqueCreateProductRequest` vs `bodyData := &OpaqueProduct{}`.

```go
func request_OpaqueEcommerceService_OpaqueCreateProduct_0(ctx context.Context, marshaler runtime.Marshaler, client OpaqueEcommerceServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
	var (
		protoReq OpaqueCreateProductRequest
		metadata runtime.ServerMetadata
	)
	var bodyData OpaqueCreateProductRequest
	if err := marshaler.NewDecoder(req.Body).Decode(&bodyData); err != nil && !errors.Is(err, io.EOF) {
		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
	}
	protoReq = bodyData
	if req.Body != nil {
		_, _ = io.Copy(io.Discard, req.Body)
	}
	msg, err := client.OpaqueCreateProduct(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
	return msg, metadata, err
}
```

vs

```go
func request_OpaqueEcommerceService_OpaqueCreateProductField_0(ctx context.Context, marshaler runtime.Marshaler, client OpaqueEcommerceServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
	var (
		protoReq OpaqueCreateProductFieldRequest
		metadata runtime.ServerMetadata
	)
	bodyData := &OpaqueProduct{}
	if err := marshaler.NewDecoder(req.Body).Decode(bodyData); err != nil && !errors.Is(err, io.EOF) {
		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
	}
	protoReq.SetProduct(bodyData)
	if req.Body != nil {
		_, _ = io.Copy(io.Discard, req.Body)
	}
	if err := req.ParseForm(); err != nil {
		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
	}
	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_OpaqueEcommerceService_OpaqueCreateProductField_0); err != nil {
		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
	}
	msg, err := client.OpaqueCreateProductField(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
	return msg, metadata, err
}
```
