### PR TITLE
docs: clarify Go tool dependency options

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ management. Use a
 [tool dependency](https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module)
 to track the versions of the following executable packages:
 
+For Go 1.24 and later, prefer the `tool` directive in `go.mod` described in the "Tracking Tools in `go.mod`" section. The following blank-import pattern is mainly useful for projects that are not using Go 1.24 yet.
+
 ```go
 // +build tools
 


### PR DESCRIPTION
References to other Issues or PRs

Related to #7007

Have you read the Contributing Guidelines?

Yes.

Brief description of what is fixed or changed

This PR adds a short clarification before the legacy blank-import tool tracking example.

The README shows both the Go 1.24 `tool` directive approach and the older blank-import pattern. This clarification helps readers understand that the `tool` directive should be preferred for Go 1.24 and later, while the blank-import pattern remains useful for projects that are not using Go 1.24 yet.

Other comments

Docs-only change. No tests were run.