### PR TITLE
fix(openapiv2): omit oneof siblings of path parameters from query parameters

### DIFF
--- a/examples/internal/clients/echo/client/echo_service/echo_service_echo3_parameters.go
+++ b/examples/internal/clients/echo/client/echo_service/echo_service_echo3_parameters.go
@@ -72,11 +72,6 @@ type EchoServiceEcho3Params struct {
 	// Lang.
 	Lang string
 
-	// LineNum.
-	//
-	// Format: int64
-	LineNum *string
-
 	// NIDnID.
 	NIDnID *string
 
@@ -191,17 +186,6 @@ func (o *EchoServiceEcho3Params) WithLang(lang string) *EchoServiceEcho3Params {
 // SetLang adds the lang to the echo service echo3 params
 func (o *EchoServiceEcho3Params) SetLang(lang string) {
 	o.Lang = lang
-}
-
-// WithLineNum adds the lineNum to the echo service echo3 params
-func (o *EchoServiceEcho3Params) WithLineNum(lineNum *string) *EchoServiceEcho3Params {
-	o.SetLineNum(lineNum)
-	return o
-}
-
-// SetLineNum adds the lineNum to the echo service echo3 params
-func (o *EchoServiceEcho3Params) SetLineNum(lineNum *string) {
-	o.LineNum = lineNum
 }
 
 // WithNIDnID adds the nIDnID to the echo service echo3 params
@@ -325,23 +309,6 @@ func (o *EchoServiceEcho3Params) WriteToRequest(r runtime.ClientRequest, reg str
 	// path param lang
 	if err := r.SetPathParam("lang", o.Lang); err != nil {
 		return err
-	}
-
-	if o.LineNum != nil {
-
-		// query param lineNum
-		var qrLineNum string
-
-		if o.LineNum != nil {
-			qrLineNum = *o.LineNum
-		}
-		qLineNum := qrLineNum
-		if qLineNum != "" {
-
-			if err := r.SetQueryParam("lineNum", qLineNum); err != nil {
-				return err
-			}
-		}
 	}
 
 	if o.NIDnID != nil {

--- a/examples/internal/clients/echo/client/echo_service/echo_service_echo4_parameters.go
+++ b/examples/internal/clients/echo/client/echo_service/echo_service_echo4_parameters.go
@@ -69,9 +69,6 @@ type EchoServiceEcho4Params struct {
 	*/
 	ID string
 
-	// Lang.
-	Lang *string
-
 	// LineNum.
 	//
 	// Format: int64
@@ -177,17 +174,6 @@ func (o *EchoServiceEcho4Params) WithID(id string) *EchoServiceEcho4Params {
 // SetID adds the id to the echo service echo4 params
 func (o *EchoServiceEcho4Params) SetID(id string) {
 	o.ID = id
-}
-
-// WithLang adds the lang to the echo service echo4 params
-func (o *EchoServiceEcho4Params) WithLang(lang *string) *EchoServiceEcho4Params {
-	o.SetLang(lang)
-	return o
-}
-
-// SetLang adds the lang to the echo service echo4 params
-func (o *EchoServiceEcho4Params) SetLang(lang *string) {
-	o.Lang = lang
 }
 
 // WithLineNum adds the lineNum to the echo service echo4 params
@@ -306,23 +292,6 @@ func (o *EchoServiceEcho4Params) WriteToRequest(r runtime.ClientRequest, reg str
 	// path param id
 	if err := r.SetPathParam("id", o.ID); err != nil {
 		return err
-	}
-
-	if o.Lang != nil {
-
-		// query param lang
-		var qrLang string
-
-		if o.Lang != nil {
-			qrLang = *o.Lang
-		}
-		qLang := qrLang
-		if qLang != "" {
-
-			if err := r.SetQueryParam("lang", qLang); err != nil {
-				return err
-			}
-		}
 	}
 
 	// path param lineNum

--- a/examples/internal/clients/echo/client/echo_service/echo_service_echo5_parameters.go
+++ b/examples/internal/clients/echo/client/echo_service/echo_service_echo5_parameters.go
@@ -58,11 +58,6 @@ EchoServiceEcho5Params contains all the parameters to send to the API endpoint
 */
 type EchoServiceEcho5Params struct {
 
-	// En.
-	//
-	// Format: int64
-	En *string
-
 	/* ID.
 
 	   Id represents the message identifier.
@@ -155,17 +150,6 @@ func (o *EchoServiceEcho5Params) WithHTTPClient(client *http.Client) *EchoServic
 // SetHTTPClient adds the HTTPClient to the echo service echo5 params
 func (o *EchoServiceEcho5Params) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
-}
-
-// WithEn adds the en to the echo service echo5 params
-func (o *EchoServiceEcho5Params) WithEn(en *string) *EchoServiceEcho5Params {
-	o.SetEn(en)
-	return o
-}
-
-// SetEn adds the en to the echo service echo5 params
-func (o *EchoServiceEcho5Params) SetEn(en *string) {
-	o.En = en
 }
 
 // WithID adds the id to the echo service echo5 params
@@ -285,23 +269,6 @@ func (o *EchoServiceEcho5Params) WriteToRequest(r runtime.ClientRequest, reg str
 		return err
 	}
 	var res []error
-
-	if o.En != nil {
-
-		// query param en
-		var qrEn string
-
-		if o.En != nil {
-			qrEn = *o.En
-		}
-		qEn := qrEn
-		if qEn != "" {
-
-			if err := r.SetQueryParam("en", qEn); err != nil {
-				return err
-			}
-		}
-	}
 
 	if o.ID != nil {
 

--- a/examples/internal/proto/examplepb/echo_service.swagger.json
+++ b/examples/internal/proto/examplepb/echo_service.swagger.json
@@ -475,13 +475,6 @@
             "type": "string"
           },
           {
-            "name": "lineNum",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "format": "int64"
-          },
-          {
             "name": "status.progress",
             "in": "query",
             "required": false,
@@ -586,12 +579,6 @@
             "format": "int64"
           },
           {
-            "name": "lang",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name": "status.progress",
             "in": "query",
             "required": false,
@@ -691,13 +678,6 @@
           },
           {
             "name": "status.progress",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "format": "int64"
-          },
-          {
-            "name": "en",
             "in": "query",
             "required": false,
             "type": "string",

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -181,6 +181,12 @@ func messageToQueryParameters(message *descriptor.Message, reg *descriptor.Regis
 			continue
 		}
 
+		// When a path parameter is set to a oneof field, we want to skip the other
+		// fields in the oneof group.
+		if isPathSameOneOf(pathParams, field) {
+			continue
+		}
+
 		if !isVisible(getFieldVisibilityOption(field), reg) {
 			continue
 		}
@@ -195,6 +201,37 @@ func messageToQueryParameters(message *descriptor.Message, reg *descriptor.Regis
 		params = append(params, p...)
 	}
 	return params, nil
+}
+
+// isPathSameOneOf returns true if the given field is a member of a oneof group of
+// which another member is already bound to a path parameter. Only one member of a
+// oneof group can be set at a time, so the remaining members can never be
+// populated through the query string.
+func isPathSameOneOf(pathParams []descriptor.Parameter, field *descriptor.Field) bool {
+	if field.OneofIndex == nil {
+		return false
+	}
+
+	for _, pathParam := range pathParams {
+		if len(pathParam.FieldPath) == 0 {
+			continue
+		}
+
+		// Only the first component of the path parameter is a field of the same
+		// message as field, so that is the only level at which the oneof indices
+		// are comparable. Oneof indices are only unique within their containing
+		// message.
+		target := pathParam.FieldPath[0].Target
+		if target == nil || target == field || target.OneofIndex == nil {
+			continue
+		}
+
+		if *target.OneofIndex == *field.OneofIndex {
+			return true
+		}
+	}
+
+	return false
 }
 
 func isBodySameOneOf(body *descriptor.Body, field *descriptor.Field) bool {

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -672,6 +672,443 @@ func TestMessageToQueryParameters(t *testing.T) {
 	}
 }
 
+// TestMessageToQueryParametersWithOneOfPathParams checks that when a member of a
+// oneof group is bound to a path parameter, the other members of that same group
+// are not emitted as query parameters, while oneof groups in nested messages are
+// left untouched.
+func TestMessageToQueryParametersWithOneOfPathParams(t *testing.T) {
+	// simpleMessageDescs mirrors the SimpleMessage/Embedded pair used by the echo
+	// service example, which is the canonical reproduction of the reported issue.
+	simpleMessageDescs := func() []*descriptorpb.DescriptorProto {
+		return []*descriptorpb.DescriptorProto{
+			{
+				Name: proto.String("Embedded"),
+				Field: []*descriptorpb.FieldDescriptorProto{
+					{
+						Name:       proto.String("progress"),
+						Type:       descriptorpb.FieldDescriptorProto_TYPE_INT64.Enum(),
+						Number:     proto.Int32(1),
+						OneofIndex: proto.Int32(0),
+					},
+					{
+						Name:       proto.String("note"),
+						Type:       descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+						Number:     proto.Int32(2),
+						OneofIndex: proto.Int32(0),
+					},
+				},
+				OneofDecl: []*descriptorpb.OneofDescriptorProto{
+					{Name: proto.String("mark")},
+				},
+			},
+			{
+				Name: proto.String("SimpleMessage"),
+				Field: []*descriptorpb.FieldDescriptorProto{
+					{
+						Name:   proto.String("id"),
+						Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+						Number: proto.Int32(1),
+					},
+					{
+						Name:   proto.String("num"),
+						Type:   descriptorpb.FieldDescriptorProto_TYPE_INT64.Enum(),
+						Number: proto.Int32(2),
+					},
+					{
+						Name:       proto.String("line_num"),
+						Type:       descriptorpb.FieldDescriptorProto_TYPE_INT64.Enum(),
+						Number:     proto.Int32(3),
+						OneofIndex: proto.Int32(0),
+					},
+					{
+						Name:       proto.String("lang"),
+						Type:       descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+						Number:     proto.Int32(4),
+						OneofIndex: proto.Int32(0),
+					},
+					{
+						Name:     proto.String("status"),
+						Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+						TypeName: proto.String(".example.Embedded"),
+						Number:   proto.Int32(5),
+					},
+					{
+						Name:       proto.String("en"),
+						Type:       descriptorpb.FieldDescriptorProto_TYPE_INT64.Enum(),
+						Number:     proto.Int32(6),
+						OneofIndex: proto.Int32(1),
+					},
+					{
+						Name:       proto.String("no"),
+						Type:       descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+						TypeName:   proto.String(".example.Embedded"),
+						Number:     proto.Int32(7),
+						OneofIndex: proto.Int32(1),
+					},
+					{
+						Name:   proto.String("resource_id"),
+						Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+						Number: proto.Int32(8),
+					},
+				},
+				OneofDecl: []*descriptorpb.OneofDescriptorProto{
+					{Name: proto.String("code")},
+					{Name: proto.String("ext")},
+				},
+			},
+		}
+	}
+
+	type test struct {
+		Descr string
+		// PathParams are dotted proto field paths, as they appear in the URL template.
+		PathParams []string
+		MsgDescs   []*descriptorpb.DescriptorProto
+		Message    string
+		Params     []openapiParameterObject
+		// Proto3 marks the file syntax explicitly, which is required for
+		// descriptors that use proto3 optional semantics.
+		Proto3 bool
+	}
+
+	tests := []test{
+		{
+			Descr:      "oneof sibling of a path parameter is omitted",
+			PathParams: []string{"lang"},
+			MsgDescs: []*descriptorpb.DescriptorProto{
+				{
+					Name: proto.String("ExampleMessage"),
+					Field: []*descriptorpb.FieldDescriptorProto{
+						{
+							Name:   proto.String("id"),
+							Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+							Number: proto.Int32(1),
+						},
+						{
+							Name:       proto.String("line_num"),
+							Type:       descriptorpb.FieldDescriptorProto_TYPE_INT64.Enum(),
+							Number:     proto.Int32(2),
+							OneofIndex: proto.Int32(0),
+						},
+						{
+							Name:       proto.String("lang"),
+							Type:       descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+							Number:     proto.Int32(3),
+							OneofIndex: proto.Int32(0),
+						},
+					},
+					OneofDecl: []*descriptorpb.OneofDescriptorProto{
+						{Name: proto.String("code")},
+					},
+				},
+			},
+			Message: "ExampleMessage",
+			Params: []openapiParameterObject{
+				{
+					Name:     "id",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+				},
+			},
+		},
+		{
+			// Regression test: oneof indices are only unique within their
+			// containing message, so a path parameter on SimpleMessage's oneof
+			// "code" (index 0) must not strip Embedded's oneof "mark" (also
+			// index 0) out of the nested query parameters.
+			Descr:      "oneof groups of nested messages are unaffected",
+			PathParams: []string{"id", "num", "lang"},
+			MsgDescs:   simpleMessageDescs(),
+			Message:    "SimpleMessage",
+			Params: []openapiParameterObject{
+				{
+					Name:     "status.progress",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+					Format:   "int64",
+				},
+				{
+					Name:     "status.note",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+				},
+				{
+					Name:     "en",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+					Format:   "int64",
+				},
+				{
+					Name:     "no.progress",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+					Format:   "int64",
+				},
+				{
+					Name:     "no.note",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+				},
+				{
+					Name:     "resource_id",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+				},
+			},
+		},
+		{
+			Descr:      "nested path parameter omits only its own oneof sibling",
+			PathParams: []string{"id.hex"},
+			MsgDescs: []*descriptorpb.DescriptorProto{
+				{
+					Name: proto.String("ObjectID"),
+					Field: []*descriptorpb.FieldDescriptorProto{
+						{
+							Name:   proto.String("hex"),
+							Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+							Number: proto.Int32(1),
+						},
+						{
+							Name:   proto.String("extra"),
+							Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+							Number: proto.Int32(2),
+						},
+					},
+				},
+				{
+					Name: proto.String("ExampleMessage"),
+					Field: []*descriptorpb.FieldDescriptorProto{
+						{
+							Name:       proto.String("id"),
+							Type:       descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+							TypeName:   proto.String(".example.ObjectID"),
+							Number:     proto.Int32(1),
+							OneofIndex: proto.Int32(0),
+						},
+						{
+							Name:       proto.String("slug"),
+							Type:       descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+							Number:     proto.Int32(2),
+							OneofIndex: proto.Int32(0),
+						},
+					},
+					OneofDecl: []*descriptorpb.OneofDescriptorProto{
+						{Name: proto.String("article_id")},
+					},
+				},
+			},
+			Message: "ExampleMessage",
+			Params: []openapiParameterObject{
+				{
+					Name:     "id.extra",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+				},
+			},
+		},
+		{
+			Descr:      "path parameter outside a oneof keeps every oneof member",
+			PathParams: []string{"id"},
+			MsgDescs:   simpleMessageDescs(),
+			Message:    "SimpleMessage",
+			Params: []openapiParameterObject{
+				{
+					Name:     "num",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+					Format:   "int64",
+				},
+				{
+					Name:     "line_num",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+					Format:   "int64",
+				},
+				{
+					Name:     "lang",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+				},
+				{
+					Name:     "status.progress",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+					Format:   "int64",
+				},
+				{
+					Name:     "status.note",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+				},
+				{
+					Name:     "en",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+					Format:   "int64",
+				},
+				{
+					Name:     "no.progress",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+					Format:   "int64",
+				},
+				{
+					Name:     "no.note",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+				},
+				{
+					Name:     "resource_id",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+				},
+			},
+		},
+		{
+			// proto3 optional fields are modelled as synthetic single-member
+			// oneofs, each with its own index, so they must not affect each other.
+			Descr:      "proto3 optional path parameter keeps the other optional fields",
+			PathParams: []string{"a"},
+			Proto3:     true,
+			MsgDescs: []*descriptorpb.DescriptorProto{
+				{
+					Name: proto.String("ExampleMessage"),
+					Field: []*descriptorpb.FieldDescriptorProto{
+						{
+							Name:           proto.String("a"),
+							Type:           descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+							Number:         proto.Int32(1),
+							Proto3Optional: proto.Bool(true),
+							OneofIndex:     proto.Int32(0),
+						},
+						{
+							Name:           proto.String("b"),
+							Type:           descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+							Number:         proto.Int32(2),
+							Proto3Optional: proto.Bool(true),
+							OneofIndex:     proto.Int32(1),
+						},
+					},
+					OneofDecl: []*descriptorpb.OneofDescriptorProto{
+						{Name: proto.String("_a")},
+						{Name: proto.String("_b")},
+					},
+				},
+			},
+			Message: "ExampleMessage",
+			Params: []openapiParameterObject{
+				{
+					Name:     "b",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Descr, func(t *testing.T) {
+			reg := descriptor.NewRegistry()
+			msgs := []*descriptor.Message{}
+			for _, msgdesc := range test.MsgDescs {
+				msgs = append(msgs, &descriptor.Message{DescriptorProto: msgdesc})
+			}
+			fileDesc := &descriptorpb.FileDescriptorProto{
+				SourceCodeInfo: &descriptorpb.SourceCodeInfo{},
+				Name:           proto.String("example.proto"),
+				Package:        proto.String("example"),
+				Dependency:     []string{},
+				MessageType:    test.MsgDescs,
+				Service:        []*descriptorpb.ServiceDescriptorProto{},
+				Options: &descriptorpb.FileOptions{
+					GoPackage: proto.String("github.com/grpc-ecosystem/grpc-gateway/runtime/internal/examplepb;example"),
+				},
+			}
+			if test.Proto3 {
+				fileDesc.Syntax = proto.String("proto3")
+			}
+			file := descriptor.File{
+				FileDescriptorProto: fileDesc,
+				GoPkg: descriptor.GoPackage{
+					Path: "example.com/path/to/example/example.pb",
+					Name: "example_pb",
+				},
+				Messages: msgs,
+			}
+			err := reg.Load(&pluginpb.CodeGeneratorRequest{
+				ProtoFile: []*descriptorpb.FileDescriptorProto{file.FileDescriptorProto},
+			})
+			if err != nil {
+				t.Fatalf("failed to load code generator request: %v", err)
+			}
+
+			message, err := reg.LookupMsg("", ".example."+test.Message)
+			if err != nil {
+				t.Fatalf("failed to lookup message: %s", err)
+			}
+
+			pathParams := make([]descriptor.Parameter, 0, len(test.PathParams))
+			for _, path := range test.PathParams {
+				current := message
+				var components []descriptor.FieldPathComponent
+				for i, name := range strings.Split(path, ".") {
+					var target *descriptor.Field
+					for _, f := range current.Fields {
+						if f.GetName() == name {
+							target = f
+							break
+						}
+					}
+					if target == nil {
+						t.Fatalf("failed to resolve path parameter %q: no field %q", path, name)
+					}
+					components = append(components, descriptor.FieldPathComponent{Name: name, Target: target})
+					if i != len(strings.Split(path, "."))-1 {
+						current, err = reg.LookupMsg("", target.GetTypeName())
+						if err != nil {
+							t.Fatalf("failed to resolve path parameter %q: %s", path, err)
+						}
+					}
+				}
+				pathParams = append(pathParams, descriptor.Parameter{
+					FieldPath: components,
+					Target:    components[len(components)-1].Target,
+				})
+			}
+
+			params, err := messageToQueryParameters(message, reg, pathParams, nil, "")
+			if err != nil {
+				t.Fatalf("failed to convert message to query parameters: %s", err)
+			}
+			// avoid checking Items for array types
+			for i := range params {
+				params[i].Items = nil
+			}
+			if !reflect.DeepEqual(params, test.Params) {
+				t.Errorf("expected %v, got %v", test.Params, params)
+			}
+		})
+	}
+}
+
 // TestMessageToQueryParametersNoRecursive, is a check that cyclical references between messages
 // are not falsely detected given previous known edge-cases.
 func TestMessageToQueryParametersNoRecursive(t *testing.T) {


### PR DESCRIPTION

When a member of a oneof group is bound to a path parameter, the other members of that group can never be set, so they should not be emitted as query parameters. This mirrors the existing isBodySameOneOf handling for request bodies.

The check is done in messageToQueryParameters, where every field is a direct field of the request message, and compares against the first component of the path parameter's field path. Comparing oneof indices further down the recursion is unsound because oneof_index is only unique within its containing message.

Fixes #2494
