### PR TITLE
fix: use proto.Merge to avoid copylocks with use_opaque_api=true

### DIFF
--- a/examples/internal/proto/examplepb/opaque.pb.gw.go
+++ b/examples/internal/proto/examplepb/opaque.pb.gw.go
@@ -128,7 +128,7 @@ func request_OpaqueEcommerceService_OpaqueCreateProduct_0(ctx context.Context, m
 	if err := marshaler.NewDecoder(req.Body).Decode(&bodyData); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	protoReq = bodyData
+	proto.Merge(&protoReq, &bodyData)
 	if req.Body != nil {
 		_, _ = io.Copy(io.Discard, req.Body)
 	}
@@ -145,7 +145,7 @@ func local_request_OpaqueEcommerceService_OpaqueCreateProduct_0(ctx context.Cont
 	if err := marshaler.NewDecoder(req.Body).Decode(&bodyData); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	protoReq = bodyData
+	proto.Merge(&protoReq, &bodyData)
 	msg, err := server.OpaqueCreateProduct(ctx, &protoReq)
 	return msg, metadata, err
 }

--- a/protoc-gen-grpc-gateway/internal/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/internal/gengateway/template.go
@@ -405,7 +405,7 @@ var filter_{{ .Method.Service.GetName }}_{{ .Method.GetName }}_{{ .Index }} = {{
 	if err := marshaler.NewDecoder(req.Body).Decode(&bodyData); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	protoReq = bodyData
+	proto.Merge(&protoReq, &bodyData)
 	{{- else }}
 	bodyData := &{{ .GetBodyFieldType }}{}
 	if err := marshaler.NewDecoder(req.Body).Decode(bodyData); err != nil && !errors.Is(err, io.EOF) {
@@ -429,7 +429,7 @@ var filter_{{ .Method.Service.GetName }}_{{ .Method.GetName }}_{{ .Index }} = {{
 	if err := marshaler.NewDecoder(newReader()).Decode(&bodyData); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	protoReq = bodyData
+	proto.Merge(&protoReq, &bodyData)
 	{{- else }}
 	bodyData := &{{ .GetBodyFieldType }}{}
 	if err := marshaler.NewDecoder(newReader()).Decode(bodyData); err != nil && !errors.Is(err, io.EOF) {
@@ -650,7 +650,7 @@ func local_request_{{ .Method.Service.GetName }}_{{ .Method.GetName }}_{{ .Index
 	if err := marshaler.NewDecoder(req.Body).Decode(&bodyData); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	protoReq = bodyData
+	proto.Merge(&protoReq, &bodyData)
 	{{- else }}
 	bodyData := &{{ .GetBodyFieldType }}{}
 	if err := marshaler.NewDecoder(req.Body).Decode(bodyData); err != nil && !errors.Is(err, io.EOF) {
@@ -671,7 +671,7 @@ func local_request_{{ .Method.Service.GetName }}_{{ .Method.GetName }}_{{ .Index
 	if err := marshaler.NewDecoder(newReader()).Decode(&bodyData); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	protoReq = bodyData
+	proto.Merge(&protoReq, &bodyData)
 	{{- else }}
 	bodyData := &{{ .GetBodyFieldType }}{}
 	if err := marshaler.NewDecoder(newReader()).Decode(bodyData); err != nil && !errors.Is(err, io.EOF) {


### PR DESCRIPTION
## Summary

When `use_opaque_api=true` , the generated `protoReq = bodyData` copies `protoimpl.MessageState`  (which contains `sync.Mutex` ), triggering `go vet copylocks` . Replace with `proto.Merge(&protoReq, &bodyData)` .


## Changes

- `protoc-gen-grpc-gateway/internal/gengateway/template.go`: Replace value
  assignment with `proto.Merge` to avoid copying `protoimpl.MessageState`
  (which embeds `sync.Mutex`)
- Regenerated `*.pb.gw.go` examples


#### References to other Issues or PRs

- #6380 