### PR TITLE
feat: add option to disable chunked headers

### DIFF
--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -28,7 +28,9 @@ func ForwardResponseStream(ctx context.Context, mux *ServeMux, marshaler Marshal
 	}
 	handleForwardResponseServerMetadata(w, mux, md)
 
-	w.Header().Set("Transfer-Encoding", "chunked")
+	if !mux.disableChunkedEncoding {
+		w.Header().Set("Transfer-Encoding", "chunked")
+	}
 	if err := handleForwardResponseOptions(ctx, w, nil, opts); err != nil {
 		HTTPError(ctx, mux, marshaler, w, req, err)
 		return

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -73,6 +73,7 @@ type ServeMux struct {
 	disablePathLengthFallback bool
 	unescapingMode            UnescapingMode
 	writeContentLength        bool
+	disableChunkedEncoding    bool
 }
 
 // ServeMuxOption is an option that can be given to a ServeMux on construction.
@@ -122,6 +123,16 @@ func WithUnescapingMode(mode UnescapingMode) ServeMuxOption {
 func WithMiddlewares(middlewares ...Middleware) ServeMuxOption {
 	return func(serveMux *ServeMux) {
 		serveMux.middlewares = append(serveMux.middlewares, middlewares...)
+	}
+}
+
+// WithDisableChunkedEncoding disables the Transfer-Encoding: chunked header
+// for streaming responses. This is useful for streaming implementations that use
+// Content-Length, which is mutually exclusive with Transfer-Encoding:chunked.
+// Note that this option will not automatically add Content-Length headers, so it should be used with caution.
+func WithDisableChunkedEncoding() ServeMuxOption {
+	return func(mux *ServeMux) {
+		mux.disableChunkedEncoding = true
 	}
 }
 


### PR DESCRIPTION

#### References to other Issues or PRs
n/a

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?
Yes

#### Brief description of what is fixed or changed
Adds the option, `WithDisableChunkedEncoding()` to the ServeMux. If set, this will not set the "Transfer-Encoding": "chunked" header in `ForwardResponseStream`.

#### Other comments
