### PR TITLE
feat(protoc-gen-openapiv2): move to protoc toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,5 @@
+common --@com_google_protobuf//bazel/flags:prefer_prebuilt_protoc
+common --incompatible_enable_proto_toolchain_resolution
+
 build --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 build --test_output=errors

--- a/protoc-gen-openapiv2/defs.bzl
+++ b/protoc-gen-openapiv2/defs.bzl
@@ -6,6 +6,9 @@ Optionally applies settings from the grpc-service configuration.
 
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 
+
+_PROTO_TOOLCHAIN_TYPE = "@com_google_protobuf//bazel/private:proto_toolchain_type"
+
 # TODO(yannic): Replace with |proto_common.direct_source_infos| when
 # https://github.com/bazelbuild/rules_proto/pull/22 lands.
 def _direct_source_infos(proto_info, provided_sources = []):
@@ -252,7 +255,7 @@ def _proto_gen_openapi_impl(ctx):
                         direct = ctx.files._well_known_protos,
                         transitive = [proto.transitive_sources],
                     ),
-                    protoc = ctx.executable._protoc,
+                    protoc = ctx.toolchains[_PROTO_TOOLCHAIN_TYPE].proto.proto_compiler,
                     protoc_gen_openapiv2 = ctx.executable._protoc_gen_openapi,
                     single_output = ctx.attr.single_output,
                     allow_delete_body = ctx.attr.allow_delete_body,
@@ -480,11 +483,6 @@ protoc_gen_openapiv2 = rule(
             mandatory = False,
             doc = "Generate x-go-type extension using the go_package option from proto files",
         ),
-        "_protoc": attr.label(
-            default = "@com_google_protobuf//:protoc",
-            executable = True,
-            cfg = "exec",
-        ),
         "_well_known_protos": attr.label(
             default = "@com_google_protobuf//:well_known_type_protos",
             allow_files = True,
@@ -495,5 +493,8 @@ protoc_gen_openapiv2 = rule(
             cfg = "exec",
         ),
     },
+    toolchains = [
+        _PROTO_TOOLCHAIN_TYPE,
+    ],
     implementation = _proto_gen_openapi_impl,
 )

--- a/protoc-gen-openapiv2/defs.bzl
+++ b/protoc-gen-openapiv2/defs.bzl
@@ -6,7 +6,6 @@ Optionally applies settings from the grpc-service configuration.
 
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 
-
 _PROTO_TOOLCHAIN_TYPE = "@com_google_protobuf//bazel/private:proto_toolchain_type"
 
 # TODO(yannic): Replace with |proto_common.direct_source_infos| when


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

Fixes #5896

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

Move to using the protoc toolchain for the openapiv2 bazel rule rather than a direct reference. This should enable utilizing pre-built protoc.

#### Other comments

I don't know if there are existing usage tests in this repo, but I tested my fork as a submodule and everything built successfully. I was also able to successfully `bazel build //... && bazel test //...` in this branch.
