### PR TITLE
feat(runtime): add per-route message validation for local handler mode

### DIFF
--- a/protoc-gen-grpc-gateway/internal/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/internal/gengateway/template.go
@@ -799,7 +799,7 @@ func Register{{ $svc.GetName }}{{ $.RegisterFuncSuffix }}Server(ctx context.Cont
 		return
 	})
 	{{- else -}}
-	mux.Handle({{ $b.HTTPMethod | toHTTPMethod}}, pattern_{{ $svc.GetName }}_{{ $m.GetName }}_{{ $b.Index }}, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.HandleWithMessage({{ $b.HTTPMethod | toHTTPMethod}}, pattern_{{ $svc.GetName }}_{{ $m.GetName }}_{{ $b.Index }}, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 	{{- if $UseRequestContext }}
 		ctx, cancel := context.WithCancel(req.Context())
 	{{- else -}}
@@ -830,7 +830,7 @@ func Register{{ $svc.GetName }}{{ $.RegisterFuncSuffix }}Server(ctx context.Cont
 		{{- else }}
 		forward_{{ $svc.GetName }}_{{ $m.GetName }}_{{ $b.Index }}(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 		{{- end }}
-	})
+	}, func() proto.Message { return &{{ $m.RequestType.GoType $m.Service.File.GoPkg.Path }}{} })
 	{{- end }}
 	{{ end }}
 	{{- end }}

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -1,9 +1,11 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/textproto"
 	"regexp"
@@ -75,6 +77,10 @@ type ServeMux struct {
 	unescapingMode            UnescapingMode
 	writeContentLength        bool
 	disableChunkedEncoding    bool
+
+	// messageFactories maps "METHOD /pattern" to a MessageFactory for validation.
+	// Populated by HandleWithMessage, consumed by ValidatorFunc middleware.
+	messageFactories map[string]MessageFactory
 }
 
 // ServeMuxOption is an option that can be given to a ServeMux on construction.
@@ -360,6 +366,7 @@ func NewServeMux(opts ...ServeMuxOption) *ServeMux {
 		streamErrorHandler:      DefaultStreamErrorHandler,
 		routingErrorHandler:     DefaultRoutingErrorHandler,
 		unescapingMode:          UnescapingModeDefault,
+		messageFactories:        make(map[string]MessageFactory),
 	}
 
 	for _, opt := range opts {
@@ -576,5 +583,105 @@ func chainMiddlewares(mws []Middleware) Middleware {
 			next = mws[i-1](next)
 		}
 		return next
+	}
+}
+
+// MessageFactory creates a new proto.Message instance for a given route.
+// It is used by the validation middleware to construct a message, deserialize
+// the request body into it, and validate it before the handler is invoked.
+type MessageFactory func() proto.Message
+
+// HandleWithMessage registers a handler and associates it with a MessageFactory.
+// The MessageFactory is stored in the mux's internal registry so that middleware
+// (e.g. a validation middleware) can look up the request message type for a route
+// and validate it automatically, without manual registration.
+//
+// This is the key building block for automatic per-route validation in local
+// handler mode (RegisterXxxHandlerServer), where gRPC interceptors are bypassed.
+func (s *ServeMux) HandleWithMessage(meth string, pat Pattern, h HandlerFunc, factory MessageFactory) {
+	s.Handle(meth, pat, h)
+	if factory != nil {
+		s.messageFactories[meth+" "+pat.String()] = factory
+	}
+}
+
+// LookupMessageFactory returns the MessageFactory registered for the given
+// method and pattern key. Returns nil if no factory is registered.
+// This is used by validation middleware to find the message type for a route.
+func (s *ServeMux) LookupMessageFactory(key string) (MessageFactory, bool) {
+	f, ok := s.messageFactories[key]
+	return f, ok
+}
+
+// ValidatorFunc validates a proto.Message and returns an error if it is invalid.
+// Users can inject any validation implementation (e.g. go-argus, protovalidate, etc.)
+// via WithValidator.
+type ValidatorFunc func(msg proto.Message) error
+
+// WithValidator returns a ServeMuxOption that adds a validation middleware.
+// The middleware automatically looks up the MessageFactory for each route,
+// deserializes the request body, validates it using fn, and returns an error
+// if validation fails.
+//
+// Usage:
+//
+//	mux := runtime.NewServeMux(
+//	    runtime.WithValidator(myValidateFunc),
+//	)
+func WithValidator(fn ValidatorFunc) ServeMuxOption {
+	return func(sm *ServeMux) {
+		sm.middlewares = append(sm.middlewares, newValidationMiddleware(sm, fn))
+	}
+}
+
+// newValidationMiddleware creates a Middleware that validates request bodies
+// using the provided ValidatorFunc and the ServeMux's message factory registry.
+func newValidationMiddleware(mux *ServeMux, fn ValidatorFunc) Middleware {
+	return func(next HandlerFunc) HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+			pat, ok := HTTPPattern(r.Context())
+			if !ok {
+				next(w, r, pathParams)
+				return
+			}
+			key := r.Method + " " + pat.String()
+			factory, ok := mux.LookupMessageFactory(key)
+			if !ok {
+				next(w, r, pathParams)
+				return
+			}
+
+			// Read request body
+			bodyBytes, err := io.ReadAll(r.Body)
+			if err != nil {
+				HTTPError(r.Context(), mux, defaultMarshaler, w, r,
+					status.Error(codes.InvalidArgument, "failed to read request body"))
+				return
+			}
+			// Replay body for downstream handler
+			r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+			if len(bodyBytes) == 0 {
+				next(w, r, pathParams)
+				return
+			}
+
+			// Deserialize into message
+			msg := factory()
+			inbound, _ := MarshalerForRequest(mux, r)
+			if err := inbound.NewDecoder(bytes.NewReader(bodyBytes)).Decode(msg); err != nil {
+				next(w, r, pathParams)
+				return
+			}
+
+			// Validate
+			if err := fn(msg); err != nil {
+				HTTPError(r.Context(), mux, inbound, w, r,
+					status.Error(codes.InvalidArgument, err.Error()))
+				return
+			}
+
+			next(w, r, pathParams)
+		}
 	}
 }

--- a/runtime/validator_test.go
+++ b/runtime/validator_test.go
@@ -1,0 +1,212 @@
+package runtime_test
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	pb "github.com/grpc-ecosystem/grpc-gateway/v2/runtime/internal/examplepb"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
+	"google.golang.org/protobuf/proto"
+)
+
+// testValidator rejects messages with empty Id.
+func testValidator(msg proto.Message) error {
+	if m, ok := msg.(*pb.SimpleMessage); ok && m.Id == "" {
+		return errors.New("id is required")
+	}
+	return nil
+}
+
+func TestHandleWithMessage_StoresFactory(t *testing.T) {
+	mux := runtime.NewServeMux()
+	pat, err := runtime.NewPattern(1, []int{int(utilities.OpLitPush), 0}, []string{"test"}, "")
+	if err != nil {
+		t.Fatalf("NewPattern failed: %v", err)
+	}
+
+	factory := func() proto.Message { return &pb.SimpleMessage{} }
+	mux.HandleWithMessage("POST", pat, func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+		w.WriteHeader(http.StatusOK)
+	}, factory)
+
+	key := "POST /test"
+	f, ok := mux.LookupMessageFactory(key)
+	if !ok {
+		t.Fatalf("LookupMessageFactory(%q) not found", key)
+	}
+	msg := f()
+	if _, ok := msg.(*pb.SimpleMessage); !ok {
+		t.Fatalf("expected *SimpleMessage, got %T", msg)
+	}
+}
+
+func TestHandleWithMessage_NilFactory(t *testing.T) {
+	mux := runtime.NewServeMux()
+	pat, err := runtime.NewPattern(1, []int{int(utilities.OpLitPush), 0}, []string{"test"}, "")
+	if err != nil {
+		t.Fatalf("NewPattern failed: %v", err)
+	}
+
+	mux.HandleWithMessage("GET", pat, func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+		w.WriteHeader(http.StatusOK)
+	}, nil)
+
+	key := "GET /test"
+	_, ok := mux.LookupMessageFactory(key)
+	if ok {
+		t.Fatalf("LookupMessageFactory(%q) should not be found for nil factory", key)
+	}
+}
+
+func TestWithValidator_ValidRequest(t *testing.T) {
+	mux := runtime.NewServeMux(
+		runtime.WithValidator(testValidator),
+	)
+	pat, err := runtime.NewPattern(1, []int{int(utilities.OpLitPush), 0}, []string{"test"}, "")
+	if err != nil {
+		t.Fatalf("NewPattern failed: %v", err)
+	}
+
+	handlerCalled := false
+	mux.HandleWithMessage("POST", pat, func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	}, func() proto.Message { return &pb.SimpleMessage{} })
+
+	body := bytes.NewReader([]byte(`{"id":"123"}`))
+	r := httptest.NewRequest("POST", "/test", body)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("w.Code = %d; want %d", w.Code, http.StatusOK)
+	}
+	if !handlerCalled {
+		t.Error("handler was not called")
+	}
+}
+
+func TestWithValidator_InvalidRequest(t *testing.T) {
+	mux := runtime.NewServeMux(
+		runtime.WithValidator(testValidator),
+	)
+	pat, err := runtime.NewPattern(1, []int{int(utilities.OpLitPush), 0}, []string{"test"}, "")
+	if err != nil {
+		t.Fatalf("NewPattern failed: %v", err)
+	}
+
+	handlerCalled := false
+	mux.HandleWithMessage("POST", pat, func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	}, func() proto.Message { return &pb.SimpleMessage{} })
+
+	body := bytes.NewReader([]byte(`{"id":""}`))
+	r := httptest.NewRequest("POST", "/test", body)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("w.Code = %d; want %d", w.Code, http.StatusBadRequest)
+	}
+	if handlerCalled {
+		t.Error("handler should not be called for invalid request")
+	}
+}
+
+func TestWithValidator_EmptyBody(t *testing.T) {
+	mux := runtime.NewServeMux(
+		runtime.WithValidator(testValidator),
+	)
+	pat, err := runtime.NewPattern(1, []int{int(utilities.OpLitPush), 0}, []string{"test"}, "")
+	if err != nil {
+		t.Fatalf("NewPattern failed: %v", err)
+	}
+
+	handlerCalled := false
+	mux.HandleWithMessage("POST", pat, func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	}, func() proto.Message { return &pb.SimpleMessage{} })
+
+	r := httptest.NewRequest("POST", "/test", nil)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, r)
+
+	// Empty body should skip validation and call handler
+	if w.Code != http.StatusOK {
+		t.Errorf("w.Code = %d; want %d", w.Code, http.StatusOK)
+	}
+	if !handlerCalled {
+		t.Error("handler should be called for empty body")
+	}
+}
+
+func TestWithValidator_NoFactoryRegistered(t *testing.T) {
+	mux := runtime.NewServeMux(
+		runtime.WithValidator(testValidator),
+	)
+	pat, err := runtime.NewPattern(1, []int{int(utilities.OpLitPush), 0}, []string{"test"}, "")
+	if err != nil {
+		t.Fatalf("NewPattern failed: %v", err)
+	}
+
+	// Use regular Handle (not HandleWithMessage) — no factory registered
+	handlerCalled := false
+	mux.Handle("GET", pat, func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	r := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, r)
+
+	// No factory → validation skipped → handler called
+	if w.Code != http.StatusOK {
+		t.Errorf("w.Code = %d; want %d", w.Code, http.StatusOK)
+	}
+	if !handlerCalled {
+		t.Error("handler should be called when no factory is registered")
+	}
+}
+
+func TestWithValidator_BodyReplayed(t *testing.T) {
+	mux := runtime.NewServeMux(
+		runtime.WithValidator(testValidator),
+	)
+	pat, err := runtime.NewPattern(1, []int{int(utilities.OpLitPush), 0}, []string{"test"}, "")
+	if err != nil {
+		t.Fatalf("NewPattern failed: %v", err)
+	}
+
+	var receivedBody string
+	mux.HandleWithMessage("POST", pat, func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r.Body)
+		receivedBody = buf.String()
+		w.WriteHeader(http.StatusOK)
+	}, func() proto.Message { return &pb.SimpleMessage{} })
+
+	bodyStr := `{"id":"123"}`
+	r := httptest.NewRequest("POST", "/test", bytes.NewReader([]byte(bodyStr)))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, r)
+
+	if receivedBody != bodyStr {
+		t.Errorf("handler received body = %q; want %q", receivedBody, bodyStr)
+	}
+}


### PR DESCRIPTION
RegisterXxxHandlerServer bypasses the gRPC interceptor chain because it calls the service implementation directly without creating a real gRPC connection. This means unary/stream interceptors (including validation) are never invoked for HTTP requests in local mode.

This adds a generic validation interface that works at the HTTP middleware layer instead:

- MessageFactory type for per-route message type registration
- HandleWithMessage() to register handlers with message factories
- ValidatorFunc type for injectable validation (go-argus, protovalidate, etc.)
- WithValidator() ServeMuxOption to enable automatic validation middleware
- protoc-gen-grpc-gateway now generates HandleWithMessage for unary methods

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

#### Other comments
