### PR TITLE
chore: improve grpc-gateway maintenance path

### DIFF
--- a/runtime/mux_test.go
+++ b/runtime/mux_test.go
@@ -846,6 +846,33 @@ func TestWithHealthzEndpoint_serviceParam(t *testing.T) {
 
 	mux.ServeHTTP(rr, r)
 
+	if got, want := rr.Code, http.StatusInternalServerError; got != want {
+		t.Errorf("rr.Code = %d; want %d", got, want)
+	}
+	if !strings.Contains(rr.Body.String(), service) {
+		t.Errorf(
+			"service query parameter should be translated to HealthCheckRequest: expected %s to contain %s",
+			rr.Body.String(), service,
+		)
+	}
+}
+
+func TestWithHealthEndpointAt_serviceParam(t *testing.T) {
+	const endpointPath = "/readyz"
+	service := "test"
+
+	// trigger error to output service in body
+	dummyClient := dummyHealthCheckClient{status: grpc_health_v1.HealthCheckResponse_UNKNOWN, code: codes.Unknown}
+	mux := runtime.NewServeMux(runtime.WithHealthEndpointAt(&dummyClient, endpointPath))
+
+	r := httptest.NewRequest(http.MethodGet, endpointPath+"?service="+service, nil)
+	rr := httptest.NewRecorder()
+
+	mux.ServeHTTP(rr, r)
+
+	if got, want := rr.Code, http.StatusInternalServerError; got != want {
+		t.Errorf("rr.Code = %d; want %d", got, want)
+	}
 	if !strings.Contains(rr.Body.String(), service) {
 		t.Errorf(
 			"service query parameter should be translated to HealthCheckRequest: expected %s to contain %s",


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in runtime/mux_test.go, runtime/query_test.go related to CI, Docker, Kubernetes, build tooling, release automation; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.