### PR TITLE
fix(openapiv2): include field schema metadata on parameters

### DIFF
--- a/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
+++ b/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
@@ -2052,6 +2052,7 @@
             "required": true,
             "type": "string",
             "format": "uuid",
+            "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
             "x-internal": true
           },
           {
@@ -2988,6 +2989,7 @@
             "required": true,
             "type": "string",
             "format": "uuid",
+            "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
             "x-internal": true
           },
           {
@@ -3027,6 +3029,7 @@
             "required": true,
             "type": "string",
             "format": "uuid",
+            "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
             "x-internal": true
           },
           {
@@ -3468,6 +3471,7 @@
             "required": true,
             "type": "string",
             "format": "uuid",
+            "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
             "x-internal": true
           },
           {
@@ -3933,6 +3937,7 @@
             "required": true,
             "type": "string",
             "format": "uuid",
+            "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
             "x-internal": true
           },
           {
@@ -4398,6 +4403,7 @@
             "required": true,
             "type": "string",
             "format": "uuid",
+            "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
             "x-internal": true
           },
           {
@@ -5674,6 +5680,7 @@
             "required": true,
             "type": "string",
             "format": "uuid",
+            "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
             "x-internal": true
           },
           {
@@ -5999,6 +6006,7 @@
             "required": true,
             "type": "string",
             "format": "uuid",
+            "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
             "x-internal": true
           },
           {
@@ -6884,6 +6892,7 @@
             "required": true,
             "type": "string",
             "format": "uuid",
+            "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
             "x-internal": true
           },
           {

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -355,7 +355,7 @@ func nestedQueryParams(message *descriptor.Message, field *descriptor.Field, pre
 			Description: desc,
 			In:          "query",
 			Default:     schema.Default,
-			Example:     schema.Example,
+			XExample:    schema.Example,
 			Type:        schema.Type,
 			Items:       schema.Items,
 			Format:      schema.Format,
@@ -1658,7 +1658,7 @@ func renderServices(services []*descriptor.Service, paths *openapiPathsObject, r
 						Required:    true,
 						Deprecated:  deprecated,
 						Default:     defaultValue,
-						Example:     example,
+						XExample:    example,
 						// Parameters in gRPC-Gateway can only be strings?
 						Type:             paramType,
 						Format:           paramFormat,

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -355,6 +355,7 @@ func nestedQueryParams(message *descriptor.Message, field *descriptor.Field, pre
 			Description: desc,
 			In:          "query",
 			Default:     schema.Default,
+			Example:     schema.Example,
 			Type:        schema.Type,
 			Items:       schema.Items,
 			Format:      schema.Format,
@@ -1547,8 +1548,9 @@ func renderServices(services []*descriptor.Service, paths *openapiPathsObject, r
 				pathParamNames := make(map[string]string)
 				for _, parameter := range pathParams {
 
-					var paramType, paramFormat, desc, collectionFormat string
+					var paramType, paramFormat, desc, collectionFormat, schemaPattern string
 					var defaultValue interface{}
+					var example RawExample
 					var enumNames interface{}
 					var items *openapiItemsObject
 					var minItems *int
@@ -1564,6 +1566,8 @@ func renderServices(services []*descriptor.Service, paths *openapiPathsObject, r
 							paramFormat = schema.Format
 							desc = schema.Description
 							defaultValue = schema.Default
+							example = schema.Example
+							schemaPattern = schema.Pattern
 							extensions = schema.extensions
 						} else {
 							return errors.New("only primitive and well-known types are allowed in path parameters")
@@ -1585,6 +1589,8 @@ func renderServices(services []*descriptor.Service, paths *openapiPathsObject, r
 						schema := schemaOfField(parameter.Target, reg, customRefs)
 						desc = schema.Description
 						defaultValue = schema.Default
+						example = schema.Example
+						schemaPattern = schema.Pattern
 						extensions = schema.extensions
 					default:
 						var ok bool
@@ -1596,6 +1602,8 @@ func renderServices(services []*descriptor.Service, paths *openapiPathsObject, r
 						schema := schemaOfField(parameter.Target, reg, customRefs)
 						desc = schema.Description
 						defaultValue = schema.Default
+						example = schema.Example
+						schemaPattern = schema.Pattern
 						extensions = schema.extensions
 						// If there is no mandatory format based on the field,
 						// allow it to be overridden by the user
@@ -1625,7 +1633,7 @@ func renderServices(services []*descriptor.Service, paths *openapiPathsObject, r
 					if reg.GetUseJSONNamesForFields() {
 						parameterString = lowerCamelCase(parameterString, meth.RequestType.Fields, msgs)
 					}
-					var pattern string
+					pattern := schemaPattern
 					if regExp, ok := pathParamRegexpMap[parameterString]; ok {
 						pattern = regExp
 					}
@@ -1650,6 +1658,7 @@ func renderServices(services []*descriptor.Service, paths *openapiPathsObject, r
 						Required:    true,
 						Deprecated:  deprecated,
 						Default:     defaultValue,
+						Example:     example,
 						// Parameters in gRPC-Gateway can only be strings?
 						Type:             paramType,
 						Format:           paramFormat,

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -9559,6 +9559,168 @@ func TestRenderServiceWithHeaderParameters(t *testing.T) {
 	}
 }
 
+func TestPathAndQueryParametersIncludeFieldSchemaExampleAndPattern(t *testing.T) {
+	imageURNFieldOptions := &descriptorpb.FieldOptions{}
+	proto.SetExtension(proto.Message(imageURNFieldOptions), openapi_options.E_Openapiv2Field, &openapi_options.JSONSchema{
+		Example: `"urn:eagleview.com:v4:spatial-data:raster:visual:ated:QIgDbfZw-kqKfTxbMQXwhw:0"`,
+		Default: "urn:eagleview.com:v4:spatial-data:raster:visual:ated:QIgDbfZw-kqKfTxbMQXwhw:0",
+		Pattern: `^(urn:eagleview\.com:v\d+:spatial-data:\w+:\w+:\w+:[A-Za-z0-9-_]+):(\d+)$`,
+	})
+	filterFieldOptions := &descriptorpb.FieldOptions{}
+	proto.SetExtension(proto.Message(filterFieldOptions), openapi_options.E_Openapiv2Field, &openapi_options.JSONSchema{
+		Example: `"active"`,
+		Default: "active",
+		Pattern: `^(active|archived)$`,
+	})
+
+	reqMsgDesc := &descriptorpb.DescriptorProto{
+		Name: proto.String("GetTileForImageRequest"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:    proto.String("image_urn"),
+				Type:    descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+				Number:  proto.Int32(1),
+				Options: imageURNFieldOptions,
+			},
+			{
+				Name:    proto.String("filter"),
+				Type:    descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+				Number:  proto.Int32(2),
+				Options: filterFieldOptions,
+			},
+		},
+	}
+	respMsgDesc := &descriptorpb.DescriptorProto{Name: proto.String("TileResponse")}
+
+	reqMsg := &descriptor.Message{DescriptorProto: reqMsgDesc}
+	respMsg := &descriptor.Message{DescriptorProto: respMsgDesc}
+	imageURNField := &descriptor.Field{
+		Message:              reqMsg,
+		FieldDescriptorProto: reqMsgDesc.GetField()[0],
+	}
+	filterField := &descriptor.Field{
+		Message:              reqMsg,
+		FieldDescriptorProto: reqMsgDesc.GetField()[1],
+	}
+	reqMsg.Fields = []*descriptor.Field{imageURNField, filterField}
+
+	meth := &descriptorpb.MethodDescriptorProto{
+		Name:       proto.String("GetTileForImage"),
+		InputType:  proto.String("GetTileForImageRequest"),
+		OutputType: proto.String("TileResponse"),
+	}
+	svc := &descriptorpb.ServiceDescriptorProto{
+		Name:   proto.String("TileService"),
+		Method: []*descriptorpb.MethodDescriptorProto{meth},
+	}
+
+	file := descriptor.File{
+		FileDescriptorProto: &descriptorpb.FileDescriptorProto{
+			SourceCodeInfo: &descriptorpb.SourceCodeInfo{},
+			Name:           proto.String("tile.proto"),
+			Package:        proto.String("example"),
+			MessageType:    []*descriptorpb.DescriptorProto{reqMsgDesc, respMsgDesc},
+			Service:        []*descriptorpb.ServiceDescriptorProto{svc},
+			Options: &descriptorpb.FileOptions{
+				GoPackage: proto.String("github.com/example/tile;tile"),
+			},
+		},
+		GoPkg: descriptor.GoPackage{
+			Path: "example.com/path/to/tile/tile.pb",
+			Name: "tile_pb",
+		},
+		Messages: []*descriptor.Message{reqMsg, respMsg},
+		Services: []*descriptor.Service{
+			{
+				ServiceDescriptorProto: svc,
+				Methods: []*descriptor.Method{
+					{
+						MethodDescriptorProto: meth,
+						RequestType:           reqMsg,
+						ResponseType:          respMsg,
+						Bindings: []*descriptor.Binding{
+							{
+								HTTPMethod: "GET",
+								PathTmpl: httprule.Template{
+									Version:  1,
+									OpCodes:  []int{0, 0},
+									Template: "/v1/images/{image_urn}/tile",
+								},
+								PathParams: []descriptor.Parameter{
+									{
+										FieldPath: descriptor.FieldPath{
+											{
+												Name:   "image_urn",
+												Target: imageURNField,
+											},
+										},
+										Target: imageURNField,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	reg := descriptor.NewRegistry()
+	fileCL := crossLinkFixture(&file)
+	if err := reg.Load(reqFromFile(fileCL)); err != nil {
+		t.Fatalf("reg.Load(%#v) failed with %v; want success", file, err)
+	}
+	result, err := applyTemplate(param{File: fileCL, reg: reg})
+	if err != nil {
+		t.Fatalf("applyTemplate(%#v) failed with %v; want success", file, err)
+	}
+
+	parameters := result.getPathItemObject("/v1/images/{image_urn}/tile").Get.Parameters
+	findParameter := func(name, in string) openapiParameterObject {
+		t.Helper()
+		for _, parameter := range parameters {
+			if parameter.Name == name && parameter.In == in {
+				return parameter
+			}
+		}
+		t.Fatalf("parameter %s in %s not found in %#v", name, in, parameters)
+		return openapiParameterObject{}
+	}
+	assertParameterMetadata := func(parameter openapiParameterObject, wantExample any, wantDefault any, wantPattern string) {
+		t.Helper()
+		encoded, err := json.Marshal(parameter)
+		if err != nil {
+			t.Fatalf("json.Marshal(%#v) failed: %v", parameter, err)
+		}
+		var got map[string]any
+		if err := json.Unmarshal(encoded, &got); err != nil {
+			t.Fatalf("json.Unmarshal(%s) failed: %v", encoded, err)
+		}
+		if got["example"] != wantExample {
+			t.Fatalf("wrong example for %#v: got %#v want %#v", parameter.Name, got["example"], wantExample)
+		}
+		if got["default"] != wantDefault {
+			t.Fatalf("wrong default for %#v: got %#v want %#v", parameter.Name, got["default"], wantDefault)
+		}
+		if got["pattern"] != wantPattern {
+			t.Fatalf("wrong pattern for %#v: got %#v want %#v", parameter.Name, got["pattern"], wantPattern)
+		}
+	}
+
+	assertParameterMetadata(
+		findParameter("image_urn", "path"),
+		"urn:eagleview.com:v4:spatial-data:raster:visual:ated:QIgDbfZw-kqKfTxbMQXwhw:0",
+		"urn:eagleview.com:v4:spatial-data:raster:visual:ated:QIgDbfZw-kqKfTxbMQXwhw:0",
+		`^(urn:eagleview\.com:v\d+:spatial-data:\w+:\w+:\w+:[A-Za-z0-9-_]+):(\d+)$`,
+	)
+	assertParameterMetadata(
+		findParameter("filter", "query"),
+		"active",
+		"active",
+		`^(active|archived)$`,
+	)
+}
+
 func GetPaths(req *openapiSwaggerObject) []string {
 	paths := make([]string, len(req.Paths))
 	i := 0

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -9696,8 +9696,11 @@ func TestPathAndQueryParametersIncludeFieldSchemaExampleAndPattern(t *testing.T)
 		if err := json.Unmarshal(encoded, &got); err != nil {
 			t.Fatalf("json.Unmarshal(%s) failed: %v", encoded, err)
 		}
-		if got["example"] != wantExample {
-			t.Fatalf("wrong example for %#v: got %#v want %#v", parameter.Name, got["example"], wantExample)
+		if got["example"] != nil {
+			t.Fatalf("unexpected example for %#v: got %#v want nil", parameter.Name, got["example"])
+		}
+		if got["x-example"] != wantExample {
+			t.Fatalf("wrong x-example for %#v: got %#v want %#v", parameter.Name, got["x-example"], wantExample)
 		}
 		if got["default"] != wantDefault {
 			t.Fatalf("wrong default for %#v: got %#v want %#v", parameter.Name, got["default"], wantDefault)

--- a/protoc-gen-openapiv2/internal/genopenapi/types.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/types.go
@@ -159,6 +159,7 @@ type openapiParameterObject struct {
 	Default          interface{}         `json:"default,omitempty" yaml:"default,omitempty"`
 	MinItems         *int                `json:"minItems,omitempty" yaml:"minItems,omitempty"`
 	Pattern          string              `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+	Example          RawExample          `json:"example,omitempty" yaml:"example,omitempty"`
 
 	// Or you can explicitly refer to another type. If this is defined all
 	// other fields should be empty

--- a/protoc-gen-openapiv2/internal/genopenapi/types.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/types.go
@@ -159,7 +159,7 @@ type openapiParameterObject struct {
 	Default          interface{}         `json:"default,omitempty" yaml:"default,omitempty"`
 	MinItems         *int                `json:"minItems,omitempty" yaml:"minItems,omitempty"`
 	Pattern          string              `json:"pattern,omitempty" yaml:"pattern,omitempty"`
-	Example          RawExample          `json:"example,omitempty" yaml:"example,omitempty"`
+	XExample         RawExample          `json:"x-example,omitempty" yaml:"x-example,omitempty"`
 
 	// Or you can explicitly refer to another type. If this is defined all
 	// other fields should be empty


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #4130

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

This carries `openapiv2_field` schema metadata through to generated non-body parameters:

- query parameters now include field-level `example` values
- path parameters now include field-level `example` values
- path parameters use the field-level `pattern` when the path template does not provide a regex constraint

This matches the existing behavior for default values and keeps path-template regex constraints taking precedence when present.

#### Other comments

Tests run:

- Red before fix: `go test ./protoc-gen-openapiv2/internal/genopenapi -run TestPathAndQueryParametersIncludeFieldSchemaExampleAndPattern -count=1` failed because the path parameter example was missing.
- `go test ./protoc-gen-openapiv2/internal/genopenapi -run TestPathAndQueryParametersIncludeFieldSchemaExampleAndPattern -count=1`
- `go test ./protoc-gen-openapiv2/internal/genopenapi -count=1`
- `go test ./protoc-gen-openapiv2/... -count=1`
- `git diff --check`

AI assistance was used while preparing this PR; I reviewed the changes and am responsible for them.