### PR TITLE
openapiv3: ignore M import-path mappings in plugin params

### DIFF
--- a/protoc-gen-openapiv3/main.go
+++ b/protoc-gen-openapiv3/main.go
@@ -106,6 +106,13 @@ func parseReqParam(param string, f *flag.FlagSet) error {
 			continue
 		}
 		flagName, val, ok := strings.Cut(p, "=")
+		if ok && strings.HasPrefix(flagName, "M") {
+			// Source-relative import-path mappings (M<file>=<importpath>) are
+			// passed to every plugin by protoc-based pipelines but are not
+			// flags of this plugin; protogen consumes them when loading the
+			// request, so we ignore them here rather than erroring out.
+			continue
+		}
 		if !ok {
 			if err := f.Set(flagName, "true"); err != nil {
 				return fmt.Errorf("cannot set flag %s: %w", flagName, err)

--- a/protoc-gen-openapiv3/main_test.go
+++ b/protoc-gen-openapiv3/main_test.go
@@ -63,3 +63,37 @@ func TestParseReqParam_DisableDefaultErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestParseReqParam_IgnoresImportPathMappings(t *testing.T) {
+	t.Parallel()
+
+	// protoc-based pipelines pass M<file>=<importpath> mappings to every
+	// plugin. They are not flags of this plugin (protogen consumes them when
+	// loading the request), so parsing them must not error out.
+	tests := []struct {
+		name  string
+		param string
+	}{
+		{
+			name:  "single mapping",
+			param: "Mshared.proto=example.com/service_a/gen/go/api",
+		},
+		{
+			name:  "multiple mappings with a real flag",
+			param: "Mservice_a_1.proto=example.com/x,Mservice_a_2.proto=example.com/x,disable_default_errors=true",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := flag.NewFlagSet("test", flag.ContinueOnError)
+			f.Bool("disable_default_errors", false, "")
+
+			if err := parseReqParam(tc.param, f); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
protoc-based pipelines pass M<file>=<importpath> mappings to every plugin, but protoc-gen-openapiv3 treated them as unknown flags and aborted with "Plugin failed with status code 1". Skip them in parseReqParam, matching protoc-gen-openapiv2; protogen already consumes them when loading the request.

Fixes #6928