### PR TITLE
fix(openapiv2): ensure enum comments go to description not title

### DIFF
--- a/examples/internal/proto/examplepb/response_body_service.swagger.json
+++ b/examples/internal/proto/examplepb/response_body_service.swagger.json
@@ -192,7 +192,7 @@
         "B"
       ],
       "default": "UNKNOWN",
-      "title": "- UNKNOWN: UNKNOWN\n - A: A is 1\n - B: B is 2"
+      "description": "- UNKNOWN: UNKNOWN\n - A: A is 1\n - B: B is 2"
     },
     "examplepbRepeatedResponseBodyOut": {
       "type": "object",

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"net/textproto"
 	"os"
 	"reflect"
 	"regexp"
-	"maps"
 	"slices"
 	"sort"
 	"strconv"
@@ -1133,6 +1133,15 @@ func renderEnumerationsAsDefinition(enums enumMap, d openapiDefinitionsObject, r
 		}
 		if err := updateOpenAPIDataFromComments(reg, &enumSchemaObject, enum, enumComments, false); err != nil {
 			panic(err)
+		}
+
+		// Enum comments should go to Description, not Title.
+		// updateOpenAPIDataFromComments may set Title as a fallback
+		// when Summary field is not available on schema objects.
+		// https://github.com/grpc-ecosystem/grpc-gateway/issues/2670
+		if enumComments != "" && enumSchemaObject.Description == "" && enumSchemaObject.Title != "" {
+			enumSchemaObject.Description = enumSchemaObject.Title
+			enumSchemaObject.Title = ""
 		}
 
 		if _, exists := d[swgName]; exists {


### PR DESCRIPTION
## Summary
Fixes #2670 - Enum value comments in proto files were incorrectly rendered as `title` instead of `description` in generated OpenAPI output.

When `updateOpenAPIDataFromComments` processes comments on schema objects that lack a `Summary` field, it falls back to using `Title` as the summary target. For enum definitions, this caused comment text like `"a field comment"` to appear in the title field instead of description.

## Changes
- `protoc-gen-openapiv2/internal/genopenapi/template.go`: After processing enum comments, if Description is empty but comments were applied to Title, move them to Description where they belong.

## Test plan
- [x] `go build ./protoc-gen-openapiv2/...` succeeds