### PR TITLE
fix(openapiv3): omit empty body objects for nested path parameters

### DIFF
--- a/examples/internal/clients/abev3/abev3.go
+++ b/examples/internal/clients/abev3/abev3.go
@@ -367,11 +367,6 @@ type GrpcGatewayExamplesInternalProtoExamplepbCheckStatusResponse struct {
 	Status *GoogleRpcStatus `json:"status,omitempty"`
 }
 
-// GrpcGatewayExamplesInternalProtoExamplepbEntityId defines model for grpc.gateway.examples.internal.proto.examplepb.EntityId.
-type GrpcGatewayExamplesInternalProtoExamplepbEntityId struct {
-	Value *string `json:"value,omitempty"`
-}
-
 // GrpcGatewayExamplesInternalProtoExamplepbFoo defines model for grpc.gateway.examples.internal.proto.examplepb.Foo.
 type GrpcGatewayExamplesInternalProtoExamplepbFoo struct {
 	Bar GrpcGatewayExamplesInternalProtoExamplepbBar `json:"bar"`
@@ -592,8 +587,7 @@ type ABitOfEverythingServiceCustom1Params struct {
 
 // ABitOfEverythingServiceUpdateEntityJSONBody defines parameters for ABitOfEverythingServiceUpdateEntity.
 type ABitOfEverythingServiceUpdateEntityJSONBody struct {
-	Id         *GrpcGatewayExamplesInternalProtoExamplepbEntityId `json:"id,omitempty"`
-	OtherField *string                                            `json:"otherField,omitempty"`
+	OtherField *string `json:"otherField,omitempty"`
 }
 
 // ABitOfEverythingServiceCreateNestedBodyOneofJSONBody defines parameters for ABitOfEverythingServiceCreateNestedBodyOneof.

--- a/examples/internal/proto/examplepb/a_bit_of_everything.openapi.json
+++ b/examples/internal/proto/examplepb/a_bit_of_everything.openapi.json
@@ -761,9 +761,6 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "id": {
-                    "$ref": "#/components/schemas/grpc.gateway.examples.internal.proto.examplepb.EntityId"
-                  },
                   "otherField": {
                     "type": "string"
                   }
@@ -7636,14 +7633,6 @@
         "properties": {
           "status": {
             "$ref": "#/components/schemas/google.rpc.Status"
-          }
-        }
-      },
-      "grpc.gateway.examples.internal.proto.examplepb.EntityId": {
-        "type": "object",
-        "properties": {
-          "value": {
-            "type": "string"
           }
         }
       },

--- a/protoc-gen-openapiv3/internal/genopenapi/BUILD.bazel
+++ b/protoc-gen-openapiv3/internal/genopenapi/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
     srcs = [
         "comments_test.go",
         "generator_test.go",
+        "operation_test.go",
         "path_test.go",
         "schema_test.go",
         "visibility_test.go",

--- a/protoc-gen-openapiv3/internal/genopenapi/operation.go
+++ b/protoc-gen-openapiv3/internal/genopenapi/operation.go
@@ -310,7 +310,7 @@ func buildRequestBody(b *schemaBuilder, m *descriptor.Method, binding *descripto
 				// Field is hidden by visibility rules, skip.
 				continue
 			}
-			if isPathParam(field, binding.PathParams) {
+			if b.fieldConsumedByPathParams(field, binding.PathParams) {
 				continue
 			}
 			b.addProperty(bodySchema, field)
@@ -422,6 +422,47 @@ func isPathParam(field *descriptor.Field, params []descriptor.Parameter) bool {
 		}
 	}
 	return false
+}
+
+// subPathParams returns the path parameters nested under the given field name,
+// with the leading field-path component stripped so they are expressed
+// relative to that field.
+func subPathParams(fieldName string, params []descriptor.Parameter) []descriptor.Parameter {
+	var inner []descriptor.Parameter
+	for _, p := range params {
+		if len(p.FieldPath) > 1 && p.FieldPath[0].Name == fieldName {
+			inner = append(inner, descriptor.Parameter{
+				FieldPath: p.FieldPath[1:],
+				Target:    p.Target,
+				Method:    p.Method,
+			})
+		}
+	}
+	return inner
+}
+
+func (b *schemaBuilder) fieldConsumedByPathParams(field *descriptor.Field, params []descriptor.Parameter) bool {
+	if isPathParam(field, params) {
+		return true
+	}
+	if field.GetType() != descriptorpb.FieldDescriptorProto_TYPE_MESSAGE ||
+		field.GetLabel() == descriptorpb.FieldDescriptorProto_LABEL_REPEATED {
+		return false
+	}
+	sub := subPathParams(field.GetName(), params)
+	if len(sub) == 0 {
+		return false
+	}
+	msg, err := b.reg.LookupMsg("", field.GetTypeName())
+	if err != nil || len(msg.Fields) == 0 {
+		return false
+	}
+	for _, f := range msg.Fields {
+		if !b.fieldConsumedByPathParams(f, sub) {
+			return false
+		}
+	}
+	return true
 }
 
 func isBodyField(field *descriptor.Field, body *descriptor.Body) bool {

--- a/protoc-gen-openapiv3/internal/genopenapi/operation_test.go
+++ b/protoc-gen-openapiv3/internal/genopenapi/operation_test.go
@@ -1,0 +1,98 @@
+package genopenapi
+
+import (
+	"testing"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/internal/descriptor"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/pluginpb"
+)
+
+func strField(name string, num int32) *descriptorpb.FieldDescriptorProto {
+	return &descriptorpb.FieldDescriptorProto{
+		Name:   proto.String(name),
+		Number: proto.Int32(num),
+		Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+		Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+	}
+}
+
+// TestFieldConsumedByPathParams covers the #2624 case: a body field whose only
+// sub-field is bound to a nested path parameter (id.value) must be reported as
+// consumed, while a sibling scalar body field must not.
+func TestFieldConsumedByPathParams(t *testing.T) {
+	fdp := &descriptorpb.FileDescriptorProto{
+		Name:    proto.String("test.proto"),
+		Package: proto.String("test"),
+		Syntax:  proto.String("proto3"),
+		Options: &descriptorpb.FileOptions{GoPackage: proto.String("github.com/example/test")},
+		MessageType: []*descriptorpb.DescriptorProto{
+			{
+				Name:  proto.String("EntityId"),
+				Field: []*descriptorpb.FieldDescriptorProto{strField("value", 1)},
+			},
+			{
+				Name: proto.String("UpdateEntityRequest"),
+				Field: []*descriptorpb.FieldDescriptorProto{
+					{
+						Name:     proto.String("id"),
+						Number:   proto.Int32(1),
+						Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+						Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+						TypeName: proto.String(".test.EntityId"),
+					},
+					strField("other_field", 2),
+				},
+			},
+		},
+	}
+
+	reg := descriptor.NewRegistry()
+	if err := reg.Load(&pluginpb.CodeGeneratorRequest{
+		ProtoFile:      []*descriptorpb.FileDescriptorProto{fdp},
+		FileToGenerate: []string{"test.proto"},
+	}); err != nil {
+		t.Fatalf("registry load: %v", err)
+	}
+
+	req, err := reg.LookupMsg("", ".test.UpdateEntityRequest")
+	if err != nil {
+		t.Fatalf("lookup request message: %v", err)
+	}
+	entityID, err := reg.LookupMsg("", ".test.EntityId")
+	if err != nil {
+		t.Fatalf("lookup EntityId message: %v", err)
+	}
+
+	var idField, otherField *descriptor.Field
+	for _, f := range req.Fields {
+		switch f.GetName() {
+		case "id":
+			idField = f
+		case "other_field":
+			otherField = f
+		}
+	}
+	if idField == nil || otherField == nil {
+		t.Fatalf("did not resolve request fields: id=%v other=%v", idField, otherField)
+	}
+	valueField := entityID.Fields[0]
+
+	// Path parameter id.value: FieldPath [id, value], leaf Target = value.
+	params := []descriptor.Parameter{{
+		FieldPath: descriptor.FieldPath{
+			{Name: "id", Target: idField},
+			{Name: "value", Target: valueField},
+		},
+		Target: valueField,
+	}}
+
+	b := &schemaBuilder{reg: reg}
+	if !b.fieldConsumedByPathParams(idField, params) {
+		t.Error("id's only sub-field is the id.value path parameter, so it should be consumed")
+	}
+	if b.fieldConsumedByPathParams(otherField, params) {
+		t.Error("other_field is a real body field and should not be consumed")
+	}
+}


### PR DESCRIPTION
#### References to other Issues or PRs

Follow-up to #7065 (which fixed the openapiv2 side of #2624). Requested by @johanbrandhorst in https://github.com/grpc-ecosystem/grpc-gateway/pull/7065#discussion_r3555387973.

#### Have you read the Contributing Guidelines?

Yes.

#### Brief description of what is fixed or changed

`protoc-gen-openapiv2` was fixed in #7065 to drop body fields whose only sub-fields are bound to path parameters. `protoc-gen-openapiv3` had the same bug: for `body: "*"`, `buildRequestBody` only skipped fields that were *directly* path parameters (`isPathParam`), so a field like `id` (an `EntityId` whose only member `value` is bound to the `{id.value}` path parameter) was still emitted as a `$ref` to a component that carries nothing but a path parameter.

`buildRequestBody` now skips a `body: "*"` field when it is fully consumed by path parameters. The check is recursive: `subPathParams` strips one field-path component per level of message nesting, so it handles arbitrarily deep nested path params and terminates. A field with any remaining non-path-parameter content, a repeated field, or a legitimately empty message is unaffected.

#### Notes

The example rendering (`a_bit_of_everything.openapi.json`) will reflect this once #7065 merges (it adds the `UpdateEntity` RPC that exercises the case); this PR is the generator fix plus a unit test, and produces no change to the current example output. Added `TestFieldConsumedByPathParams`.