### PR TITLE
fix(openapiv2): preserve x-nullable when use_allof_for_refs wraps $ref

### DIFF
--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -743,12 +743,13 @@ func renderMessageAsDefinition(msg *descriptor.Message, reg *descriptor.Registry
 				// Per the JSON Reference syntax: Any members other than "$ref" in a JSON Reference object SHALL be ignored.
 				// https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03#section-3
 				// However, use allOf to specify Title/Description/Example/readOnly fields.
-				if fieldSchema.Title != "" || fieldSchema.Description != "" || len(fieldSchema.Example) > 0 || fieldSchema.ReadOnly || len(fieldSchema.extensions) > 0 {
+				if fieldSchema.Title != "" || fieldSchema.Description != "" || len(fieldSchema.Example) > 0 || fieldSchema.ReadOnly || fieldSchema.XNullable || len(fieldSchema.extensions) > 0 {
 					fieldSchema = openapiSchemaObject{
 						Title:       fieldSchema.Title,
 						Description: fieldSchema.Description,
 						schemaCore: schemaCore{
-							Example: fieldSchema.Example,
+							Example:   fieldSchema.Example,
+							XNullable: fieldSchema.XNullable,
 						},
 						ReadOnly:   fieldSchema.ReadOnly,
 						extensions: fieldSchema.extensions,

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -5528,6 +5528,8 @@ func TestRenderMessagesAsDefinition(t *testing.T) {
 	fieldVisibilityPreviewOption := new(descriptorpb.FieldOptions)
 	proto.SetExtension(fieldVisibilityPreviewOption, visibility.E_FieldVisibility, fieldVisibilityFieldPreview)
 
+	boolTrue := true
+
 	tests := []struct {
 		descr                 string
 		msgDescs              []*descriptorpb.DescriptorProto
@@ -5537,6 +5539,7 @@ func TestRenderMessagesAsDefinition(t *testing.T) {
 		pathParams            []descriptor.Parameter
 		UseJSONNamesForFields bool
 		UseAllOfForRefs       bool
+		Proto3OptionalNullable bool
 	}{
 		{
 			descr: "no OpenAPI options",
@@ -6205,6 +6208,97 @@ func TestRenderMessagesAsDefinition(t *testing.T) {
 				},
 			},
 		},
+		{
+			descr: "optional proto3 message field with use_allof_for_refs and proto3_optional_nullable",
+			msgDescs: []*descriptorpb.DescriptorProto{
+				{
+					Name: proto.String("Message"),
+					Field: []*descriptorpb.FieldDescriptorProto{
+						{
+							Name:           proto.String("items"),
+							Type:           descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+							TypeName:       proto.String(".example.Message.Nested"),
+							Number:         proto.Int32(1),
+							Proto3Optional: &boolTrue,
+						},
+					},
+					NestedType: []*descriptorpb.DescriptorProto{{
+						Name: proto.String("Nested"),
+					}},
+				},
+			},
+			UseAllOfForRefs:        true,
+			Proto3OptionalNullable: true,
+			defs: map[string]openapiSchemaObject{
+				"exampleMessage": {
+					schemaCore: schemaCore{
+						Type: "object",
+					},
+					Properties: &openapiSchemaObjectProperties{
+						{
+							Key: "items",
+							Value: openapiSchemaObject{
+								AllOf: []allOfEntry{{Ref: "#/definitions/MessageNested"}},
+								schemaCore: schemaCore{
+									XNullable: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			descr: "optional proto3 message field with title, use_allof_for_refs and proto3_optional_nullable",
+			msgDescs: []*descriptorpb.DescriptorProto{
+				{
+					Name: proto.String("Message"),
+					Field: []*descriptorpb.FieldDescriptorProto{
+						{
+							Name:           proto.String("items"),
+							Type:           descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+							TypeName:       proto.String(".example.Message.Nested"),
+							Number:         proto.Int32(1),
+							Proto3Optional: &boolTrue,
+						},
+					},
+					NestedType: []*descriptorpb.DescriptorProto{{
+						Name: proto.String("Nested"),
+					}},
+				},
+			},
+			UseAllOfForRefs:        true,
+			Proto3OptionalNullable: true,
+			openAPIOptions: &openapiconfig.OpenAPIOptions{
+				Field: []*openapiconfig.OpenAPIFieldOption{
+					{
+						Field: "example.Message.items",
+						Option: &openapi_options.JSONSchema{
+							Title: "Support for array item definitions",
+						},
+					},
+				},
+			},
+			defs: map[string]openapiSchemaObject{
+				"exampleMessage": {
+					schemaCore: schemaCore{
+						Type: "object",
+					},
+					Properties: &openapiSchemaObjectProperties{
+						{
+							Key: "items",
+							Value: openapiSchemaObject{
+								AllOf: []allOfEntry{{Ref: "#/definitions/MessageNested"}},
+								schemaCore: schemaCore{
+									XNullable: true,
+								},
+								Title: "Support for array item definitions",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -6216,20 +6310,24 @@ func TestRenderMessagesAsDefinition(t *testing.T) {
 			}
 
 			reg := descriptor.NewRegistry()
-			file := descriptor.File{
-				FileDescriptorProto: &descriptorpb.FileDescriptorProto{
-					SourceCodeInfo: &descriptorpb.SourceCodeInfo{},
-					Name:           proto.String("example.proto"),
-					Package:        proto.String("example"),
-					Dependency:     []string{},
-					MessageType:    test.msgDescs,
-					EnumType:       []*descriptorpb.EnumDescriptorProto{},
-					Service:        []*descriptorpb.ServiceDescriptorProto{},
-					Options: &descriptorpb.FileOptions{
-						GoPackage: proto.String("github.com/grpc-ecosystem/grpc-gateway/runtime/internal/examplepb;example"),
-					},
+			fileDesc := &descriptorpb.FileDescriptorProto{
+				SourceCodeInfo: &descriptorpb.SourceCodeInfo{},
+				Name:           proto.String("example.proto"),
+				Package:        proto.String("example"),
+				Dependency:     []string{},
+				MessageType:    test.msgDescs,
+				EnumType:       []*descriptorpb.EnumDescriptorProto{},
+				Service:        []*descriptorpb.ServiceDescriptorProto{},
+				Options: &descriptorpb.FileOptions{
+					GoPackage: proto.String("github.com/grpc-ecosystem/grpc-gateway/runtime/internal/examplepb;example"),
 				},
-				Messages: msgs,
+			}
+			if test.Proto3OptionalNullable {
+				fileDesc.Syntax = proto.String("proto3")
+			}
+			file := descriptor.File{
+				FileDescriptorProto: fileDesc,
+				Messages:            msgs,
 			}
 			err := reg.Load(&pluginpb.CodeGeneratorRequest{
 				ProtoFile: []*descriptorpb.FileDescriptorProto{file.FileDescriptorProto},
@@ -6242,6 +6340,10 @@ func TestRenderMessagesAsDefinition(t *testing.T) {
 
 			if test.UseAllOfForRefs {
 				reg.SetUseAllOfForRefs(true)
+			}
+
+			if test.Proto3OptionalNullable {
+				reg.SetProto3OptionalNullable(true)
 			}
 
 			if err != nil {


### PR DESCRIPTION
## Summary

- When both `proto3_optional_nullable=true` and `use_allof_for_refs=true` are enabled, optional **message** fields now keep `x-nullable: true` after the `allOf` `$ref` rewrite.
- `XNullable` is included in the wrap condition and copied into the wrapper `schemaCore`, matching how `extensions` were preserved in #3100.
- Adds `TestRenderMessagesAsDefinition` cases for optional proto3 message fields with and without a field title.

## Problem

`schemaOfField` sets `XNullable: true` for proto3 optional fields when `proto3_optional_nullable` is enabled. The `use_allof_for_refs` block in `renderMessageAsDefinition` rebuilds message `$ref` fields into an `allOf` wrapper but previously copied `Title`, `Description`, `Example`, `readOnly`, and `extensions` only—dropping `XNullable` because it lives on `schemaCore`, not in `extensions`.

Example broken output:

```yaml
items:
  title: Support for array item definitions
  allOf:
    - $ref: '#/definitions/...'
```

Expected:

```yaml
items:
  title: Support for array item definitions
  x-nullable: true
  allOf:
    - $ref: '#/definitions/...'
```

## Test plan

- [x] `go test ./protoc-gen-openapiv2/internal/genopenapi/ -run TestRenderMessagesAsDefinition/optional`
- [x] `go test ./protoc-gen-openapiv2/internal/genopenapi/ -run TestRenderMessagesAsDefinition`


Made with [Cursor](https://cursor.com)