### PR TITLE
fix(gengateway): remove redundant enum assignment for nested proto3 f…

### DIFF
--- a/examples/internal/integration/integration_test.go
+++ b/examples/internal/integration/integration_test.go
@@ -2882,3 +2882,23 @@ func testExcessBodyStreamWithBodyUnexpected(t *testing.T, port int) {
 		t.Errorf("server context not done")
 	}
 }
+
+func TestNestedEnumGetQueryParams(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+		return
+	}
+
+	// 1 corresponds to DeepEnum.TRUE
+	url := "http://localhost:8088/v1/example/a_bit_of_everything/params/get/nested_enum/1"
+	
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("http.Get(%q) failed with %v; want success", url, err)
+	}
+	defer resp.Body.Close()
+
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("resp.StatusCode = %d; want %d", got, want)
+	}
+}

--- a/examples/internal/proto/examplepb/a_bit_of_everything.pb.gw.go
+++ b/examples/internal/proto/examplepb/a_bit_of_everything.pb.gw.go
@@ -1706,7 +1706,6 @@ func request_ABitOfEverythingService_CheckNestedEnumGetQueryParams_0(ctx context
 	var (
 		protoReq ABitOfEverything
 		metadata runtime.ServerMetadata
-		e        int32
 		err      error
 	)
 	if req.Body != nil {
@@ -1720,11 +1719,6 @@ func request_ABitOfEverythingService_CheckNestedEnumGetQueryParams_0(ctx context
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "single_nested.ok", err)
 	}
-	e, err = runtime.Enum(val, ABitOfEverything_Nested_DeepEnum_value)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "could not parse path as enum value, parameter: %s, error: %v", "single_nested.ok", err)
-	}
-	protoReq.SingleNested.Ok = ABitOfEverything_Nested_DeepEnum(e)
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -1739,7 +1733,6 @@ func local_request_ABitOfEverythingService_CheckNestedEnumGetQueryParams_0(ctx c
 	var (
 		protoReq ABitOfEverything
 		metadata runtime.ServerMetadata
-		e        int32
 		err      error
 	)
 	val, ok := pathParams["single_nested.ok"]
@@ -1750,11 +1743,6 @@ func local_request_ABitOfEverythingService_CheckNestedEnumGetQueryParams_0(ctx c
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "single_nested.ok", err)
 	}
-	e, err = runtime.Enum(val, ABitOfEverything_Nested_DeepEnum_value)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "could not parse path as enum value, parameter: %s, error: %v", "single_nested.ok", err)
-	}
-	protoReq.SingleNested.Ok = ABitOfEverything_Nested_DeepEnum(e)
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}

--- a/examples/internal/proto/examplepb/opaque.pb.gw.go
+++ b/examples/internal/proto/examplepb/opaque.pb.gw.go
@@ -370,7 +370,6 @@ func request_OpaqueEcommerceService_OpaqueSearchOrders_0(ctx context.Context, ma
 	var (
 		protoReq OpaqueSearchOrdersRequest
 		metadata runtime.ServerMetadata
-		e        int32
 		err      error
 	)
 	if req.Body != nil {
@@ -384,11 +383,6 @@ func request_OpaqueEcommerceService_OpaqueSearchOrders_0(ctx context.Context, ma
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "order.status", err)
 	}
-	e, err = runtime.Enum(val, OpaqueOrder_OpaqueOrderStatus_value)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "could not parse path as enum value, parameter: %s, error: %v", "order.status", err)
-	}
-	protoReq.GetOrder().SetStatus(OpaqueOrder_OpaqueOrderStatus(e))
 	val, ok = pathParams["order.shipping_address.address_type"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "order.shipping_address.address_type")
@@ -397,11 +391,6 @@ func request_OpaqueEcommerceService_OpaqueSearchOrders_0(ctx context.Context, ma
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "order.shipping_address.address_type", err)
 	}
-	e, err = runtime.Enum(val, OpaqueAddress_OpaqueAddressType_value)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "could not parse path as enum value, parameter: %s, error: %v", "order.shipping_address.address_type", err)
-	}
-	protoReq.GetOrder().GetShippingAddress().SetAddressType(OpaqueAddress_OpaqueAddressType(e))
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -416,7 +405,6 @@ func local_request_OpaqueEcommerceService_OpaqueSearchOrders_0(ctx context.Conte
 	var (
 		protoReq OpaqueSearchOrdersRequest
 		metadata runtime.ServerMetadata
-		e        int32
 		err      error
 	)
 	val, ok := pathParams["order.status"]
@@ -427,11 +415,6 @@ func local_request_OpaqueEcommerceService_OpaqueSearchOrders_0(ctx context.Conte
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "order.status", err)
 	}
-	e, err = runtime.Enum(val, OpaqueOrder_OpaqueOrderStatus_value)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "could not parse path as enum value, parameter: %s, error: %v", "order.status", err)
-	}
-	protoReq.GetOrder().SetStatus(OpaqueOrder_OpaqueOrderStatus(e))
 	val, ok = pathParams["order.shipping_address.address_type"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "order.shipping_address.address_type")
@@ -440,11 +423,6 @@ func local_request_OpaqueEcommerceService_OpaqueSearchOrders_0(ctx context.Conte
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "order.shipping_address.address_type", err)
 	}
-	e, err = runtime.Enum(val, OpaqueAddress_OpaqueAddressType_value)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "could not parse path as enum value, parameter: %s, error: %v", "order.shipping_address.address_type", err)
-	}
-	protoReq.GetOrder().GetShippingAddress().SetAddressType(OpaqueAddress_OpaqueAddressType(e))
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}

--- a/protoc-gen-grpc-gateway/internal/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/internal/gengateway/template.go
@@ -120,7 +120,7 @@ func (b binding) HasRepeatedEnumPathParam() bool {
 // based on the provided 'repeated' parameter.
 func (b binding) hasEnumPathParam(repeated bool) bool {
 	for _, p := range b.PathParams {
-		if p.IsEnum() && p.IsRepeated() == repeated {
+		if p.IsEnum() && p.IsRepeated() == repeated && !p.IsNestedProto3() {
 			return true
 		}
 	}
@@ -481,12 +481,6 @@ var filter_{{ .Method.Service.GetName }}_{{ .Method.GetName }}_{{ .Index }} = {{
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", {{ $param | printf "%q" }}, err)
 	}
-	{{- if $enum }}
-		e{{ if $param.IsRepeated }}s{{ end }}, err = {{ $param.ConvertFuncExpr }}(val{{ if $param.IsRepeated }}, {{ $binding.Registry.GetRepeatedPathParamSeparator | printf "%c" | printf "%q" }}{{ end }}, {{ $enum.GoType $param.Method.Service.File.GoPkg.Path | camelIdentifier }}_value)
-		if err != nil {
-			return nil, metadata, status.Errorf(codes.InvalidArgument, "could not parse path as enum value, parameter: %s, error: %v", {{ $param | printf "%q"}}, err)
-		}
-	{{- end }}
 {{- else if $enum }}
 	e{{ if $param.IsRepeated }}s{{ end }}, err = {{ $param.ConvertFuncExpr }}(val{{ if $param.IsRepeated }}, {{ $binding.Registry.GetRepeatedPathParamSeparator | printf "%c" | printf "%q" }}{{ end }}, {{ $enum.GoType $param.Method.Service.File.GoPkg.Path | camelIdentifier }}_value)
 	if err != nil {
@@ -510,6 +504,7 @@ var filter_{{ .Method.Service.GetName }}_{{ .Method.GetName }}_{{ .Index }} = {{
 	}
 	{{- end }}
 {{- end}}
+{{- if not $param.IsNestedProto3 }}
 {{- if and $enum $param.IsRepeated }}
 	s := make([]{{ $enum.GoType $param.Method.Service.File.GoPkg.Path }}, len(es))
 	for i, v := range es {
@@ -527,6 +522,7 @@ var filter_{{ .Method.Service.GetName }}_{{ .Method.GetName }}_{{ .Index }} = {{
 	{{ $param.AssignableExpr "protoReq" $binding.Method.Service.File.GoPkg.Path }} = {{ $enum.GoType $param.Method.Service.File.GoPkg.Path | camelIdentifier }}(e)
 	{{- end }}
 {{- end}}
+{{- end }}
 	{{- end }}
 {{- end }}
 {{- if .HasQueryParam }}
@@ -716,12 +712,6 @@ func local_request_{{ .Method.Service.GetName }}_{{ .Method.GetName }}_{{ .Index
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", {{ $param | printf "%q"}}, err)
 	}
-	{{- if $enum }}
-		e{{ if $param.IsRepeated }}s{{ end }}, err = {{ $param.ConvertFuncExpr }}(val{{ if $param.IsRepeated }}, {{ $binding.Registry.GetRepeatedPathParamSeparator | printf "%c" | printf "%q" }}{{ end }}, {{ $enum.GoType $param.Method.Service.File.GoPkg.Path | camelIdentifier }}_value)
-		if err != nil {
-			return nil, metadata, status.Errorf(codes.InvalidArgument, "could not parse path as enum value, parameter: %s, error: %v", {{ $param | printf "%q"}}, err)
-		}
-	{{- end }}
 {{- else if $enum}}
 	e{{ if $param.IsRepeated }}s{{ end }}, err = {{ $param.ConvertFuncExpr }}(val{{ if $param.IsRepeated }}, {{ $binding.Registry.GetRepeatedPathParamSeparator | printf "%c" | printf "%q" }}{{ end }}, {{ $enum.GoType  $param.Method.Service.File.GoPkg.Path | camelIdentifier }}_value)
 	if err != nil {
@@ -745,6 +735,7 @@ func local_request_{{ .Method.Service.GetName }}_{{ .Method.GetName }}_{{ .Index
 	}
 	{{- end }}
 {{- end}}
+{{- if not $param.IsNestedProto3 }}
 {{- if and $enum $param.IsRepeated }}
 	s := make([]{{ $enum.GoType $param.Method.Service.File.GoPkg.Path }}, len(es))
 	for i, v := range es {
@@ -761,6 +752,7 @@ func local_request_{{ .Method.Service.GetName }}_{{ .Method.GetName }}_{{ .Index
 	{{- else }}
 	{{ $param.AssignableExpr "protoReq" $binding.Method.Service.File.GoPkg.Path }} = {{ $enum.GoType $param.Method.Service.File.GoPkg.Path | camelIdentifier }}(e)
 	{{- end }}
+{{- end }}
 {{- end }}
 	{{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes #2901

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?
Yes

#### Brief description of what is fixed or changed
Removes the redundant enum assignment block in `protoc-gen-grpc-gateway/internal/gengateway/template.go` for nested proto3 fields (`IsNestedProto3 = true`). 

For nested proto3 fields, `runtime.PopulateFieldFromPath` completely handles the initialization of nested structs and sets the enum value properly based on the path parameters. However, the generator was redundantly emitting code to parse the enum again and directly assign it to `protoReq.Nested.Field`. This caused a nil pointer dereference panic when the nested struct was uninitialized prior to this manual assignment.

Additionally, updated `hasEnumPathParam` to omit nested proto3 enums, which prevents generating unused variables (`e int32`) in the generated output.

#### Other comments
All unit tests and integration tests have been run locally, including those testing repeated path enums and opaque API fields, and they pass successfully without any regressions.
