### PR TITLE
openapiv3-merge: new openapiv3 document merge tool

### DIFF
--- a/docs/docs/mapping/openapi_v3_merge.md
+++ b/docs/docs/mapping/openapi_v3_merge.md
@@ -1,0 +1,146 @@
+---
+layout: default
+title: Merging OpenAPI 3.1 Output
+nav_order: 8
+parent: Mapping
+---
+
+# Merging OpenAPI 3.1 Output
+
+{: .note }
+This page describes `openapiv3-merge`, the post-processing tool that
+combines `protoc-gen-openapiv3` output into a single OpenAPI document. The
+generator itself is documented under
+[OpenAPI 3.1 Output](./openapi_v3.md).
+
+[`protoc-gen-openapiv3`](./openapi_v3.md) emits **one OpenAPI document per
+proto file**, matching the protobuf convention of 1:1 input-to-output
+files. Many OpenAPI consumers — UI viewers, client generators, gateway
+configurations — expect a single document instead. `openapiv3-merge` is the
+post-processing step that combines the per-file outputs into one.
+
+## Installation
+
+```sh
+go install github.com/grpc-ecosystem/grpc-gateway/v2/openapiv3-merge@latest
+```
+
+## Usage
+
+```sh
+openapiv3-merge FILE [FILE ...] > merged.openapi.json
+```
+
+The merged document is written to stdout. Errors go to stderr and the
+process exits with a non-zero status. Input order matters: the first
+input's `info`, `servers`, and `externalDocs` are kept in the merged
+document, so put the file with the broadest scope (the one carrying any
+shared [`openapiv3_document`](./openapi_v3.md#example) annotation) first.
+
+### With buf
+
+Generate per-proto-file documents the usual way, then merge them:
+
+```sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+buf generate
+
+# Put the file with the shared openapiv3_document annotation first so
+# its info/servers/externalDocs are kept, then everything else in
+# sorted order for determinism.
+root=gen/api/v1/api.openapi.json
+mapfile -t rest < <(find gen -name '*.openapi.json' ! -path "$root" | sort)
+openapiv3-merge "$root" "${rest[@]}" > gen/api.openapi.json
+```
+
+If you don't have a designated root file, just sort all inputs and accept
+whichever sorts first — but set the `openapiv3_document` annotation on
+that proto so the merged output has a sensible `title`, `version`, and
+`servers`.
+
+### With protoc
+
+```sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+protoc -I. \
+  --openapiv3_out=./gen \
+  $(find . -name '*.proto')
+
+root=gen/api/v1/api.openapi.json
+mapfile -t rest < <(find gen -name '*.openapi.json' ! -path "$root" | sort)
+openapiv3-merge "$root" "${rest[@]}" > gen/api.openapi.json
+```
+
+### One-shot
+
+For trivial trees where any input may go first:
+
+```sh
+openapiv3-merge $(find . -name '*.openapi.json' | sort) > api.openapi.json
+```
+
+## What gets merged, and how
+
+| Field | Rule |
+| --- | --- |
+| `openapi` | Must match across all inputs. |
+| `info`, `servers`, `externalDocs` | Taken from the first input. Later inputs' values are dropped. |
+| `paths`, `webhooks` | Unioned in input order. Path collisions with non-identical content are errors. |
+| `components/*` | Unioned with sorted keys. Same name with non-identical content is an error. |
+| `tags` | Deduplicated by `name`. Same name with non-identical metadata is an error. |
+| `security` | First input to declare a non-empty array wins. Later inputs that declare a different non-empty array are an error. |
+| Unknown top-level keys (extensions, `x-*`) | Taken from the first input. |
+
+"Non-identical content" is determined by canonical comparison: two values
+that differ only in key order compare equal. Since `protoc-gen-openapiv3`
+names component schemas with their fully qualified proto name (e.g.
+`example.v1.User`), the same message reused across packages contributes a
+single, identical component to every output, and the merger combines them
+cleanly.
+
+The first input controls the merged document's `info` block. If you want a
+shared title, version, contact, license, or set of `servers` across all
+merged output, set them with an
+[`openapiv3_document`](./openapi_v3.md#example) annotation on the
+proto file that appears first in your merge invocation.
+
+## Output
+
+- Top-level fields are emitted in OpenAPI 3.1.0 declaration order
+  (`openapi`, `info`, `servers`, `paths`, `webhooks`, `components`,
+  `security`, `tags`, `externalDocs`, then any extensions).
+- `paths` and `webhooks` are emitted in input order.
+- `components/*` sub-maps are sorted lexicographically, matching what
+  `protoc-gen-openapiv3` itself emits per file.
+- `tags` are emitted in first-occurrence order across inputs.
+
+## Example merge errors
+
+When a merge fails, the error message identifies the conflicting field:
+
+```
+openapiv3-merge: paths."/v1/echo": echo.openapi.json redefines an entry with a different value
+```
+
+Common causes:
+
+- **Conflicting path definitions.** Two protos declared the same HTTP path
+  with different bindings. Decide which one is authoritative.
+- **Conflicting component definitions.** Two messages with the same fully
+  qualified proto name but different shapes — usually means a duplicate
+  `package` + message declaration somewhere in your proto tree.
+- **Conflicting tag metadata.** Two `openapiv3_document.tags` annotations
+  described the same tag with different descriptions. Make them match or
+  move the metadata to one place.
+- **Mismatched OpenAPI versions.** All inputs must declare the same
+  `openapi` value.
+
+## See also
+
+- [OpenAPI 3.1 Output](./openapi_v3.md) — the generator that produces the
+  per-file inputs to `openapiv3-merge`.
+- [openapiv3-merge README](https://github.com/grpc-ecosystem/grpc-gateway/tree/main/openapiv3-merge) — quick reference and source.

--- a/openapiv3-merge/BUILD.bazel
+++ b/openapiv3-merge/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "openapiv3-merge_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/grpc-ecosystem/grpc-gateway/v2/openapiv3-merge",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//openapiv3-merge/internal/merge",
+    ],
+)
+
+go_binary(
+    name = "openapiv3-merge",
+    embed = [":openapiv3-merge_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "openapiv3-merge_test",
+    srcs = ["main_test.go"],
+    embed = [":openapiv3-merge_lib"],
+)

--- a/openapiv3-merge/README.md
+++ b/openapiv3-merge/README.md
@@ -1,0 +1,95 @@
+# openapiv3-merge
+
+`openapiv3-merge` combines multiple OpenAPI 3.1 JSON documents into a single
+document. It is the companion tool for [`protoc-gen-openapiv3`](../protoc-gen-openapiv3/),
+which emits one document per proto file. Pipe its output through
+`openapiv3-merge` to produce a single combined spec.
+
+## Why a separate binary
+
+`protoc-gen-openapiv3` follows the protobuf convention of one output file per
+input file. That keeps the plugin well-behaved under all protoc/buf
+invocations and avoids forcing `buf` users onto `strategy: all`. The trade-off
+is that consumers who want one document have to combine the per-file outputs
+themselves. `openapiv3-merge` is that step.
+
+## Install
+
+```sh
+go install github.com/grpc-ecosystem/grpc-gateway/v2/openapiv3-merge@latest
+```
+
+## Usage
+
+```sh
+openapiv3-merge FILE [FILE ...] > merged.openapi.json
+```
+
+The merged document is written to stdout. Errors go to stderr and the
+process exits with a non-zero status. Input order matters: the first
+input's `info`, `servers`, and `externalDocs` are kept in the merged
+document, so put the file with the broadest scope first.
+
+### With buf
+
+```sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+buf generate
+
+# Put the file with the shared openapiv3_document annotation first so
+# its info/servers/externalDocs are kept; sort the rest for determinism.
+root=gen/api/v1/api.openapi.json
+mapfile -t rest < <(find gen -name '*.openapi.json' ! -path "$root" | sort)
+openapiv3-merge "$root" "${rest[@]}" > gen/api.openapi.json
+```
+
+### With protoc
+
+```sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+protoc -I. \
+  --openapiv3_out=./gen \
+  $(find . -name '*.proto')
+
+root=gen/api/v1/api.openapi.json
+mapfile -t rest < <(find gen -name '*.openapi.json' ! -path "$root" | sort)
+openapiv3-merge "$root" "${rest[@]}" > gen/api.openapi.json
+```
+
+### One-shot
+
+For trivial trees where any input may go first:
+
+```sh
+openapiv3-merge $(find . -name '*.openapi.json' | sort) > api.openapi.json
+```
+
+## Merge rules
+
+The merger is strict: anything that could be a silent overwrite is rejected.
+
+| Field | Rule |
+| --- | --- |
+| `openapi` | Must match across all inputs. |
+| `info`, `servers`, `externalDocs` | Taken from the first input. Later inputs' values are dropped. |
+| `paths`, `webhooks` | Unioned in input order. Same path with non-identical content → error. |
+| `components/*` | Unioned with sorted keys. Same name with non-identical content → error. |
+| `tags` | Deduplicated by `name`. Same name with non-identical metadata → error. |
+| `security` | First input to declare a non-empty array wins. Later inputs that declare a different non-empty array → error. |
+| Unknown top-level keys (extensions, `x-*`) | Taken from the first input. |
+
+"Non-identical content" is compared canonically: two values that differ only
+in key order are equal. This means component schemas with the same fully
+qualified name (which is what `protoc-gen-openapiv3` emits — e.g.
+`example.v1.User`) merge cleanly across packages.
+
+## Output
+
+- Top-level fields appear in OpenAPI 3.1.0 declaration order.
+- `paths` and `webhooks` are emitted in input order.
+- `components/*` sub-maps are sorted by key, matching `protoc-gen-openapiv3`.
+- Tags appear in first-occurrence order.

--- a/openapiv3-merge/internal/merge/BUILD.bazel
+++ b/openapiv3-merge/internal/merge/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "merge",
+    srcs = ["merge.go"],
+    importpath = "github.com/grpc-ecosystem/grpc-gateway/v2/openapiv3-merge/internal/merge",
+    visibility = ["//openapiv3-merge:__subpackages__"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":merge",
+    visibility = ["//openapiv3-merge:__subpackages__"],
+)
+
+go_test(
+    name = "merge_test",
+    srcs = ["merge_test.go"],
+    data = glob(["testdata/**"]),
+    embed = [":merge"],
+)

--- a/openapiv3-merge/internal/merge/merge.go
+++ b/openapiv3-merge/internal/merge/merge.go
@@ -1,0 +1,582 @@
+// Package merge merges multiple OpenAPI 3.1 JSON documents into a single
+// document.
+//
+// The merger is strict by design: it refuses to silently overwrite anything.
+// Two inputs that declare the same path, the same component name, or the
+// same tag name with conflicting content are rejected as errors. In
+// practice, output from protoc-gen-openapiv3 merges cleanly across packages
+// because component names are fully-qualified proto names (e.g.
+// `example.v1.User`); conflicts surface only for genuine mistakes.
+//
+// Field-by-field rules:
+//
+//   - `openapi` must match across all inputs.
+//   - `info`, `servers`, `externalDocs`, and any unknown top-level keys
+//     (including OpenAPI extensions `x-*`) are taken from the first
+//     input; the corresponding fields in later inputs are silently
+//     discarded. This matches the practical case where
+//     protoc-gen-openapiv3 derives a default `info.title` from each
+//     file's name — without this lenience, the common case would never
+//     merge.
+//   - `paths` and `webhooks` are unioned in input order; key collisions
+//     with non-identical values are an error.
+//   - `components/*` sub-maps are unioned with sorted-key output;
+//     same-named entries with non-identical values are an error.
+//   - `tags` are deduplicated by `name`; same-named entries with
+//     non-identical metadata are an error.
+//   - `security` is first-wins: the first input to declare a non-empty
+//     `security` array sets it; later inputs that declare a different
+//     non-empty array are rejected.
+package merge
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Input is a single OpenAPI 3.1 JSON document to merge.
+type Input struct {
+	// Name identifies the document in error messages, typically the path
+	// the document was loaded from.
+	Name string
+	// Data is the raw JSON content of the document.
+	Data []byte
+}
+
+// Merge combines inputs into a single OpenAPI 3.1 JSON document and returns
+// its pretty-printed bytes (two-space indent, matching protoc-gen-openapiv3).
+//
+// At least one input is required. The first input's `info`, `servers`, and
+// `externalDocs` are kept in the merged document.
+func Merge(inputs []Input) ([]byte, error) {
+	if len(inputs) == 0 {
+		return nil, errors.New("at least one input is required")
+	}
+	docs := make([]*document, len(inputs))
+	for i, in := range inputs {
+		d, err := parse(in)
+		if err != nil {
+			return nil, err
+		}
+		docs[i] = d
+	}
+	merged, err := mergeAll(docs)
+	if err != nil {
+		return nil, err
+	}
+	// Drop empty container fields so encoding/json's omitempty omits them.
+	if merged.Paths.len() == 0 {
+		merged.Paths = nil
+	}
+	if merged.Webhooks.len() == 0 {
+		merged.Webhooks = nil
+	}
+	if merged.Components.empty() {
+		merged.Components = nil
+	}
+	if merged.extras.len() == 0 {
+		merged.extras = nil
+	}
+	return json.MarshalIndent(merged, "", "  ")
+}
+
+// document is the in-memory and serialised shape of an OpenAPI 3.1
+// document. Field order matches the spec, so encoding/json emits them in
+// the canonical order; encoding/json also sorts map keys alphabetically,
+// which is what protoc-gen-openapiv3 itself emits per file. paths and
+// webhooks preserve input-file ordering via orderedObject's MarshalJSON.
+type document struct {
+	OpenAPI      string            `json:"openapi"`
+	Info         json.RawMessage   `json:"info,omitempty"`
+	Servers      json.RawMessage   `json:"servers,omitempty"`
+	Paths        *orderedObject    `json:"paths,omitempty"`
+	Webhooks     *orderedObject    `json:"webhooks,omitempty"`
+	Components   *components       `json:"components,omitempty"`
+	Security     []json.RawMessage `json:"security,omitempty"`
+	Tags         []json.RawMessage `json:"tags,omitempty"`
+	ExternalDocs json.RawMessage   `json:"externalDocs,omitempty"`
+
+	// name identifies the input in error messages and is not serialised.
+	name string
+	// extras holds top-level keys outside the OpenAPI 3.1 defined set,
+	// notably extensions (`x-*`). The json:"-" tag keeps them out of
+	// the default marshaler; MarshalJSON splices them in after the
+	// known fields, preserving first-occurrence order.
+	extras *orderedObject `json:"-"`
+}
+
+// MarshalJSON marshals the struct fields via the standard encoder, then
+// splices in extras before the closing brace. The alias type strips this
+// MarshalJSON method so the inner Marshal call doesn't recurse.
+func (d *document) MarshalJSON() ([]byte, error) {
+	type alias document
+	body, err := json.Marshal((*alias)(d))
+	if err != nil {
+		return nil, err
+	}
+	if d.extras == nil || d.extras.len() == 0 {
+		return body, nil
+	}
+	// body ends with '}'. If the struct produced an empty object ("{}"),
+	// the spliced extras must not be preceded by a comma.
+	body = body[:len(body)-1]
+	needComma := !bytes.Equal(body, []byte("{"))
+	var buf bytes.Buffer
+	buf.Write(body)
+	for _, k := range d.extras.keys {
+		if needComma {
+			buf.WriteByte(',')
+		}
+		needComma = true
+		keyJSON, err := json.Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(keyJSON)
+		buf.WriteByte(':')
+		buf.Write(d.extras.vals[k])
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+// components captures the components/* section. Field order matches
+// OpenAPI 3.1.0 §4.8.7; encoding/json sorts the keys of each map.
+type components struct {
+	Schemas         map[string]json.RawMessage `json:"schemas,omitempty"`
+	Responses       map[string]json.RawMessage `json:"responses,omitempty"`
+	Parameters      map[string]json.RawMessage `json:"parameters,omitempty"`
+	Examples        map[string]json.RawMessage `json:"examples,omitempty"`
+	RequestBodies   map[string]json.RawMessage `json:"requestBodies,omitempty"`
+	Headers         map[string]json.RawMessage `json:"headers,omitempty"`
+	SecuritySchemes map[string]json.RawMessage `json:"securitySchemes,omitempty"`
+	Links           map[string]json.RawMessage `json:"links,omitempty"`
+	Callbacks       map[string]json.RawMessage `json:"callbacks,omitempty"`
+	PathItems       map[string]json.RawMessage `json:"pathItems,omitempty"`
+}
+
+func (c *components) empty() bool {
+	if c == nil {
+		return true
+	}
+	return len(c.Schemas)+len(c.Responses)+len(c.Parameters)+len(c.Examples)+
+		len(c.RequestBodies)+len(c.Headers)+len(c.SecuritySchemes)+
+		len(c.Links)+len(c.Callbacks)+len(c.PathItems) == 0
+}
+
+// parse decodes one input into a document, separating known top-level
+// fields from extras. The token-based parser is used instead of
+// json.Unmarshal because we need to capture first-occurrence order of
+// unknown keys and the insertion order of `paths`/`webhooks` entries.
+func parse(in Input) (*document, error) {
+	d := &document{
+		name:       in.Name,
+		Paths:      newOrderedObject(),
+		Webhooks:   newOrderedObject(),
+		Components: &components{},
+		extras:     newOrderedObject(),
+	}
+	dec := json.NewDecoder(bytes.NewReader(in.Data))
+	dec.UseNumber()
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", in.Name, err)
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		return nil, fmt.Errorf("%s: expected JSON object at top level", in.Name)
+	}
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", in.Name, err)
+		}
+		key, ok := tok.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s: unexpected token %v", in.Name, tok)
+		}
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("%s: %q: %w", in.Name, key, err)
+		}
+		switch key {
+		case "openapi":
+			if err := json.Unmarshal(raw, &d.OpenAPI); err != nil {
+				return nil, fmt.Errorf("%s: openapi: %w", in.Name, err)
+			}
+		case "info":
+			d.Info = raw
+		case "servers":
+			d.Servers = raw
+		case "paths":
+			obj, err := decodeOrderedObject(raw)
+			if err != nil {
+				return nil, fmt.Errorf("%s: paths: %w", in.Name, err)
+			}
+			d.Paths = obj
+		case "webhooks":
+			obj, err := decodeOrderedObject(raw)
+			if err != nil {
+				return nil, fmt.Errorf("%s: webhooks: %w", in.Name, err)
+			}
+			d.Webhooks = obj
+		case "components":
+			if !isJSONNull(raw) {
+				if err := json.Unmarshal(raw, d.Components); err != nil {
+					return nil, fmt.Errorf("%s: components: %w", in.Name, err)
+				}
+			}
+		case "security":
+			if err := json.Unmarshal(raw, &d.Security); err != nil {
+				return nil, fmt.Errorf("%s: security: %w", in.Name, err)
+			}
+		case "tags":
+			if err := json.Unmarshal(raw, &d.Tags); err != nil {
+				return nil, fmt.Errorf("%s: tags: %w", in.Name, err)
+			}
+		case "externalDocs":
+			d.ExternalDocs = raw
+		default:
+			d.extras.set(key, raw)
+		}
+	}
+	if _, err := dec.Token(); err != nil {
+		return nil, fmt.Errorf("%s: %w", in.Name, err)
+	}
+	if d.OpenAPI == "" {
+		return nil, fmt.Errorf("%s: missing required field \"openapi\"", in.Name)
+	}
+	if isJSONNull(d.Info) {
+		return nil, fmt.Errorf("%s: missing required field \"info\"", in.Name)
+	}
+	return d, nil
+}
+
+// mergeAll merges parsed documents in order. The first establishes the
+// values that later inputs must not contradict.
+func mergeAll(docs []*document) (*document, error) {
+	first := docs[0]
+	out := &document{
+		name:         "merged",
+		OpenAPI:      first.OpenAPI,
+		Info:         first.Info,
+		Servers:      first.Servers,
+		Paths:        newOrderedObject(),
+		Webhooks:     newOrderedObject(),
+		Components:   &components{},
+		ExternalDocs: first.ExternalDocs,
+		extras:       newOrderedObject(),
+	}
+	seenTags := map[string]json.RawMessage{}
+
+	for _, d := range docs {
+		if d.OpenAPI != out.OpenAPI {
+			return nil, fmt.Errorf("openapi: %s declares %q but %s declares %q",
+				first.name, out.OpenAPI, d.name, d.OpenAPI)
+		}
+		// info/servers/externalDocs and unknown top-level keys are first-wins,
+		// silently. The first input's value is already in `out`; nothing to
+		// do for later inputs.
+		if err := mergeOrdered("paths", out.Paths, d.Paths, d.name); err != nil {
+			return nil, err
+		}
+		if err := mergeOrdered("webhooks", out.Webhooks, d.Webhooks, d.name); err != nil {
+			return nil, err
+		}
+		if err := mergeComponents(out.Components, d.Components, d.name); err != nil {
+			return nil, err
+		}
+		if err := mergeTags(out, seenTags, d); err != nil {
+			return nil, err
+		}
+		if err := mergeSecurity(out, d); err != nil {
+			return nil, err
+		}
+		mergeExtras(out.extras, d.extras)
+	}
+	return out, nil
+}
+
+// mergeOrdered appends entries from src into dst, rejecting key collisions
+// whose values differ canonically.
+func mergeOrdered(field string, dst, src *orderedObject, srcName string) error {
+	for _, k := range src.keys {
+		v := src.vals[k]
+		if existing, ok := dst.get(k); ok {
+			same, err := canonicalEqual(existing, v)
+			if err != nil {
+				return fmt.Errorf("%s.%s: %w", field, k, err)
+			}
+			if !same {
+				return fmt.Errorf("%s.%q: %s redefines an entry with a different value", field, k, srcName)
+			}
+			continue
+		}
+		dst.set(k, v)
+	}
+	return nil
+}
+
+// mergeComponents unions each components/* sub-map. Same-named entries
+// across inputs must be canonically identical. The sub-maps are walked in
+// spec order so error messages are deterministic.
+func mergeComponents(dst, src *components, srcName string) error {
+	pairs := []struct {
+		name string
+		dst  *map[string]json.RawMessage
+		src  *map[string]json.RawMessage
+	}{
+		{"schemas", &dst.Schemas, &src.Schemas},
+		{"responses", &dst.Responses, &src.Responses},
+		{"parameters", &dst.Parameters, &src.Parameters},
+		{"examples", &dst.Examples, &src.Examples},
+		{"requestBodies", &dst.RequestBodies, &src.RequestBodies},
+		{"headers", &dst.Headers, &src.Headers},
+		{"securitySchemes", &dst.SecuritySchemes, &src.SecuritySchemes},
+		{"links", &dst.Links, &src.Links},
+		{"callbacks", &dst.Callbacks, &src.Callbacks},
+		{"pathItems", &dst.PathItems, &src.PathItems},
+	}
+	for _, p := range pairs {
+		if len(*p.src) == 0 {
+			continue
+		}
+		if *p.dst == nil {
+			*p.dst = make(map[string]json.RawMessage, len(*p.src))
+		}
+		for k, v := range *p.src {
+			if prev, dup := (*p.dst)[k]; dup {
+				same, err := canonicalEqual(prev, v)
+				if err != nil {
+					return fmt.Errorf("components.%s.%s: %w", p.name, k, err)
+				}
+				if !same {
+					return fmt.Errorf("components.%s.%q: %s redefines an entry with a different value", p.name, k, srcName)
+				}
+				continue
+			}
+			(*p.dst)[k] = v
+		}
+	}
+	return nil
+}
+
+// mergeTags appends tags from src to out, deduplicating by `name`. Two tag
+// entries sharing a name must declare identical metadata.
+func mergeTags(out *document, seen map[string]json.RawMessage, src *document) error {
+	for _, raw := range src.Tags {
+		name, err := tagName(raw)
+		if err != nil {
+			return fmt.Errorf("%s: tags: %w", src.name, err)
+		}
+		if prev, ok := seen[name]; ok {
+			same, err := canonicalEqual(prev, raw)
+			if err != nil {
+				return fmt.Errorf("tags[%q]: %w", name, err)
+			}
+			if !same {
+				return fmt.Errorf("tags[%q]: %s redefines a tag with different metadata", name, src.name)
+			}
+			continue
+		}
+		seen[name] = raw
+		out.Tags = append(out.Tags, raw)
+	}
+	return nil
+}
+
+// mergeSecurity applies first-wins to the root `security` array. The first
+// input to declare a non-empty `security` value establishes it; later
+// inputs that declare a different non-empty value are an error. (The root
+// `security` is a list of alternatives that apply across the whole API; if
+// two generators disagree, silently keeping one would change what callers
+// are allowed to do.)
+func mergeSecurity(out, src *document) error {
+	if len(src.Security) == 0 {
+		return nil
+	}
+	if len(out.Security) == 0 {
+		out.Security = src.Security
+		return nil
+	}
+	a, err := json.Marshal(out.Security)
+	if err != nil {
+		return fmt.Errorf("security: %w", err)
+	}
+	b, err := json.Marshal(src.Security)
+	if err != nil {
+		return fmt.Errorf("security: %w", err)
+	}
+	same, err := canonicalEqual(a, b)
+	if err != nil {
+		return fmt.Errorf("security: %w", err)
+	}
+	if !same {
+		return fmt.Errorf("security: %s declares different requirements", src.name)
+	}
+	return nil
+}
+
+// mergeExtras applies first-wins to unknown top-level keys (notably
+// extensions `x-*`). Conflicting redeclarations from later inputs are
+// silently ignored, matching the policy for info/servers/etc.
+func mergeExtras(dst, src *orderedObject) {
+	for _, k := range src.keys {
+		if _, ok := dst.get(k); ok {
+			continue
+		}
+		dst.set(k, src.vals[k])
+	}
+}
+
+// canonicalEqual reports whether a and b decode to the same JSON value
+// under canonical (sorted-key) encoding.
+func canonicalEqual(a, b json.RawMessage) (bool, error) {
+	if bytes.Equal(a, b) {
+		return true, nil
+	}
+	ca, err := canonicalize(a)
+	if err != nil {
+		return false, err
+	}
+	cb, err := canonicalize(b)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(ca, cb), nil
+}
+
+// canonicalize re-encodes raw with sorted map keys, so two semantically
+// identical JSON documents that happen to differ in key order compare equal.
+func canonicalize(raw json.RawMessage) ([]byte, error) {
+	if len(raw) == 0 {
+		return raw, nil
+	}
+	var v any
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	if err := dec.Decode(&v); err != nil {
+		return nil, err
+	}
+	return json.Marshal(v)
+}
+
+// tagName extracts the `name` field from a tag entry. Tag entries without
+// a name violate the OpenAPI spec and are rejected.
+func tagName(raw json.RawMessage) (string, error) {
+	var t struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(raw, &t); err != nil {
+		return "", fmt.Errorf("invalid tag entry: %w", err)
+	}
+	if t.Name == "" {
+		return "", errors.New("tag entry missing required \"name\"")
+	}
+	return t.Name, nil
+}
+
+// isJSONNull reports whether raw is the JSON null literal (possibly
+// surrounded by whitespace). Empty input also counts as null.
+func isJSONNull(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return true
+	}
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
+}
+
+// orderedObject is an insertion-ordered JSON object. It is used for
+// `paths`, `webhooks`, and the bucket of unrecognised top-level keys —
+// the three places where input-file order matters and encoding/json's
+// alphabetical key sort would lose information.
+type orderedObject struct {
+	keys []string
+	vals map[string]json.RawMessage
+}
+
+func newOrderedObject() *orderedObject {
+	return &orderedObject{vals: map[string]json.RawMessage{}}
+}
+
+func (o *orderedObject) set(k string, v json.RawMessage) {
+	if _, ok := o.vals[k]; !ok {
+		o.keys = append(o.keys, k)
+	}
+	o.vals[k] = v
+}
+
+func (o *orderedObject) get(k string) (json.RawMessage, bool) {
+	if o == nil {
+		return nil, false
+	}
+	v, ok := o.vals[k]
+	return v, ok
+}
+
+func (o *orderedObject) len() int {
+	if o == nil {
+		return 0
+	}
+	return len(o.keys)
+}
+
+// MarshalJSON emits the entries in insertion order.
+func (o *orderedObject) MarshalJSON() ([]byte, error) {
+	if o == nil || len(o.keys) == 0 {
+		return []byte("{}"), nil
+	}
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, k := range o.keys {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		key, err := json.Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(key)
+		buf.WriteByte(':')
+		buf.Write(o.vals[k])
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+// decodeOrderedObject parses a JSON object into an orderedObject, preserving
+// the input's key order.
+func decodeOrderedObject(raw json.RawMessage) (*orderedObject, error) {
+	if isJSONNull(raw) {
+		return newOrderedObject(), nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		return nil, fmt.Errorf("expected JSON object, got %v", tok)
+	}
+	out := newOrderedObject()
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		k, ok := tok.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected string key, got %v", tok)
+		}
+		var v json.RawMessage
+		if err := dec.Decode(&v); err != nil {
+			return nil, err
+		}
+		out.set(k, v)
+	}
+	if _, err := dec.Token(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/openapiv3-merge/internal/merge/merge_test.go
+++ b/openapiv3-merge/internal/merge/merge_test.go
@@ -1,0 +1,793 @@
+package merge
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+// minimal returns a minimal valid OpenAPI 3.1 document body with the given
+// path and component schema. Used by the table-driven cases below to keep
+// fixtures compact.
+func minimal(title, pathKey, schemaName string) string {
+	return `{
+  "openapi": "3.1.0",
+  "info": { "title": "` + title + `", "version": "1.0.0" },
+  "paths": {
+    "` + pathKey + `": {
+      "get": { "operationId": "Op_` + schemaName + `", "responses": { "200": { "description": "ok" } } }
+    }
+  },
+  "components": { "schemas": { "` + schemaName + `": { "type": "object" } } }
+}`
+}
+
+func TestMerge_TwoDisjointInputs(t *testing.T) {
+	out, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(minimal("a", "/a", "pkg.A"))},
+		{Name: "b.json", Data: []byte(minimal("b", "/b", "pkg.B"))},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, out)
+	}
+	// info comes from the first input
+	if title := got["info"].(map[string]any)["title"]; title != "a" {
+		t.Errorf("info.title: got %q, want %q", title, "a")
+	}
+	paths := got["paths"].(map[string]any)
+	if _, ok := paths["/a"]; !ok {
+		t.Errorf("paths missing /a; got %v", paths)
+	}
+	if _, ok := paths["/b"]; !ok {
+		t.Errorf("paths missing /b; got %v", paths)
+	}
+	schemas := got["components"].(map[string]any)["schemas"].(map[string]any)
+	if _, ok := schemas["pkg.A"]; !ok {
+		t.Errorf("schemas missing pkg.A")
+	}
+	if _, ok := schemas["pkg.B"]; !ok {
+		t.Errorf("schemas missing pkg.B")
+	}
+}
+
+func TestMerge_PathOrder(t *testing.T) {
+	// Paths must appear in input order: a.json's paths first, b.json's after.
+	out, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(minimal("a", "/zzz", "pkg.A"))},
+		{Name: "b.json", Data: []byte(minimal("b", "/aaa", "pkg.B"))},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	zzzIdx := bytes.Index(out, []byte(`"/zzz"`))
+	aaaIdx := bytes.Index(out, []byte(`"/aaa"`))
+	if zzzIdx < 0 || aaaIdx < 0 || zzzIdx > aaaIdx {
+		t.Errorf("paths out of input order; /zzz at %d, /aaa at %d:\n%s", zzzIdx, aaaIdx, out)
+	}
+}
+
+func TestMerge_ComponentsSorted(t *testing.T) {
+	// components.schemas keys must come out sorted regardless of input order.
+	out, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(minimal("a", "/a", "z.Z"))},
+		{Name: "b.json", Data: []byte(minimal("b", "/b", "a.A"))},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	aIdx := bytes.Index(out, []byte(`"a.A"`))
+	zIdx := bytes.Index(out, []byte(`"z.Z"`))
+	if aIdx < 0 || zIdx < 0 || aIdx > zIdx {
+		t.Errorf("components not sorted; a.A at %d, z.Z at %d:\n%s", aIdx, zIdx, out)
+	}
+}
+
+func TestMerge_PathCollisionConflictingValues(t *testing.T) {
+	a := minimal("a", "/v1/echo", "pkg.A")
+	b := minimal("b", "/v1/echo", "pkg.B")
+	_, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err == nil {
+		t.Fatal("expected error on path collision, got nil")
+	}
+	if !strings.Contains(err.Error(), "/v1/echo") {
+		t.Errorf("error should mention the conflicting path; got: %v", err)
+	}
+}
+
+func TestMerge_PathCollisionIdenticalValues(t *testing.T) {
+	// Same path with identical content should merge cleanly.
+	a := minimal("a", "/v1/echo", "pkg.X")
+	b := minimal("b", "/v1/echo", "pkg.X")
+	_, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err != nil {
+		t.Fatalf("expected identical paths to merge, got: %v", err)
+	}
+}
+
+func TestMerge_ComponentCollisionConflictingValues(t *testing.T) {
+	a := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/a": { "get": { "operationId": "Op_a", "responses": { "200": { "description": "ok" } } } } },
+  "components": { "schemas": { "pkg.User": { "type": "object", "properties": { "id": { "type": "string" } } } } }
+}`
+	b := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/b": { "get": { "operationId": "Op_b", "responses": { "200": { "description": "ok" } } } } },
+  "components": { "schemas": { "pkg.User": { "type": "object", "properties": { "name": { "type": "string" } } } } }
+}`
+	_, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err == nil {
+		t.Fatal("expected error on component collision")
+	}
+	if !strings.Contains(err.Error(), "pkg.User") {
+		t.Errorf("error should mention conflicting component; got: %v", err)
+	}
+}
+
+func TestMerge_ComponentCollisionKeyOrderInsensitive(t *testing.T) {
+	// Two schemas that differ only in key order must compare equal.
+	a := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/a": { "get": { "operationId": "Op_a", "responses": { "200": { "description": "ok" } } } } },
+  "components": { "schemas": { "pkg.User": { "type": "object", "description": "u" } } }
+}`
+	b := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/b": { "get": { "operationId": "Op_b", "responses": { "200": { "description": "ok" } } } } },
+  "components": { "schemas": { "pkg.User": { "description": "u", "type": "object" } } }
+}`
+	if _, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	}); err != nil {
+		t.Errorf("expected canonical equality; got: %v", err)
+	}
+}
+
+func TestMerge_TagDedup(t *testing.T) {
+	a := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/a": { "get": { "operationId": "Op_a", "tags": ["Users"], "responses": { "200": { "description": "ok" } } } } },
+  "tags": [{ "name": "Users", "description": "manage users" }]
+}`
+	b := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/b": { "get": { "operationId": "Op_b", "tags": ["Users"], "responses": { "200": { "description": "ok" } } } } },
+  "tags": [{ "name": "Users", "description": "manage users" }]
+}`
+	out, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, out)
+	}
+	tags := got["tags"].([]any)
+	if len(tags) != 1 {
+		t.Errorf("expected 1 deduplicated tag, got %d: %v", len(tags), tags)
+	}
+}
+
+func TestMerge_TagConflict(t *testing.T) {
+	a := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/a": { "get": { "operationId": "Op_a", "responses": { "200": { "description": "ok" } } } } },
+  "tags": [{ "name": "Users", "description": "first" }]
+}`
+	b := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/b": { "get": { "operationId": "Op_b", "responses": { "200": { "description": "ok" } } } } },
+  "tags": [{ "name": "Users", "description": "second" }]
+}`
+	_, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err == nil {
+		t.Fatal("expected error on conflicting tag metadata")
+	}
+	if !strings.Contains(err.Error(), "Users") {
+		t.Errorf("error should mention the conflicting tag; got: %v", err)
+	}
+}
+
+func TestMerge_OpenAPIVersionMismatch(t *testing.T) {
+	a := `{"openapi":"3.1.0","info":{"title":"a","version":"1.0.0"},"paths":{}}`
+	b := `{"openapi":"3.2.0","info":{"title":"b","version":"1.0.0"},"paths":{}}`
+	_, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err == nil {
+		t.Fatal("expected error on openapi version mismatch")
+	}
+	if !strings.Contains(err.Error(), "openapi") {
+		t.Errorf("error should mention the openapi field; got: %v", err)
+	}
+}
+
+func TestMerge_InfoFirstWins(t *testing.T) {
+	// Different info blocks across inputs must not error — the first input
+	// wins quietly. protoc-gen-openapiv3 derives info.title from each file's
+	// name, so disagreement is the common case.
+	a := `{
+  "openapi": "3.1.0",
+  "info": { "title": "from-a", "version": "1.0.0" },
+  "paths": { "/a": { "get": { "operationId": "Op_a", "responses": { "200": { "description": "ok" } } } } }
+}`
+	b := `{
+  "openapi": "3.1.0",
+  "info": { "title": "from-b", "version": "1.0.0" },
+  "paths": { "/b": { "get": { "operationId": "Op_b", "responses": { "200": { "description": "ok" } } } } }
+}`
+	out, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("invalid output JSON: %v\n%s", err, out)
+	}
+	if title := got["info"].(map[string]any)["title"]; title != "from-a" {
+		t.Errorf("info.title: got %q, want %q (first input)", title, "from-a")
+	}
+}
+
+func TestMerge_InfoIdentical(t *testing.T) {
+	// Same info on both inputs is the common case for protoc-gen-openapiv3
+	// output sharing an `openapiv3_document` annotation.
+	body := `{
+  "openapi": "3.1.0",
+  "info": { "title": "shared", "version": "1.0.0" },
+  "paths": { "/PATH": { "get": { "operationId": "Op_X", "responses": { "200": { "description": "ok" } } } } }
+}`
+	a := strings.ReplaceAll(body, "PATH", "a")
+	b := strings.ReplaceAll(body, "PATH", "b")
+	if _, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	}); err != nil {
+		t.Errorf("identical info should merge cleanly; got: %v", err)
+	}
+}
+
+func TestMerge_NoInputs(t *testing.T) {
+	if _, err := Merge(nil); err == nil {
+		t.Error("expected error on empty input list")
+	}
+}
+
+func TestMerge_SingleInputPassthrough(t *testing.T) {
+	in := minimal("only", "/only", "pkg.Only")
+	out, err := Merge([]Input{{Name: "only.json", Data: []byte(in)}})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("invalid output JSON: %v\n%s", err, out)
+	}
+	if got["info"].(map[string]any)["title"] != "only" {
+		t.Errorf("info.title not preserved")
+	}
+	if _, ok := got["paths"].(map[string]any)["/only"]; !ok {
+		t.Errorf("paths not preserved")
+	}
+}
+
+func TestMerge_ExtrasFirstWins(t *testing.T) {
+	a := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "x-internal-id": "alpha",
+  "x-team": "platform",
+  "paths": { "/a": { "get": { "operationId": "Op_a", "responses": { "200": { "description": "ok" } } } } }
+}`
+	b := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "x-internal-id": "alpha",
+  "paths": { "/b": { "get": { "operationId": "Op_b", "responses": { "200": { "description": "ok" } } } } }
+}`
+	out, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if !bytes.Contains(out, []byte(`"x-internal-id": "alpha"`)) {
+		t.Errorf("x-internal-id not in output:\n%s", out)
+	}
+	if !bytes.Contains(out, []byte(`"x-team": "platform"`)) {
+		t.Errorf("x-team not in output:\n%s", out)
+	}
+}
+
+func TestMerge_ExtrasFirstWinsOnConflict(t *testing.T) {
+	// Conflicting top-level extensions: first input's value wins silently.
+	a := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "x-internal-id": "alpha",
+  "paths": { "/a": { "get": { "operationId": "Op_a", "responses": { "200": { "description": "ok" } } } } }
+}`
+	b := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "x-internal-id": "beta",
+  "paths": { "/b": { "get": { "operationId": "Op_b", "responses": { "200": { "description": "ok" } } } } }
+}`
+	out, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if id := got["x-internal-id"]; id != "alpha" {
+		t.Errorf("x-internal-id: got %q, want %q (first input)", id, "alpha")
+	}
+}
+
+func TestMerge_SecurityIdentical(t *testing.T) {
+	// Identical security arrays merge cleanly under first-wins.
+	a := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/a": { "get": { "operationId": "Op_a", "responses": { "200": { "description": "ok" } } } } },
+  "security": [{ "bearer": [] }, { "oauth2": ["read"] }]
+}`
+	b := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/b": { "get": { "operationId": "Op_b", "responses": { "200": { "description": "ok" } } } } },
+  "security": [{ "bearer": [] }, { "oauth2": ["read"] }]
+}`
+	out, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	sec := got["security"].([]any)
+	if len(sec) != 2 {
+		t.Errorf("expected 2 security requirements, got %d: %v", len(sec), sec)
+	}
+}
+
+func TestMerge_SecurityFirstOnly(t *testing.T) {
+	// First input's security is kept when later inputs don't declare any.
+	a := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/a": { "get": { "operationId": "Op_a", "responses": { "200": { "description": "ok" } } } } },
+  "security": [{ "bearer": [] }]
+}`
+	b := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/b": { "get": { "operationId": "Op_b", "responses": { "200": { "description": "ok" } } } } }
+}`
+	out, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	sec, ok := got["security"].([]any)
+	if !ok || len(sec) != 1 {
+		t.Errorf("expected first input's security to be preserved; got %v", got["security"])
+	}
+}
+
+func TestMerge_SecurityLaterOnly(t *testing.T) {
+	// Later inputs may introduce security when the first didn't declare any.
+	a := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/a": { "get": { "operationId": "Op_a", "responses": { "200": { "description": "ok" } } } } }
+}`
+	b := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/b": { "get": { "operationId": "Op_b", "responses": { "200": { "description": "ok" } } } } },
+  "security": [{ "bearer": [] }]
+}`
+	out, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	sec, ok := got["security"].([]any)
+	if !ok || len(sec) != 1 {
+		t.Errorf("expected later input's security to land in output; got %v", got["security"])
+	}
+}
+
+func TestMerge_SecurityConflict(t *testing.T) {
+	// Two inputs declaring non-empty, non-identical security arrays is an
+	// error: the root security list governs the whole API and silently
+	// keeping one would change what's allowed.
+	a := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/a": { "get": { "operationId": "Op_a", "responses": { "200": { "description": "ok" } } } } },
+  "security": [{ "bearer": [] }]
+}`
+	b := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/b": { "get": { "operationId": "Op_b", "responses": { "200": { "description": "ok" } } } } },
+  "security": [{ "bearer": [] }, { "oauth2": ["read"] }]
+}`
+	_, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err == nil {
+		t.Fatal("expected error on conflicting security definitions")
+	}
+	if !strings.Contains(err.Error(), "security") {
+		t.Errorf("error should mention security; got: %v", err)
+	}
+}
+
+func TestMerge_TopLevelFieldOrder(t *testing.T) {
+	// Output must be in OpenAPI 3.1 declaration order regardless of input
+	// order. Decode the top-level keys to compare against the expected order.
+	in := `{
+  "openapi": "3.1.0",
+  "info": { "title": "x", "version": "1" },
+  "tags": [{ "name": "T" }],
+  "paths": { "/x": { "get": { "operationId": "Op_x", "tags": ["T"], "responses": { "200": { "description": "ok" } } } } },
+  "components": { "schemas": { "Foo": { "type": "object" } } }
+}`
+	out, err := Merge([]Input{{Name: "x.json", Data: []byte(in)}})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	keys := topLevelKeys(t, out)
+	want := []string{"openapi", "info", "paths", "components", "tags"}
+	if !reflectDeepEqualStrings(keys, want) {
+		t.Errorf("top-level field order:\n got: %v\nwant: %v\nout:\n%s", keys, want, out)
+	}
+}
+
+// topLevelKeys decodes a JSON object and returns its top-level keys in
+// source order.
+func topLevelKeys(t *testing.T, data []byte) []string {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader(data))
+	tok, err := dec.Token()
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		t.Fatalf("expected JSON object, got %v", tok)
+	}
+	var keys []string
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			t.Fatalf("decode key: %v", err)
+		}
+		keys = append(keys, tok.(string))
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			t.Fatalf("decode value: %v", err)
+		}
+	}
+	return keys
+}
+
+func reflectDeepEqualStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestMerge_WebhooksUnioned(t *testing.T) {
+	// `webhooks` follow the same rules as `paths`: unioned in input order,
+	// conflicting keys are an error, identical keys merge.
+	a := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "webhooks": { "userCreated": { "post": { "operationId": "Hook_UserCreated", "responses": { "200": { "description": "ok" } } } } }
+}`
+	b := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "webhooks": { "orderShipped": { "post": { "operationId": "Hook_OrderShipped", "responses": { "200": { "description": "ok" } } } } }
+}`
+	out, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	hooks, ok := got["webhooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("webhooks missing from output: %v", got)
+	}
+	if _, ok := hooks["userCreated"]; !ok {
+		t.Errorf("webhooks missing userCreated")
+	}
+	if _, ok := hooks["orderShipped"]; !ok {
+		t.Errorf("webhooks missing orderShipped")
+	}
+}
+
+func TestMerge_WebhooksConflict(t *testing.T) {
+	a := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "webhooks": { "evt": { "post": { "operationId": "Hook_v1", "responses": { "200": { "description": "ok" } } } } }
+}`
+	b := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "webhooks": { "evt": { "post": { "operationId": "Hook_v2", "responses": { "200": { "description": "ok" } } } } }
+}`
+	_, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err == nil {
+		t.Fatal("expected error on conflicting webhook entries")
+	}
+	if !strings.Contains(err.Error(), "webhooks") || !strings.Contains(err.Error(), "evt") {
+		t.Errorf("error should mention webhooks.evt; got: %v", err)
+	}
+}
+
+func TestMerge_ExternalDocsFirstWins(t *testing.T) {
+	a := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "externalDocs": { "url": "https://example.com/a", "description": "from a" },
+  "paths": { "/a": { "get": { "operationId": "Op_a", "responses": { "200": { "description": "ok" } } } } }
+}`
+	b := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "externalDocs": { "url": "https://example.com/b", "description": "from b" },
+  "paths": { "/b": { "get": { "operationId": "Op_b", "responses": { "200": { "description": "ok" } } } } }
+}`
+	out, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	ext, ok := got["externalDocs"].(map[string]any)
+	if !ok {
+		t.Fatalf("externalDocs missing from output: %v", got)
+	}
+	if url := ext["url"]; url != "https://example.com/a" {
+		t.Errorf("externalDocs.url: got %q, want first input's value", url)
+	}
+}
+
+func TestMerge_ServersFirstWins(t *testing.T) {
+	a := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "servers": [{ "url": "https://api-a.example.com" }],
+  "paths": { "/a": { "get": { "operationId": "Op_a", "responses": { "200": { "description": "ok" } } } } }
+}`
+	b := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "servers": [{ "url": "https://api-b.example.com" }],
+  "paths": { "/b": { "get": { "operationId": "Op_b", "responses": { "200": { "description": "ok" } } } } }
+}`
+	out, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	servers, ok := got["servers"].([]any)
+	if !ok || len(servers) != 1 {
+		t.Fatalf("servers missing or wrong length: %v", got["servers"])
+	}
+	if url := servers[0].(map[string]any)["url"]; url != "https://api-a.example.com" {
+		t.Errorf("servers[0].url: got %q, want first input's value", url)
+	}
+}
+
+func TestMerge_MissingInfo(t *testing.T) {
+	// OpenAPI 3.1 requires `info`. Reject inputs lacking it.
+	in := `{
+  "openapi": "3.1.0",
+  "paths": { "/x": { "get": { "operationId": "Op_x", "responses": { "200": { "description": "ok" } } } } }
+}`
+	_, err := Merge([]Input{{Name: "noinfo.json", Data: []byte(in)}})
+	if err == nil {
+		t.Fatal("expected error when info is missing")
+	}
+	if !strings.Contains(err.Error(), "info") {
+		t.Errorf("error should mention info; got: %v", err)
+	}
+}
+
+func TestMerge_ComponentsSecuritySchemes(t *testing.T) {
+	// Components sub-maps other than `schemas` must merge with the same
+	// rules: union, sorted keys on output, conflicts rejected.
+	a := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/a": { "get": { "operationId": "Op_a", "responses": { "200": { "description": "ok" } } } } },
+  "components": {
+    "securitySchemes": {
+      "bearer": { "type": "http", "scheme": "bearer" }
+    }
+  }
+}`
+	b := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/b": { "get": { "operationId": "Op_b", "responses": { "200": { "description": "ok" } } } } },
+  "components": {
+    "securitySchemes": {
+      "apiKey": { "type": "apiKey", "in": "header", "name": "X-API-Key" }
+    }
+  }
+}`
+	out, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	schemes := got["components"].(map[string]any)["securitySchemes"].(map[string]any)
+	if _, ok := schemes["bearer"]; !ok {
+		t.Errorf("securitySchemes missing bearer: %v", schemes)
+	}
+	if _, ok := schemes["apiKey"]; !ok {
+		t.Errorf("securitySchemes missing apiKey: %v", schemes)
+	}
+	// Keys must come out sorted (apiKey before bearer).
+	apiIdx := bytes.Index(out, []byte(`"apiKey"`))
+	bearerIdx := bytes.Index(out, []byte(`"bearer"`))
+	if apiIdx < 0 || bearerIdx < 0 || apiIdx > bearerIdx {
+		t.Errorf("securitySchemes keys not sorted; apiKey at %d, bearer at %d", apiIdx, bearerIdx)
+	}
+}
+
+func TestMerge_ComponentsSecuritySchemesConflict(t *testing.T) {
+	a := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/a": { "get": { "operationId": "Op_a", "responses": { "200": { "description": "ok" } } } } },
+  "components": { "securitySchemes": { "bearer": { "type": "http", "scheme": "bearer" } } }
+}`
+	b := `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": { "/b": { "get": { "operationId": "Op_b", "responses": { "200": { "description": "ok" } } } } },
+  "components": { "securitySchemes": { "bearer": { "type": "http", "scheme": "basic" } } }
+}`
+	_, err := Merge([]Input{
+		{Name: "a.json", Data: []byte(a)},
+		{Name: "b.json", Data: []byte(b)},
+	})
+	if err == nil {
+		t.Fatal("expected error on conflicting securitySchemes")
+	}
+	if !strings.Contains(err.Error(), "securitySchemes") || !strings.Contains(err.Error(), "bearer") {
+		t.Errorf("error should mention securitySchemes.bearer; got: %v", err)
+	}
+}
+
+// TestMerge_Golden exercises the merger against a realistic fixture and
+// compares against a golden file. Run with -update to refresh the golden.
+func TestMerge_Golden(t *testing.T) {
+	inputs := []Input{}
+	for _, name := range []string{"library.openapi.json", "users.openapi.json"} {
+		data, err := os.ReadFile(filepath.Join("testdata", name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		inputs = append(inputs, Input{Name: name, Data: data})
+	}
+	got, err := Merge(inputs)
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	goldenPath := filepath.Join("testdata", "merged.openapi.json")
+	if *update {
+		if err := os.WriteFile(goldenPath, got, 0644); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+		return
+	}
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if !bytes.Equal(bytes.TrimRight(got, "\n"), bytes.TrimRight(want, "\n")) {
+		t.Errorf("golden mismatch; run with -update to refresh.\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}

--- a/openapiv3-merge/internal/merge/testdata/library.openapi.json
+++ b/openapiv3-merge/internal/merge/testdata/library.openapi.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Shared API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/v1/books": {
+      "get": {
+        "tags": [
+          "LibraryService"
+        ],
+        "operationId": "LibraryService_ListBooks",
+        "responses": {
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/google.rpc.Status"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "A successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/library.v1.ListBooksResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "google.rpc.Status": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "library.v1.Book": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      },
+      "library.v1.ListBooksResponse": {
+        "type": "object",
+        "properties": {
+          "books": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/library.v1.Book"
+            }
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "LibraryService",
+      "description": "Manages books."
+    }
+  ]
+}

--- a/openapiv3-merge/internal/merge/testdata/merged.openapi.json
+++ b/openapiv3-merge/internal/merge/testdata/merged.openapi.json
@@ -1,0 +1,139 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Shared API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/v1/books": {
+      "get": {
+        "tags": [
+          "LibraryService"
+        ],
+        "operationId": "LibraryService_ListBooks",
+        "responses": {
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/google.rpc.Status"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "A successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/library.v1.ListBooksResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/users": {
+      "get": {
+        "tags": [
+          "UserService"
+        ],
+        "operationId": "UserService_ListUsers",
+        "responses": {
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/google.rpc.Status"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "A successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/users.v1.ListUsersResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "google.rpc.Status": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "library.v1.Book": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      },
+      "library.v1.ListBooksResponse": {
+        "type": "object",
+        "properties": {
+          "books": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/library.v1.Book"
+            }
+          }
+        }
+      },
+      "users.v1.ListUsersResponse": {
+        "type": "object",
+        "properties": {
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/users.v1.User"
+            }
+          }
+        }
+      },
+      "users.v1.User": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "LibraryService",
+      "description": "Manages books."
+    },
+    {
+      "name": "UserService",
+      "description": "Manages users."
+    }
+  ]
+}

--- a/openapiv3-merge/internal/merge/testdata/users.openapi.json
+++ b/openapiv3-merge/internal/merge/testdata/users.openapi.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Shared API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/v1/users": {
+      "get": {
+        "tags": [
+          "UserService"
+        ],
+        "operationId": "UserService_ListUsers",
+        "responses": {
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/google.rpc.Status"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "A successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/users.v1.ListUsersResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "google.rpc.Status": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "users.v1.ListUsersResponse": {
+        "type": "object",
+        "properties": {
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/users.v1.User"
+            }
+          }
+        }
+      },
+      "users.v1.User": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "UserService",
+      "description": "Manages users."
+    }
+  ]
+}

--- a/openapiv3-merge/main.go
+++ b/openapiv3-merge/main.go
@@ -1,0 +1,61 @@
+// Command openapiv3-merge merges multiple OpenAPI 3.1 JSON documents into
+// a single document and writes the result to stdout.
+//
+// The OpenAPI 3.1 spec describes one API as a single document, but
+// protoc-gen-openapiv3 follows the protobuf convention of one output file
+// per input file. openapiv3-merge bridges the two: pipe `protoc-gen-openapiv3`
+// output through it to obtain a single combined spec.
+//
+// Usage:
+//
+//	openapiv3-merge FILE [FILE ...] > merged.openapi.json
+//
+// The merger is strict: path collisions, conflicting component definitions,
+// and conflicting tag metadata are errors. `info`, `servers`, `externalDocs`,
+// and unknown top-level fields are taken from the first input; later inputs'
+// values for those fields are ignored. See the package documentation in
+// internal/merge for the full ruleset.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/openapiv3-merge/internal/merge"
+)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, "openapiv3-merge:", err)
+		os.Exit(1)
+	}
+}
+
+// run is the testable entry point. It accepts the program's arguments (no
+// program name) and the writer to emit the merged document to.
+func run(args []string, out io.Writer) error {
+	if len(args) == 0 {
+		return errors.New("usage: openapiv3-merge FILE [FILE ...]")
+	}
+	inputs := make([]merge.Input, 0, len(args))
+	for _, path := range args {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		inputs = append(inputs, merge.Input{Name: path, Data: data})
+	}
+	merged, err := merge.Merge(inputs)
+	if err != nil {
+		return err
+	}
+	if _, err := out.Write(merged); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(out, "\n"); err != nil {
+		return err
+	}
+	return nil
+}

--- a/openapiv3-merge/main_test.go
+++ b/openapiv3-merge/main_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const docA = `{
+  "openapi": "3.1.0",
+  "info": { "title": "a", "version": "1.0.0" },
+  "paths": {
+    "/v1/a": {
+      "get": { "operationId": "Op_A", "responses": { "200": { "description": "ok" } } }
+    }
+  }
+}`
+
+const docB = `{
+  "openapi": "3.1.0",
+  "info": { "title": "b", "version": "1.0.0" },
+  "paths": {
+    "/v1/b": {
+      "get": { "operationId": "Op_B", "responses": { "200": { "description": "ok" } } }
+    }
+  }
+}`
+
+func writeTemp(t *testing.T, name, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+func TestRun_MergesTwoFiles(t *testing.T) {
+	a := writeTemp(t, "a.openapi.json", docA)
+	b := writeTemp(t, "b.openapi.json", docB)
+
+	var buf bytes.Buffer
+	if err := run([]string{a, b}, &buf); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, buf.String())
+	}
+	paths := got["paths"].(map[string]any)
+	if _, ok := paths["/v1/a"]; !ok {
+		t.Errorf("missing /v1/a in output")
+	}
+	if _, ok := paths["/v1/b"]; !ok {
+		t.Errorf("missing /v1/b in output")
+	}
+	if !bytes.HasSuffix(buf.Bytes(), []byte("\n")) {
+		t.Errorf("output should end with a newline")
+	}
+}
+
+func TestRun_NoArgs(t *testing.T) {
+	var buf bytes.Buffer
+	err := run(nil, &buf)
+	if err == nil {
+		t.Fatal("expected error with no arguments")
+	}
+	if !strings.Contains(err.Error(), "usage") {
+		t.Errorf("error should be a usage message; got: %v", err)
+	}
+}
+
+func TestRun_MissingFile(t *testing.T) {
+	var buf bytes.Buffer
+	err := run([]string{"/no/such/file.json"}, &buf)
+	if err == nil {
+		t.Fatal("expected error for missing input file")
+	}
+	if !strings.Contains(err.Error(), "/no/such/file.json") {
+		t.Errorf("error should mention the missing path; got: %v", err)
+	}
+}
+
+func TestRun_PropagatesMergeError(t *testing.T) {
+	// Two files with conflicting path definitions: the merge package's
+	// strictness should surface through run().
+	a := writeTemp(t, "a.openapi.json", `{
+  "openapi": "3.1.0",
+  "info": { "title": "x", "version": "1" },
+  "paths": { "/x": { "get": { "operationId": "Op_x1", "responses": { "200": { "description": "ok" } } } } }
+}`)
+	b := writeTemp(t, "b.openapi.json", `{
+  "openapi": "3.1.0",
+  "info": { "title": "x", "version": "1" },
+  "paths": { "/x": { "get": { "operationId": "Op_x2", "responses": { "200": { "description": "ok" } } } } }
+}`)
+	var buf bytes.Buffer
+	if err := run([]string{a, b}, &buf); err == nil {
+		t.Fatal("expected error from conflicting path definitions")
+	}
+}


### PR DESCRIPTION
Add a new CLI tool for merging OpenAPIv3 documents produced by protoc-gen-openapiv3. It takes any number of input openapiv3 JSON documents and outputs the merged file to standard out. The merged data comes from the first file specified, and will error if there is conflicting data.

Fixes #6639
