### PR TITLE
docs: fix SLSA link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Make sure that your `$GOBIN` is in your `$PATH`.
 ### Download the binaries
 
 You may alternatively download the binaries from the [GitHub releases page](https://github.com/grpc-ecosystem/grpc-gateway/releases/latest).
-We generate [SLSA3 signatures](slsa.dev) using the OpenSSF's [slsa-framework/slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator) during the release process. To verify a release binary:
+We generate [SLSA3 signatures](https://slsa.dev) using the OpenSSF's [slsa-framework/slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator) during the release process. To verify a release binary:
 
 1. Install the verification tool from [slsa-framework/slsa-verifier#installation](https://github.com/slsa-framework/slsa-verifier#installation).
 2. Download the provenance file `attestation.intoto.jsonl` from the [GitHub releases page](https://github.com/grpc-ecosystem/grpc-gateway/releases/latest).


### PR DESCRIPTION
In the "How to use" section, the README links `[SLSA3 signatures](slsa.dev)`. Because the destination has no scheme, Markdown treats `slsa.dev` as a repository-relative path, so the link resolves to `github.com/grpc-ecosystem/grpc-gateway/blob/main/slsa.dev` and 404s instead of going to the SLSA site.

Changed to the absolute `https://slsa.dev`. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)