### PR TITLE
test(runtime): add coverage for slice converters in convert.go

### DIFF
--- a/runtime/convert_test.go
+++ b/runtime/convert_test.go
@@ -1,6 +1,7 @@
 package runtime_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -134,6 +135,280 @@ func TestConvertDuration(t *testing.T) {
 					ts,
 					spec.output,
 				)
+			}
+		})
+	}
+}
+
+func TestConvertStringSlice(t *testing.T) {
+	specs := []struct {
+		name   string
+		input  string
+		sep    string
+		output []string
+	}{
+		{name: "multiple values", input: "a,b,c", sep: ",", output: []string{"a", "b", "c"}},
+		{name: "single value", input: "a", sep: ",", output: []string{"a"}},
+		{name: "custom separator", input: "a|b", sep: "|", output: []string{"a", "b"}},
+		{name: "empty string yields one empty element", input: "", sep: ",", output: []string{""}},
+	}
+	for _, spec := range specs {
+		t.Run(spec.name, func(t *testing.T) {
+			got, err := runtime.StringSlice(spec.input, spec.sep)
+			if err != nil {
+				t.Errorf("got unexpected error\n%#v", err)
+			}
+			if !reflect.DeepEqual(got, spec.output) {
+				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+			}
+		})
+	}
+}
+
+func TestConvertBoolSlice(t *testing.T) {
+	specs := []struct {
+		name    string
+		input   string
+		sep     string
+		output  []bool
+		wanterr bool
+	}{
+		{name: "valid values", input: "true,false,1,0", sep: ",", output: []bool{true, false, true, false}},
+		{name: "single value", input: "true", sep: ",", output: []bool{true}},
+		{name: "invalid element", input: "true,notabool", sep: ",", wanterr: true},
+	}
+	for _, spec := range specs {
+		t.Run(spec.name, func(t *testing.T) {
+			got, err := runtime.BoolSlice(spec.input, spec.sep)
+			switch {
+			case err != nil && !spec.wanterr:
+				t.Errorf("got unexpected error\n%#v", err)
+			case err == nil && spec.wanterr:
+				t.Errorf("did not error when expected")
+			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
+				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+			}
+		})
+	}
+}
+
+func TestConvertFloat64Slice(t *testing.T) {
+	specs := []struct {
+		name    string
+		input   string
+		sep     string
+		output  []float64
+		wanterr bool
+	}{
+		{name: "valid values", input: "1.5,2,-3.25", sep: ",", output: []float64{1.5, 2, -3.25}},
+		{name: "single value", input: "1.5", sep: ",", output: []float64{1.5}},
+		{name: "invalid element", input: "1.5,notafloat", sep: ",", wanterr: true},
+	}
+	for _, spec := range specs {
+		t.Run(spec.name, func(t *testing.T) {
+			got, err := runtime.Float64Slice(spec.input, spec.sep)
+			switch {
+			case err != nil && !spec.wanterr:
+				t.Errorf("got unexpected error\n%#v", err)
+			case err == nil && spec.wanterr:
+				t.Errorf("did not error when expected")
+			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
+				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+			}
+		})
+	}
+}
+
+func TestConvertFloat32Slice(t *testing.T) {
+	specs := []struct {
+		name    string
+		input   string
+		sep     string
+		output  []float32
+		wanterr bool
+	}{
+		{name: "valid values", input: "1.5,2,-3.25", sep: ",", output: []float32{1.5, 2, -3.25}},
+		{name: "single value", input: "1.5", sep: ",", output: []float32{1.5}},
+		{name: "invalid element", input: "1.5,notafloat", sep: ",", wanterr: true},
+	}
+	for _, spec := range specs {
+		t.Run(spec.name, func(t *testing.T) {
+			got, err := runtime.Float32Slice(spec.input, spec.sep)
+			switch {
+			case err != nil && !spec.wanterr:
+				t.Errorf("got unexpected error\n%#v", err)
+			case err == nil && spec.wanterr:
+				t.Errorf("did not error when expected")
+			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
+				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+			}
+		})
+	}
+}
+
+func TestConvertInt64Slice(t *testing.T) {
+	specs := []struct {
+		name    string
+		input   string
+		sep     string
+		output  []int64
+		wanterr bool
+	}{
+		{name: "valid values", input: "1,-2,3", sep: ",", output: []int64{1, -2, 3}},
+		{name: "single value", input: "42", sep: ",", output: []int64{42}},
+		{name: "invalid element", input: "1,notanint", sep: ",", wanterr: true},
+	}
+	for _, spec := range specs {
+		t.Run(spec.name, func(t *testing.T) {
+			got, err := runtime.Int64Slice(spec.input, spec.sep)
+			switch {
+			case err != nil && !spec.wanterr:
+				t.Errorf("got unexpected error\n%#v", err)
+			case err == nil && spec.wanterr:
+				t.Errorf("did not error when expected")
+			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
+				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+			}
+		})
+	}
+}
+
+func TestConvertInt32Slice(t *testing.T) {
+	specs := []struct {
+		name    string
+		input   string
+		sep     string
+		output  []int32
+		wanterr bool
+	}{
+		{name: "valid values", input: "1,-2,3", sep: ",", output: []int32{1, -2, 3}},
+		{name: "single value", input: "42", sep: ",", output: []int32{42}},
+		{name: "invalid element", input: "1,notanint", sep: ",", wanterr: true},
+		{name: "overflows int32", input: "2147483648", sep: ",", wanterr: true},
+	}
+	for _, spec := range specs {
+		t.Run(spec.name, func(t *testing.T) {
+			got, err := runtime.Int32Slice(spec.input, spec.sep)
+			switch {
+			case err != nil && !spec.wanterr:
+				t.Errorf("got unexpected error\n%#v", err)
+			case err == nil && spec.wanterr:
+				t.Errorf("did not error when expected")
+			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
+				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+			}
+		})
+	}
+}
+
+func TestConvertUint64Slice(t *testing.T) {
+	specs := []struct {
+		name    string
+		input   string
+		sep     string
+		output  []uint64
+		wanterr bool
+	}{
+		{name: "valid values", input: "1,2,3", sep: ",", output: []uint64{1, 2, 3}},
+		{name: "single value", input: "42", sep: ",", output: []uint64{42}},
+		{name: "invalid element", input: "1,-2", sep: ",", wanterr: true},
+	}
+	for _, spec := range specs {
+		t.Run(spec.name, func(t *testing.T) {
+			got, err := runtime.Uint64Slice(spec.input, spec.sep)
+			switch {
+			case err != nil && !spec.wanterr:
+				t.Errorf("got unexpected error\n%#v", err)
+			case err == nil && spec.wanterr:
+				t.Errorf("did not error when expected")
+			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
+				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+			}
+		})
+	}
+}
+
+func TestConvertUint32Slice(t *testing.T) {
+	specs := []struct {
+		name    string
+		input   string
+		sep     string
+		output  []uint32
+		wanterr bool
+	}{
+		{name: "valid values", input: "1,2,3", sep: ",", output: []uint32{1, 2, 3}},
+		{name: "single value", input: "42", sep: ",", output: []uint32{42}},
+		{name: "invalid element", input: "1,-2", sep: ",", wanterr: true},
+		{name: "overflows uint32", input: "4294967296", sep: ",", wanterr: true},
+	}
+	for _, spec := range specs {
+		t.Run(spec.name, func(t *testing.T) {
+			got, err := runtime.Uint32Slice(spec.input, spec.sep)
+			switch {
+			case err != nil && !spec.wanterr:
+				t.Errorf("got unexpected error\n%#v", err)
+			case err == nil && spec.wanterr:
+				t.Errorf("did not error when expected")
+			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
+				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+			}
+		})
+	}
+}
+
+func TestConvertBytesSlice(t *testing.T) {
+	// "Zm9v" and "YmFy" are base64 for "foo" and "bar".
+	specs := []struct {
+		name    string
+		input   string
+		sep     string
+		output  [][]byte
+		wanterr bool
+	}{
+		{name: "valid values", input: "Zm9v,YmFy", sep: ",", output: [][]byte{[]byte("foo"), []byte("bar")}},
+		{name: "single value", input: "Zm9v", sep: ",", output: [][]byte{[]byte("foo")}},
+		{name: "invalid base64 element", input: "Zm9v,!!!!", sep: ",", wanterr: true},
+	}
+	for _, spec := range specs {
+		t.Run(spec.name, func(t *testing.T) {
+			got, err := runtime.BytesSlice(spec.input, spec.sep)
+			switch {
+			case err != nil && !spec.wanterr:
+				t.Errorf("got unexpected error\n%#v", err)
+			case err == nil && spec.wanterr:
+				t.Errorf("did not error when expected")
+			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
+				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+			}
+		})
+	}
+}
+
+func TestConvertEnumSlice(t *testing.T) {
+	enumValMap := map[string]int32{"A": 0, "B": 1, "C": 2}
+	specs := []struct {
+		name    string
+		input   string
+		sep     string
+		output  []int32
+		wanterr bool
+	}{
+		{name: "by name", input: "A,C", sep: ",", output: []int32{0, 2}},
+		{name: "by numeric value", input: "0,2", sep: ",", output: []int32{0, 2}},
+		{name: "mixed name and value", input: "A,1", sep: ",", output: []int32{0, 1}},
+		{name: "unknown name", input: "A,Z", sep: ",", wanterr: true},
+		{name: "numeric value out of range", input: "0,9", sep: ",", wanterr: true},
+	}
+	for _, spec := range specs {
+		t.Run(spec.name, func(t *testing.T) {
+			got, err := runtime.EnumSlice(spec.input, spec.sep, enumValMap)
+			switch {
+			case err != nil && !spec.wanterr:
+				t.Errorf("got unexpected error\n%#v", err)
+			case err == nil && spec.wanterr:
+				t.Errorf("did not error when expected")
+			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
+				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
 			}
 		})
 	}

--- a/runtime/convert_test.go
+++ b/runtime/convert_test.go
@@ -60,9 +60,9 @@ func TestConvertTimestamp(t *testing.T) {
 			ts, err := runtime.Timestamp(spec.input)
 			switch {
 			case err != nil && !spec.wanterr:
-				t.Errorf("got unexpected error\n%#v", err)
+				t.Errorf("got error %v, want nil", err)
 			case err == nil && spec.wanterr:
-				t.Errorf("did not error when expected")
+				t.Errorf("got nil error, want an error")
 			case !proto.Equal(ts, spec.output):
 				t.Errorf(
 					"when testing %s; got\n%#v\nexpected\n%#v",
@@ -125,9 +125,9 @@ func TestConvertDuration(t *testing.T) {
 			ts, err := runtime.Duration(spec.input)
 			switch {
 			case err != nil && !spec.wanterr:
-				t.Errorf("got unexpected error\n%#v", err)
+				t.Errorf("got error %v, want nil", err)
 			case err == nil && spec.wanterr:
-				t.Errorf("did not error when expected")
+				t.Errorf("got nil error, want an error")
 			case !proto.Equal(ts, spec.output):
 				t.Errorf(
 					"when testing %s; got\n%#v\nexpected\n%#v",
@@ -156,10 +156,10 @@ func TestConvertStringSlice(t *testing.T) {
 		t.Run(spec.name, func(t *testing.T) {
 			got, err := runtime.StringSlice(spec.input, spec.sep)
 			if err != nil {
-				t.Errorf("got unexpected error\n%#v", err)
+				t.Errorf("got error %v, want nil", err)
 			}
 			if !reflect.DeepEqual(got, spec.output) {
-				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+				t.Errorf("got %v, want %v", got, spec.output)
 			}
 		})
 	}
@@ -182,11 +182,11 @@ func TestConvertBoolSlice(t *testing.T) {
 			got, err := runtime.BoolSlice(spec.input, spec.sep)
 			switch {
 			case err != nil && !spec.wanterr:
-				t.Errorf("got unexpected error\n%#v", err)
+				t.Errorf("got error %v, want nil", err)
 			case err == nil && spec.wanterr:
-				t.Errorf("did not error when expected")
+				t.Errorf("got nil error, want an error")
 			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
-				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+				t.Errorf("got %v, want %v", got, spec.output)
 			}
 		})
 	}
@@ -209,11 +209,11 @@ func TestConvertFloat64Slice(t *testing.T) {
 			got, err := runtime.Float64Slice(spec.input, spec.sep)
 			switch {
 			case err != nil && !spec.wanterr:
-				t.Errorf("got unexpected error\n%#v", err)
+				t.Errorf("got error %v, want nil", err)
 			case err == nil && spec.wanterr:
-				t.Errorf("did not error when expected")
+				t.Errorf("got nil error, want an error")
 			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
-				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+				t.Errorf("got %v, want %v", got, spec.output)
 			}
 		})
 	}
@@ -236,11 +236,11 @@ func TestConvertFloat32Slice(t *testing.T) {
 			got, err := runtime.Float32Slice(spec.input, spec.sep)
 			switch {
 			case err != nil && !spec.wanterr:
-				t.Errorf("got unexpected error\n%#v", err)
+				t.Errorf("got error %v, want nil", err)
 			case err == nil && spec.wanterr:
-				t.Errorf("did not error when expected")
+				t.Errorf("got nil error, want an error")
 			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
-				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+				t.Errorf("got %v, want %v", got, spec.output)
 			}
 		})
 	}
@@ -263,11 +263,11 @@ func TestConvertInt64Slice(t *testing.T) {
 			got, err := runtime.Int64Slice(spec.input, spec.sep)
 			switch {
 			case err != nil && !spec.wanterr:
-				t.Errorf("got unexpected error\n%#v", err)
+				t.Errorf("got error %v, want nil", err)
 			case err == nil && spec.wanterr:
-				t.Errorf("did not error when expected")
+				t.Errorf("got nil error, want an error")
 			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
-				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+				t.Errorf("got %v, want %v", got, spec.output)
 			}
 		})
 	}
@@ -291,11 +291,11 @@ func TestConvertInt32Slice(t *testing.T) {
 			got, err := runtime.Int32Slice(spec.input, spec.sep)
 			switch {
 			case err != nil && !spec.wanterr:
-				t.Errorf("got unexpected error\n%#v", err)
+				t.Errorf("got error %v, want nil", err)
 			case err == nil && spec.wanterr:
-				t.Errorf("did not error when expected")
+				t.Errorf("got nil error, want an error")
 			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
-				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+				t.Errorf("got %v, want %v", got, spec.output)
 			}
 		})
 	}
@@ -318,11 +318,11 @@ func TestConvertUint64Slice(t *testing.T) {
 			got, err := runtime.Uint64Slice(spec.input, spec.sep)
 			switch {
 			case err != nil && !spec.wanterr:
-				t.Errorf("got unexpected error\n%#v", err)
+				t.Errorf("got error %v, want nil", err)
 			case err == nil && spec.wanterr:
-				t.Errorf("did not error when expected")
+				t.Errorf("got nil error, want an error")
 			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
-				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+				t.Errorf("got %v, want %v", got, spec.output)
 			}
 		})
 	}
@@ -346,11 +346,11 @@ func TestConvertUint32Slice(t *testing.T) {
 			got, err := runtime.Uint32Slice(spec.input, spec.sep)
 			switch {
 			case err != nil && !spec.wanterr:
-				t.Errorf("got unexpected error\n%#v", err)
+				t.Errorf("got error %v, want nil", err)
 			case err == nil && spec.wanterr:
-				t.Errorf("did not error when expected")
+				t.Errorf("got nil error, want an error")
 			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
-				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+				t.Errorf("got %v, want %v", got, spec.output)
 			}
 		})
 	}
@@ -374,11 +374,11 @@ func TestConvertBytesSlice(t *testing.T) {
 			got, err := runtime.BytesSlice(spec.input, spec.sep)
 			switch {
 			case err != nil && !spec.wanterr:
-				t.Errorf("got unexpected error\n%#v", err)
+				t.Errorf("got error %v, want nil", err)
 			case err == nil && spec.wanterr:
-				t.Errorf("did not error when expected")
+				t.Errorf("got nil error, want an error")
 			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
-				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+				t.Errorf("got %v, want %v", got, spec.output)
 			}
 		})
 	}
@@ -404,11 +404,11 @@ func TestConvertEnumSlice(t *testing.T) {
 			got, err := runtime.EnumSlice(spec.input, spec.sep, enumValMap)
 			switch {
 			case err != nil && !spec.wanterr:
-				t.Errorf("got unexpected error\n%#v", err)
+				t.Errorf("got error %v, want nil", err)
 			case err == nil && spec.wanterr:
-				t.Errorf("did not error when expected")
+				t.Errorf("got nil error, want an error")
 			case !spec.wanterr && !reflect.DeepEqual(got, spec.output):
-				t.Errorf("got\n%#v\nexpected\n%#v", got, spec.output)
+				t.Errorf("got %v, want %v", got, spec.output)
 			}
 		})
 	}


### PR DESCRIPTION
#### References to other Issues or PRs

None — this is a standalone test-coverage improvement.

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

The scalar `*Slice` conversion helpers in `runtime/convert.go` had no test coverage (0% of statements). This adds table-driven tests for `StringSlice`, `BoolSlice`, `Float64Slice`, `Float32Slice`, `Int64Slice`, `Int32Slice`, `Uint64Slice`, `Uint32Slice`, `BytesSlice` and `EnumSlice`.

Each test exercises both the success path (multiple values, single value, custom separators) and the error path (invalid elements, integer overflow, unknown enum values). This raises each of these functions from 0% to 100% statement coverage.

No production code is changed — tests only.

#### Other comments

Verified locally:
- `go test -race ./runtime/` passes.
- `gofmt -l runtime/convert_test.go` is clean.
- The 10 targeted functions report 100% coverage via `go tool cover`.