### PR TITLE
fix: Support Service doc comments for OpenApi/Swagger generation

### DIFF
--- a/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
+++ b/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
@@ -29,7 +29,8 @@
       }
     },
     {
-      "name": "camelCaseServiceName"
+      "name": "camelCaseServiceName",
+      "description": "camelCase and lowercase service names are valid but not recommended (use TitleCase instead)"
     },
     {
       "name": "AnotherServiceWithNoBindings"

--- a/examples/internal/proto/examplepb/camel_case_service.swagger.json
+++ b/examples/internal/proto/examplepb/camel_case_service.swagger.json
@@ -6,7 +6,8 @@
   },
   "tags": [
     {
-      "name": "Camel_Case_service"
+      "name": "Camel_Case_service",
+      "description": "Camel_Case_service consumes snake_case identifiers declared in the sub\npackage to ensure generated code camel-cases enum/message references, even\nwhen service and RPC names are snake_case."
     }
   ],
   "consumes": [

--- a/examples/internal/proto/examplepb/echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/echo_service.swagger.json
@@ -7,7 +7,8 @@
   },
   "tags": [
     {
-      "name": "EchoService"
+      "name": "EchoService",
+      "description": "Echo service responds to incoming echo requests."
     }
   ],
   "consumes": [

--- a/examples/internal/proto/examplepb/generate_unbound_methods.swagger.json
+++ b/examples/internal/proto/examplepb/generate_unbound_methods.swagger.json
@@ -7,7 +7,8 @@
   },
   "tags": [
     {
-      "name": "GenerateUnboundMethodsEchoService"
+      "name": "GenerateUnboundMethodsEchoService",
+      "description": "GenerateUnboundMethodsEchoService service responds to incoming echo requests."
     }
   ],
   "consumes": [

--- a/examples/internal/proto/examplepb/generated_input.swagger.json
+++ b/examples/internal/proto/examplepb/generated_input.swagger.json
@@ -6,7 +6,8 @@
   },
   "tags": [
     {
-      "name": "GeneratedService"
+      "name": "GeneratedService",
+      "description": "Defines some more operations to be added to ABitOfEverythingService"
     }
   ],
   "consumes": [

--- a/examples/internal/proto/examplepb/non_standard_names.swagger.json
+++ b/examples/internal/proto/examplepb/non_standard_names.swagger.json
@@ -6,7 +6,8 @@
   },
   "tags": [
     {
-      "name": "NonStandardService"
+      "name": "NonStandardService",
+      "description": "NonStandardService responds to incoming messages, applies a field mask and returns the masked response."
     }
   ],
   "consumes": [

--- a/examples/internal/proto/examplepb/opaque.swagger.json
+++ b/examples/internal/proto/examplepb/opaque.swagger.json
@@ -6,7 +6,8 @@
   },
   "tags": [
     {
-      "name": "OpaqueEcommerceService"
+      "name": "OpaqueEcommerceService",
+      "description": "OpaqueEcommerceService provides a comprehensive e-commerce API with various request/response patterns"
     }
   ],
   "consumes": [

--- a/examples/internal/proto/examplepb/openapi_merge.swagger.json
+++ b/examples/internal/proto/examplepb/openapi_merge.swagger.json
@@ -7,13 +7,16 @@
   },
   "tags": [
     {
-      "name": "ServiceA"
+      "name": "ServiceA",
+      "description": "ServiceA provides MethodOne and MethodTwo"
     },
     {
-      "name": "ServiceC"
+      "name": "ServiceC",
+      "description": "ServiceC service responds to incoming merge requests."
     },
     {
-      "name": "ServiceB"
+      "name": "ServiceB",
+      "description": "ServiceB service responds to incoming merge requests."
     }
   ],
   "consumes": [

--- a/examples/internal/proto/examplepb/openapi_merge_a.swagger.json
+++ b/examples/internal/proto/examplepb/openapi_merge_a.swagger.json
@@ -7,10 +7,12 @@
   },
   "tags": [
     {
-      "name": "ServiceA"
+      "name": "ServiceA",
+      "description": "ServiceA provides MethodOne and MethodTwo"
     },
     {
-      "name": "ServiceC"
+      "name": "ServiceC",
+      "description": "ServiceC service responds to incoming merge requests."
     }
   ],
   "consumes": [

--- a/examples/internal/proto/examplepb/openapi_merge_b.swagger.json
+++ b/examples/internal/proto/examplepb/openapi_merge_b.swagger.json
@@ -7,7 +7,8 @@
   },
   "tags": [
     {
-      "name": "ServiceB"
+      "name": "ServiceB",
+      "description": "ServiceB service responds to incoming merge requests."
     }
   ],
   "consumes": [

--- a/examples/internal/proto/examplepb/remove_internal_comment.swagger.json
+++ b/examples/internal/proto/examplepb/remove_internal_comment.swagger.json
@@ -6,7 +6,8 @@
   },
   "tags": [
     {
-      "name": "Foo2Service"
+      "name": "Foo2Service",
+      "description": "Foo2Service"
     }
   ],
   "consumes": [

--- a/examples/internal/proto/examplepb/stream.swagger.json
+++ b/examples/internal/proto/examplepb/stream.swagger.json
@@ -6,7 +6,8 @@
   },
   "tags": [
     {
-      "name": "StreamService"
+      "name": "StreamService",
+      "description": "Defines some more operations to be added to ABitOfEverythingService"
     }
   ],
   "consumes": [

--- a/examples/internal/proto/examplepb/visibility_rule_enums_as_ints_echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/visibility_rule_enums_as_ints_echo_service.swagger.json
@@ -7,7 +7,8 @@
   },
   "tags": [
     {
-      "name": "VisibilityRuleEchoService"
+      "name": "VisibilityRuleEchoService",
+      "description": "VisibilityRuleEchoService service responds to incoming echo requests.\nDifferent services will be available in the swagger documentation depending\nbased on `google.api.VisibilityRule`s and the set `visibility_restriction_selectors`\nflag when calling protoc-gen-openapiv2."
     }
   ],
   "consumes": [

--- a/examples/internal/proto/examplepb/visibility_rule_internal_echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/visibility_rule_internal_echo_service.swagger.json
@@ -7,10 +7,12 @@
   },
   "tags": [
     {
-      "name": "VisibilityRuleEchoService"
+      "name": "VisibilityRuleEchoService",
+      "description": "VisibilityRuleEchoService service responds to incoming echo requests.\nDifferent services will be available in the swagger documentation depending\nbased on `google.api.VisibilityRule`s and the set `visibility_restriction_selectors`\nflag when calling protoc-gen-openapiv2."
     },
     {
-      "name": "VisibilityRuleInternalEchoService"
+      "name": "VisibilityRuleInternalEchoService",
+      "description": "VisibilityRuleInternalEchoService service responds to incoming echo requests.\nIt should only be visible in the OpenAPI spec if `visibility_restriction_selectors` includes \"INTERNAL\"."
     }
   ],
   "consumes": [

--- a/examples/internal/proto/examplepb/visibility_rule_none_echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/visibility_rule_none_echo_service.swagger.json
@@ -7,7 +7,8 @@
   },
   "tags": [
     {
-      "name": "VisibilityRuleEchoService"
+      "name": "VisibilityRuleEchoService",
+      "description": "VisibilityRuleEchoService service responds to incoming echo requests.\nDifferent services will be available in the swagger documentation depending\nbased on `google.api.VisibilityRule`s and the set `visibility_restriction_selectors`\nflag when calling protoc-gen-openapiv2."
     }
   ],
   "consumes": [

--- a/examples/internal/proto/examplepb/visibility_rule_preview_and_internal_echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/visibility_rule_preview_and_internal_echo_service.swagger.json
@@ -7,10 +7,12 @@
   },
   "tags": [
     {
-      "name": "VisibilityRuleEchoService"
+      "name": "VisibilityRuleEchoService",
+      "description": "VisibilityRuleEchoService service responds to incoming echo requests.\nDifferent services will be available in the swagger documentation depending\nbased on `google.api.VisibilityRule`s and the set `visibility_restriction_selectors`\nflag when calling protoc-gen-openapiv2."
     },
     {
-      "name": "VisibilityRuleInternalEchoService"
+      "name": "VisibilityRuleInternalEchoService",
+      "description": "VisibilityRuleInternalEchoService service responds to incoming echo requests.\nIt should only be visible in the OpenAPI spec if `visibility_restriction_selectors` includes \"INTERNAL\"."
     }
   ],
   "consumes": [

--- a/examples/internal/proto/examplepb/visibility_rule_preview_echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/visibility_rule_preview_echo_service.swagger.json
@@ -7,7 +7,8 @@
   },
   "tags": [
     {
-      "name": "VisibilityRuleEchoService"
+      "name": "VisibilityRuleEchoService",
+      "description": "VisibilityRuleEchoService service responds to incoming echo requests.\nDifferent services will be available in the swagger documentation depending\nbased on `google.api.VisibilityRule`s and the set `visibility_restriction_selectors`\nflag when calling protoc-gen-openapiv2."
     }
   ],
   "consumes": [

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -1403,9 +1403,31 @@ func renderServiceTags(services []*descriptor.Service, reg *descriptor.Registry)
 				tag.Name = opts.GetName()
 			}
 		}
+
+		// If no description is set from options, use proto comments
+		if tag.Description == "" {
+			svcIdx := findServiceIndex(svc)
+			if svcIdx >= 0 {
+				svcComments := protoComments(reg, svc.File, nil, "Service", int32(svcIdx))
+				if err := updateOpenAPIDataFromComments(reg, &tag, svc, svcComments, false); err != nil {
+					grpclog.Error(err)
+				}
+			}
+		}
+
 		tags = append(tags, tag)
 	}
 	return tags
+}
+
+// findServiceIndex finds the index of a service within its file's service list.
+func findServiceIndex(svc *descriptor.Service) int {
+	for i, s := range svc.File.Services {
+		if s == svc {
+			return i
+		}
+	}
+	return -1
 }
 
 // expandPathPatterns searches the URI parts for path parameters with pattern and when the pattern contains a sub-path,

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -12822,3 +12822,194 @@ func TestFieldCommentsWithNewlines(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderServiceTagsWithProtoComments(t *testing.T) {
+	svc := &descriptorpb.ServiceDescriptorProto{
+		Name: proto.String("ExampleService"),
+	}
+
+	serviceComment := "This is a service-level comment.\n\nIt has multiple paragraphs."
+	// The service path in proto source code info is [6, service_index]
+	// where 6 is the field number for 'service' in FileDescriptorProto
+	servicePath := []int32{6, 0}
+
+	file := &descriptor.File{
+		FileDescriptorProto: &descriptorpb.FileDescriptorProto{
+			SourceCodeInfo: &descriptorpb.SourceCodeInfo{
+				Location: []*descriptorpb.SourceCodeInfo_Location{
+					{
+						Path:            servicePath,
+						LeadingComments: &serviceComment,
+					},
+				},
+			},
+			Name:    proto.String("example.proto"),
+			Package: proto.String("example"),
+			Service: []*descriptorpb.ServiceDescriptorProto{svc},
+		},
+	}
+
+	services := []*descriptor.Service{
+		{
+			ServiceDescriptorProto: svc,
+			File:                   file,
+		},
+	}
+	file.Services = services
+
+	reg := descriptor.NewRegistry()
+
+	tags := renderServiceTags(services, reg)
+
+	if len(tags) != 1 {
+		t.Fatalf("expected 1 tag, got %d", len(tags))
+	}
+
+	// The description should be populated from the proto comment
+	// Since openapiTagObject doesn't have a Summary field, the entire comment
+	// goes into the Description field
+	expectedDesc := "This is a service-level comment.\n\nIt has multiple paragraphs."
+	if tags[0].Description != expectedDesc {
+		t.Errorf("renderServiceTags().Tags[0].Description = %q, want %q", tags[0].Description, expectedDesc)
+	}
+
+	if tags[0].Name != "ExampleService" {
+		t.Errorf("renderServiceTags().Tags[0].Name = %q, want %q", tags[0].Name, "ExampleService")
+	}
+}
+
+func TestRenderServiceTagsWithSingleParagraphComment(t *testing.T) {
+	svc := &descriptorpb.ServiceDescriptorProto{
+		Name: proto.String("ExampleService"),
+	}
+
+	serviceComment := "This is a single paragraph service comment."
+	servicePath := []int32{6, 0}
+
+	file := &descriptor.File{
+		FileDescriptorProto: &descriptorpb.FileDescriptorProto{
+			SourceCodeInfo: &descriptorpb.SourceCodeInfo{
+				Location: []*descriptorpb.SourceCodeInfo_Location{
+					{
+						Path:            servicePath,
+						LeadingComments: &serviceComment,
+					},
+				},
+			},
+			Name:    proto.String("example.proto"),
+			Package: proto.String("example"),
+			Service: []*descriptorpb.ServiceDescriptorProto{svc},
+		},
+	}
+
+	services := []*descriptor.Service{
+		{
+			ServiceDescriptorProto: svc,
+			File:                   file,
+		},
+	}
+	file.Services = services
+
+	reg := descriptor.NewRegistry()
+
+	tags := renderServiceTags(services, reg)
+
+	if len(tags) != 1 {
+		t.Fatalf("expected 1 tag, got %d", len(tags))
+	}
+
+	// For a single paragraph without explicit title, the whole comment becomes the description
+	expectedDesc := "This is a single paragraph service comment."
+	if tags[0].Description != expectedDesc {
+		t.Errorf("renderServiceTags().Tags[0].Description = %q, want %q", tags[0].Description, expectedDesc)
+	}
+}
+
+func TestRenderServiceTagsExplicitOptionTakesPrecedence(t *testing.T) {
+	svc := &descriptorpb.ServiceDescriptorProto{
+		Name:    proto.String("ExampleService"),
+		Options: &descriptorpb.ServiceOptions{},
+	}
+
+	// Set explicit OpenAPI option on the service descriptor using proto extension
+	proto.SetExtension(svc.Options, openapi_options.E_Openapiv2Tag, &openapi_options.Tag{
+		Description: "Explicit option description",
+	})
+
+	serviceComment := "This is a service-level comment from proto."
+	servicePath := []int32{6, 0}
+
+	file := &descriptor.File{
+		FileDescriptorProto: &descriptorpb.FileDescriptorProto{
+			SourceCodeInfo: &descriptorpb.SourceCodeInfo{
+				Location: []*descriptorpb.SourceCodeInfo_Location{
+					{
+						Path:            servicePath,
+						LeadingComments: &serviceComment,
+					},
+				},
+			},
+			Name:    proto.String("example.proto"),
+			Package: proto.String("example"),
+			Service: []*descriptorpb.ServiceDescriptorProto{svc},
+		},
+	}
+
+	services := []*descriptor.Service{
+		{
+			ServiceDescriptorProto: svc,
+			File:                   file,
+		},
+	}
+	file.Services = services
+
+	reg := descriptor.NewRegistry()
+
+	tags := renderServiceTags(services, reg)
+
+	if len(tags) != 1 {
+		t.Fatalf("expected 1 tag, got %d", len(tags))
+	}
+
+	// The explicit option should take precedence over proto comment
+	expectedDesc := "Explicit option description"
+	if tags[0].Description != expectedDesc {
+		t.Errorf("renderServiceTags().Tags[0].Description = %q, want %q", tags[0].Description, expectedDesc)
+	}
+}
+
+func TestRenderServiceTagsNoComment(t *testing.T) {
+	svc := &descriptorpb.ServiceDescriptorProto{
+		Name: proto.String("ExampleService"),
+	}
+
+	file := &descriptor.File{
+		FileDescriptorProto: &descriptorpb.FileDescriptorProto{
+			SourceCodeInfo: &descriptorpb.SourceCodeInfo{},
+			Name:           proto.String("example.proto"),
+			Package:        proto.String("example"),
+			Service:        []*descriptorpb.ServiceDescriptorProto{svc},
+		},
+	}
+
+	services := []*descriptor.Service{
+		{
+			ServiceDescriptorProto: svc,
+			File:                   file,
+		},
+	}
+	file.Services = services
+
+	reg := descriptor.NewRegistry()
+
+	tags := renderServiceTags(services, reg)
+
+	if len(tags) != 1 {
+		t.Fatalf("expected 1 tag, got %d", len(tags))
+	}
+
+	// No comment should result in empty description
+	if tags[0].Description != "" {
+		t.Errorf("renderServiceTags().Tags[0].Description = %q, want empty string", tags[0].Description)
+	}
+}

--- a/runtime/internal/examplepb/non_standard_names.swagger.json
+++ b/runtime/internal/examplepb/non_standard_names.swagger.json
@@ -6,7 +6,8 @@
   },
   "tags": [
     {
-      "name": "NonStandardService"
+      "name": "NonStandardService",
+      "description": "NonStandardService responds to incoming messages, applies a field mask and returns the masked response."
     }
   ],
   "consumes": [


### PR DESCRIPTION
## Summary
This PR fixes #4419

## Changes
- `protoc-gen-openapiv2/internal/genopenapi/template.go`
- `protoc-gen-openapiv2/internal/genopenapi/template_test.go`
