### PR TITLE
 fix(openapiv2): emit map key type in query parameter names

### DIFF
--- a/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_check_get_query_params_parameters.go
+++ b/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_check_get_query_params_parameters.go
@@ -128,22 +128,19 @@ type ABitOfEverythingServiceCheckGetQueryParamsParams struct {
 	// Format: int64
 	Int64Value string
 
-	/* MapValue.
+	/* MapValueString.
 
 	   map of numeric enum
 	*/
-	MapValue *string
+	MapValueString *string
 
-	// MappedNestedValue.
-	MappedNestedValue *string
-
-	/* MappedStringValue.
+	/* MappedStringValueString.
 
 	     Map of string title
 
 	Map of string description.
 	*/
-	MappedStringValue *string
+	MappedStringValueString *string
 
 	// NestedAnnotationAmount.
 	//
@@ -559,37 +556,26 @@ func (o *ABitOfEverythingServiceCheckGetQueryParamsParams) SetInt64Value(int64Va
 	o.Int64Value = int64Value
 }
 
-// WithMapValue adds the mapValue to the a bit of everything service check get query params params
-func (o *ABitOfEverythingServiceCheckGetQueryParamsParams) WithMapValue(mapValue *string) *ABitOfEverythingServiceCheckGetQueryParamsParams {
-	o.SetMapValue(mapValue)
+// WithMapValueString adds the mapValueString to the a bit of everything service check get query params params
+func (o *ABitOfEverythingServiceCheckGetQueryParamsParams) WithMapValueString(mapValueString *string) *ABitOfEverythingServiceCheckGetQueryParamsParams {
+	o.SetMapValueString(mapValueString)
 	return o
 }
 
-// SetMapValue adds the mapValue to the a bit of everything service check get query params params
-func (o *ABitOfEverythingServiceCheckGetQueryParamsParams) SetMapValue(mapValue *string) {
-	o.MapValue = mapValue
+// SetMapValueString adds the mapValueString to the a bit of everything service check get query params params
+func (o *ABitOfEverythingServiceCheckGetQueryParamsParams) SetMapValueString(mapValueString *string) {
+	o.MapValueString = mapValueString
 }
 
-// WithMappedNestedValue adds the mappedNestedValue to the a bit of everything service check get query params params
-func (o *ABitOfEverythingServiceCheckGetQueryParamsParams) WithMappedNestedValue(mappedNestedValue *string) *ABitOfEverythingServiceCheckGetQueryParamsParams {
-	o.SetMappedNestedValue(mappedNestedValue)
+// WithMappedStringValueString adds the mappedStringValueString to the a bit of everything service check get query params params
+func (o *ABitOfEverythingServiceCheckGetQueryParamsParams) WithMappedStringValueString(mappedStringValueString *string) *ABitOfEverythingServiceCheckGetQueryParamsParams {
+	o.SetMappedStringValueString(mappedStringValueString)
 	return o
 }
 
-// SetMappedNestedValue adds the mappedNestedValue to the a bit of everything service check get query params params
-func (o *ABitOfEverythingServiceCheckGetQueryParamsParams) SetMappedNestedValue(mappedNestedValue *string) {
-	o.MappedNestedValue = mappedNestedValue
-}
-
-// WithMappedStringValue adds the mappedStringValue to the a bit of everything service check get query params params
-func (o *ABitOfEverythingServiceCheckGetQueryParamsParams) WithMappedStringValue(mappedStringValue *string) *ABitOfEverythingServiceCheckGetQueryParamsParams {
-	o.SetMappedStringValue(mappedStringValue)
-	return o
-}
-
-// SetMappedStringValue adds the mappedStringValue to the a bit of everything service check get query params params
-func (o *ABitOfEverythingServiceCheckGetQueryParamsParams) SetMappedStringValue(mappedStringValue *string) {
-	o.MappedStringValue = mappedStringValue
+// SetMappedStringValueString adds the mappedStringValueString to the a bit of everything service check get query params params
+func (o *ABitOfEverythingServiceCheckGetQueryParamsParams) SetMappedStringValueString(mappedStringValueString *string) {
+	o.MappedStringValueString = mappedStringValueString
 }
 
 // WithNestedAnnotationAmount adds the nestedAnnotationAmount to the a bit of everything service check get query params params
@@ -1173,52 +1159,35 @@ func (o *ABitOfEverythingServiceCheckGetQueryParamsParams) WriteToRequest(r runt
 		}
 	}
 
-	if o.MapValue != nil {
+	if o.MapValueString != nil {
 
-		// query param mapValue
-		var qrMapValue string
+		// query param mapValue[string]
+		var qrMapValueString string
 
-		if o.MapValue != nil {
-			qrMapValue = *o.MapValue
+		if o.MapValueString != nil {
+			qrMapValueString = *o.MapValueString
 		}
-		qMapValue := qrMapValue
-		if qMapValue != "" {
+		qMapValueString := qrMapValueString
+		if qMapValueString != "" {
 
-			if err := r.SetQueryParam("mapValue", qMapValue); err != nil {
+			if err := r.SetQueryParam("mapValue[string]", qMapValueString); err != nil {
 				return err
 			}
 		}
 	}
 
-	if o.MappedNestedValue != nil {
+	if o.MappedStringValueString != nil {
 
-		// query param mappedNestedValue
-		var qrMappedNestedValue string
+		// query param mappedStringValue[string]
+		var qrMappedStringValueString string
 
-		if o.MappedNestedValue != nil {
-			qrMappedNestedValue = *o.MappedNestedValue
+		if o.MappedStringValueString != nil {
+			qrMappedStringValueString = *o.MappedStringValueString
 		}
-		qMappedNestedValue := qrMappedNestedValue
-		if qMappedNestedValue != "" {
+		qMappedStringValueString := qrMappedStringValueString
+		if qMappedStringValueString != "" {
 
-			if err := r.SetQueryParam("mappedNestedValue", qMappedNestedValue); err != nil {
-				return err
-			}
-		}
-	}
-
-	if o.MappedStringValue != nil {
-
-		// query param mappedStringValue
-		var qrMappedStringValue string
-
-		if o.MappedStringValue != nil {
-			qrMappedStringValue = *o.MappedStringValue
-		}
-		qMappedStringValue := qrMappedStringValue
-		if qMappedStringValue != "" {
-
-			if err := r.SetQueryParam("mappedStringValue", qMappedStringValue); err != nil {
+			if err := r.SetQueryParam("mappedStringValue[string]", qMappedStringValueString); err != nil {
 				return err
 			}
 		}

--- a/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_check_nested_enum_get_query_params_parameters.go
+++ b/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_check_nested_enum_get_query_params_parameters.go
@@ -128,22 +128,19 @@ type ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams struct {
 	// Format: int64
 	Int64Value string
 
-	/* MapValue.
+	/* MapValueString.
 
 	   map of numeric enum
 	*/
-	MapValue *string
+	MapValueString *string
 
-	// MappedNestedValue.
-	MappedNestedValue *string
-
-	/* MappedStringValue.
+	/* MappedStringValueString.
 
 	     Map of string title
 
 	Map of string description.
 	*/
-	MappedStringValue *string
+	MappedStringValueString *string
 
 	// NestedAnnotationAmount.
 	//
@@ -543,37 +540,26 @@ func (o *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams) SetInt64Val
 	o.Int64Value = int64Value
 }
 
-// WithMapValue adds the mapValue to the a bit of everything service check nested enum get query params params
-func (o *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams) WithMapValue(mapValue *string) *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams {
-	o.SetMapValue(mapValue)
+// WithMapValueString adds the mapValueString to the a bit of everything service check nested enum get query params params
+func (o *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams) WithMapValueString(mapValueString *string) *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams {
+	o.SetMapValueString(mapValueString)
 	return o
 }
 
-// SetMapValue adds the mapValue to the a bit of everything service check nested enum get query params params
-func (o *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams) SetMapValue(mapValue *string) {
-	o.MapValue = mapValue
+// SetMapValueString adds the mapValueString to the a bit of everything service check nested enum get query params params
+func (o *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams) SetMapValueString(mapValueString *string) {
+	o.MapValueString = mapValueString
 }
 
-// WithMappedNestedValue adds the mappedNestedValue to the a bit of everything service check nested enum get query params params
-func (o *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams) WithMappedNestedValue(mappedNestedValue *string) *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams {
-	o.SetMappedNestedValue(mappedNestedValue)
+// WithMappedStringValueString adds the mappedStringValueString to the a bit of everything service check nested enum get query params params
+func (o *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams) WithMappedStringValueString(mappedStringValueString *string) *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams {
+	o.SetMappedStringValueString(mappedStringValueString)
 	return o
 }
 
-// SetMappedNestedValue adds the mappedNestedValue to the a bit of everything service check nested enum get query params params
-func (o *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams) SetMappedNestedValue(mappedNestedValue *string) {
-	o.MappedNestedValue = mappedNestedValue
-}
-
-// WithMappedStringValue adds the mappedStringValue to the a bit of everything service check nested enum get query params params
-func (o *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams) WithMappedStringValue(mappedStringValue *string) *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams {
-	o.SetMappedStringValue(mappedStringValue)
-	return o
-}
-
-// SetMappedStringValue adds the mappedStringValue to the a bit of everything service check nested enum get query params params
-func (o *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams) SetMappedStringValue(mappedStringValue *string) {
-	o.MappedStringValue = mappedStringValue
+// SetMappedStringValueString adds the mappedStringValueString to the a bit of everything service check nested enum get query params params
+func (o *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams) SetMappedStringValueString(mappedStringValueString *string) {
+	o.MappedStringValueString = mappedStringValueString
 }
 
 // WithNestedAnnotationAmount adds the nestedAnnotationAmount to the a bit of everything service check nested enum get query params params
@@ -1157,52 +1143,35 @@ func (o *ABitOfEverythingServiceCheckNestedEnumGetQueryParamsParams) WriteToRequ
 		}
 	}
 
-	if o.MapValue != nil {
+	if o.MapValueString != nil {
 
-		// query param mapValue
-		var qrMapValue string
+		// query param mapValue[string]
+		var qrMapValueString string
 
-		if o.MapValue != nil {
-			qrMapValue = *o.MapValue
+		if o.MapValueString != nil {
+			qrMapValueString = *o.MapValueString
 		}
-		qMapValue := qrMapValue
-		if qMapValue != "" {
+		qMapValueString := qrMapValueString
+		if qMapValueString != "" {
 
-			if err := r.SetQueryParam("mapValue", qMapValue); err != nil {
+			if err := r.SetQueryParam("mapValue[string]", qMapValueString); err != nil {
 				return err
 			}
 		}
 	}
 
-	if o.MappedNestedValue != nil {
+	if o.MappedStringValueString != nil {
 
-		// query param mappedNestedValue
-		var qrMappedNestedValue string
+		// query param mappedStringValue[string]
+		var qrMappedStringValueString string
 
-		if o.MappedNestedValue != nil {
-			qrMappedNestedValue = *o.MappedNestedValue
+		if o.MappedStringValueString != nil {
+			qrMappedStringValueString = *o.MappedStringValueString
 		}
-		qMappedNestedValue := qrMappedNestedValue
-		if qMappedNestedValue != "" {
+		qMappedStringValueString := qrMappedStringValueString
+		if qMappedStringValueString != "" {
 
-			if err := r.SetQueryParam("mappedNestedValue", qMappedNestedValue); err != nil {
-				return err
-			}
-		}
-	}
-
-	if o.MappedStringValue != nil {
-
-		// query param mappedStringValue
-		var qrMappedStringValue string
-
-		if o.MappedStringValue != nil {
-			qrMappedStringValue = *o.MappedStringValue
-		}
-		qMappedStringValue := qrMappedStringValue
-		if qMappedStringValue != "" {
-
-			if err := r.SetQueryParam("mappedStringValue", qMappedStringValue); err != nil {
+			if err := r.SetQueryParam("mappedStringValue[string]", qMappedStringValueString); err != nil {
 				return err
 			}
 		}

--- a/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_check_post_query_params_parameters.go
+++ b/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_check_post_query_params_parameters.go
@@ -130,22 +130,19 @@ type ABitOfEverythingServiceCheckPostQueryParamsParams struct {
 	// Format: int64
 	Int64Value string
 
-	/* MapValue.
+	/* MapValueString.
 
 	   map of numeric enum
 	*/
-	MapValue *string
+	MapValueString *string
 
-	// MappedNestedValue.
-	MappedNestedValue *string
-
-	/* MappedStringValue.
+	/* MappedStringValueString.
 
 	     Map of string title
 
 	Map of string description.
 	*/
-	MappedStringValue *string
+	MappedStringValueString *string
 
 	// NestedAnnotationAmount.
 	//
@@ -545,37 +542,26 @@ func (o *ABitOfEverythingServiceCheckPostQueryParamsParams) SetInt64Value(int64V
 	o.Int64Value = int64Value
 }
 
-// WithMapValue adds the mapValue to the a bit of everything service check post query params params
-func (o *ABitOfEverythingServiceCheckPostQueryParamsParams) WithMapValue(mapValue *string) *ABitOfEverythingServiceCheckPostQueryParamsParams {
-	o.SetMapValue(mapValue)
+// WithMapValueString adds the mapValueString to the a bit of everything service check post query params params
+func (o *ABitOfEverythingServiceCheckPostQueryParamsParams) WithMapValueString(mapValueString *string) *ABitOfEverythingServiceCheckPostQueryParamsParams {
+	o.SetMapValueString(mapValueString)
 	return o
 }
 
-// SetMapValue adds the mapValue to the a bit of everything service check post query params params
-func (o *ABitOfEverythingServiceCheckPostQueryParamsParams) SetMapValue(mapValue *string) {
-	o.MapValue = mapValue
+// SetMapValueString adds the mapValueString to the a bit of everything service check post query params params
+func (o *ABitOfEverythingServiceCheckPostQueryParamsParams) SetMapValueString(mapValueString *string) {
+	o.MapValueString = mapValueString
 }
 
-// WithMappedNestedValue adds the mappedNestedValue to the a bit of everything service check post query params params
-func (o *ABitOfEverythingServiceCheckPostQueryParamsParams) WithMappedNestedValue(mappedNestedValue *string) *ABitOfEverythingServiceCheckPostQueryParamsParams {
-	o.SetMappedNestedValue(mappedNestedValue)
+// WithMappedStringValueString adds the mappedStringValueString to the a bit of everything service check post query params params
+func (o *ABitOfEverythingServiceCheckPostQueryParamsParams) WithMappedStringValueString(mappedStringValueString *string) *ABitOfEverythingServiceCheckPostQueryParamsParams {
+	o.SetMappedStringValueString(mappedStringValueString)
 	return o
 }
 
-// SetMappedNestedValue adds the mappedNestedValue to the a bit of everything service check post query params params
-func (o *ABitOfEverythingServiceCheckPostQueryParamsParams) SetMappedNestedValue(mappedNestedValue *string) {
-	o.MappedNestedValue = mappedNestedValue
-}
-
-// WithMappedStringValue adds the mappedStringValue to the a bit of everything service check post query params params
-func (o *ABitOfEverythingServiceCheckPostQueryParamsParams) WithMappedStringValue(mappedStringValue *string) *ABitOfEverythingServiceCheckPostQueryParamsParams {
-	o.SetMappedStringValue(mappedStringValue)
-	return o
-}
-
-// SetMappedStringValue adds the mappedStringValue to the a bit of everything service check post query params params
-func (o *ABitOfEverythingServiceCheckPostQueryParamsParams) SetMappedStringValue(mappedStringValue *string) {
-	o.MappedStringValue = mappedStringValue
+// SetMappedStringValueString adds the mappedStringValueString to the a bit of everything service check post query params params
+func (o *ABitOfEverythingServiceCheckPostQueryParamsParams) SetMappedStringValueString(mappedStringValueString *string) {
+	o.MappedStringValueString = mappedStringValueString
 }
 
 // WithNestedAnnotationAmount adds the nestedAnnotationAmount to the a bit of everything service check post query params params
@@ -1148,52 +1134,35 @@ func (o *ABitOfEverythingServiceCheckPostQueryParamsParams) WriteToRequest(r run
 		}
 	}
 
-	if o.MapValue != nil {
+	if o.MapValueString != nil {
 
-		// query param mapValue
-		var qrMapValue string
+		// query param mapValue[string]
+		var qrMapValueString string
 
-		if o.MapValue != nil {
-			qrMapValue = *o.MapValue
+		if o.MapValueString != nil {
+			qrMapValueString = *o.MapValueString
 		}
-		qMapValue := qrMapValue
-		if qMapValue != "" {
+		qMapValueString := qrMapValueString
+		if qMapValueString != "" {
 
-			if err := r.SetQueryParam("mapValue", qMapValue); err != nil {
+			if err := r.SetQueryParam("mapValue[string]", qMapValueString); err != nil {
 				return err
 			}
 		}
 	}
 
-	if o.MappedNestedValue != nil {
+	if o.MappedStringValueString != nil {
 
-		// query param mappedNestedValue
-		var qrMappedNestedValue string
+		// query param mappedStringValue[string]
+		var qrMappedStringValueString string
 
-		if o.MappedNestedValue != nil {
-			qrMappedNestedValue = *o.MappedNestedValue
+		if o.MappedStringValueString != nil {
+			qrMappedStringValueString = *o.MappedStringValueString
 		}
-		qMappedNestedValue := qrMappedNestedValue
-		if qMappedNestedValue != "" {
+		qMappedStringValueString := qrMappedStringValueString
+		if qMappedStringValueString != "" {
 
-			if err := r.SetQueryParam("mappedNestedValue", qMappedNestedValue); err != nil {
-				return err
-			}
-		}
-	}
-
-	if o.MappedStringValue != nil {
-
-		// query param mappedStringValue
-		var qrMappedStringValue string
-
-		if o.MappedStringValue != nil {
-			qrMappedStringValue = *o.MappedStringValue
-		}
-		qMappedStringValue := qrMappedStringValue
-		if qMappedStringValue != "" {
-
-			if err := r.SetQueryParam("mappedStringValue", qMappedStringValue); err != nil {
+			if err := r.SetQueryParam("mappedStringValue[string]", qMappedStringValueString); err != nil {
 				return err
 			}
 		}

--- a/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_create_parameters.go
+++ b/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_create_parameters.go
@@ -115,22 +115,19 @@ type ABitOfEverythingServiceCreateParams struct {
 	// Format: int64
 	Int64Value string
 
-	/* MapValue.
+	/* MapValueString.
 
 	   map of numeric enum
 	*/
-	MapValue *string
+	MapValueString *string
 
-	// MappedNestedValue.
-	MappedNestedValue *string
-
-	/* MappedStringValue.
+	/* MappedStringValueString.
 
 	     Map of string title
 
 	Map of string description.
 	*/
-	MappedStringValue *string
+	MappedStringValueString *string
 
 	// NestedAnnotationAmount.
 	//
@@ -536,37 +533,26 @@ func (o *ABitOfEverythingServiceCreateParams) SetInt64Value(int64Value string) {
 	o.Int64Value = int64Value
 }
 
-// WithMapValue adds the mapValue to the a bit of everything service create params
-func (o *ABitOfEverythingServiceCreateParams) WithMapValue(mapValue *string) *ABitOfEverythingServiceCreateParams {
-	o.SetMapValue(mapValue)
+// WithMapValueString adds the mapValueString to the a bit of everything service create params
+func (o *ABitOfEverythingServiceCreateParams) WithMapValueString(mapValueString *string) *ABitOfEverythingServiceCreateParams {
+	o.SetMapValueString(mapValueString)
 	return o
 }
 
-// SetMapValue adds the mapValue to the a bit of everything service create params
-func (o *ABitOfEverythingServiceCreateParams) SetMapValue(mapValue *string) {
-	o.MapValue = mapValue
+// SetMapValueString adds the mapValueString to the a bit of everything service create params
+func (o *ABitOfEverythingServiceCreateParams) SetMapValueString(mapValueString *string) {
+	o.MapValueString = mapValueString
 }
 
-// WithMappedNestedValue adds the mappedNestedValue to the a bit of everything service create params
-func (o *ABitOfEverythingServiceCreateParams) WithMappedNestedValue(mappedNestedValue *string) *ABitOfEverythingServiceCreateParams {
-	o.SetMappedNestedValue(mappedNestedValue)
+// WithMappedStringValueString adds the mappedStringValueString to the a bit of everything service create params
+func (o *ABitOfEverythingServiceCreateParams) WithMappedStringValueString(mappedStringValueString *string) *ABitOfEverythingServiceCreateParams {
+	o.SetMappedStringValueString(mappedStringValueString)
 	return o
 }
 
-// SetMappedNestedValue adds the mappedNestedValue to the a bit of everything service create params
-func (o *ABitOfEverythingServiceCreateParams) SetMappedNestedValue(mappedNestedValue *string) {
-	o.MappedNestedValue = mappedNestedValue
-}
-
-// WithMappedStringValue adds the mappedStringValue to the a bit of everything service create params
-func (o *ABitOfEverythingServiceCreateParams) WithMappedStringValue(mappedStringValue *string) *ABitOfEverythingServiceCreateParams {
-	o.SetMappedStringValue(mappedStringValue)
-	return o
-}
-
-// SetMappedStringValue adds the mappedStringValue to the a bit of everything service create params
-func (o *ABitOfEverythingServiceCreateParams) SetMappedStringValue(mappedStringValue *string) {
-	o.MappedStringValue = mappedStringValue
+// SetMappedStringValueString adds the mappedStringValueString to the a bit of everything service create params
+func (o *ABitOfEverythingServiceCreateParams) SetMappedStringValueString(mappedStringValueString *string) {
+	o.MappedStringValueString = mappedStringValueString
 }
 
 // WithNestedAnnotationAmount adds the nestedAnnotationAmount to the a bit of everything service create params
@@ -1074,52 +1060,35 @@ func (o *ABitOfEverythingServiceCreateParams) WriteToRequest(r runtime.ClientReq
 		return err
 	}
 
-	if o.MapValue != nil {
+	if o.MapValueString != nil {
 
-		// query param mapValue
-		var qrMapValue string
+		// query param mapValue[string]
+		var qrMapValueString string
 
-		if o.MapValue != nil {
-			qrMapValue = *o.MapValue
+		if o.MapValueString != nil {
+			qrMapValueString = *o.MapValueString
 		}
-		qMapValue := qrMapValue
-		if qMapValue != "" {
+		qMapValueString := qrMapValueString
+		if qMapValueString != "" {
 
-			if err := r.SetQueryParam("mapValue", qMapValue); err != nil {
+			if err := r.SetQueryParam("mapValue[string]", qMapValueString); err != nil {
 				return err
 			}
 		}
 	}
 
-	if o.MappedNestedValue != nil {
+	if o.MappedStringValueString != nil {
 
-		// query param mappedNestedValue
-		var qrMappedNestedValue string
+		// query param mappedStringValue[string]
+		var qrMappedStringValueString string
 
-		if o.MappedNestedValue != nil {
-			qrMappedNestedValue = *o.MappedNestedValue
+		if o.MappedStringValueString != nil {
+			qrMappedStringValueString = *o.MappedStringValueString
 		}
-		qMappedNestedValue := qrMappedNestedValue
-		if qMappedNestedValue != "" {
+		qMappedStringValueString := qrMappedStringValueString
+		if qMappedStringValueString != "" {
 
-			if err := r.SetQueryParam("mappedNestedValue", qMappedNestedValue); err != nil {
-				return err
-			}
-		}
-	}
-
-	if o.MappedStringValue != nil {
-
-		// query param mappedStringValue
-		var qrMappedStringValue string
-
-		if o.MappedStringValue != nil {
-			qrMappedStringValue = *o.MappedStringValue
-		}
-		qMappedStringValue := qrMappedStringValue
-		if qMappedStringValue != "" {
-
-			if err := r.SetQueryParam("mappedStringValue", qMappedStringValue); err != nil {
+			if err := r.SetQueryParam("mappedStringValue[string]", qMappedStringValueString); err != nil {
 				return err
 			}
 		}

--- a/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_custom2_parameters.go
+++ b/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_custom2_parameters.go
@@ -128,22 +128,19 @@ type ABitOfEverythingServiceCustom2Params struct {
 	// Format: int64
 	Int64Value string
 
-	/* MapValue.
+	/* MapValueString.
 
 	   map of numeric enum
 	*/
-	MapValue *string
+	MapValueString *string
 
-	// MappedNestedValue.
-	MappedNestedValue *string
-
-	/* MappedStringValue.
+	/* MappedStringValueString.
 
 	     Map of string title
 
 	Map of string description.
 	*/
-	MappedStringValue *string
+	MappedStringValueString *string
 
 	// NestedAnnotationAmount.
 	//
@@ -565,37 +562,26 @@ func (o *ABitOfEverythingServiceCustom2Params) SetInt64Value(int64Value string) 
 	o.Int64Value = int64Value
 }
 
-// WithMapValue adds the mapValue to the a bit of everything service custom2 params
-func (o *ABitOfEverythingServiceCustom2Params) WithMapValue(mapValue *string) *ABitOfEverythingServiceCustom2Params {
-	o.SetMapValue(mapValue)
+// WithMapValueString adds the mapValueString to the a bit of everything service custom2 params
+func (o *ABitOfEverythingServiceCustom2Params) WithMapValueString(mapValueString *string) *ABitOfEverythingServiceCustom2Params {
+	o.SetMapValueString(mapValueString)
 	return o
 }
 
-// SetMapValue adds the mapValue to the a bit of everything service custom2 params
-func (o *ABitOfEverythingServiceCustom2Params) SetMapValue(mapValue *string) {
-	o.MapValue = mapValue
+// SetMapValueString adds the mapValueString to the a bit of everything service custom2 params
+func (o *ABitOfEverythingServiceCustom2Params) SetMapValueString(mapValueString *string) {
+	o.MapValueString = mapValueString
 }
 
-// WithMappedNestedValue adds the mappedNestedValue to the a bit of everything service custom2 params
-func (o *ABitOfEverythingServiceCustom2Params) WithMappedNestedValue(mappedNestedValue *string) *ABitOfEverythingServiceCustom2Params {
-	o.SetMappedNestedValue(mappedNestedValue)
+// WithMappedStringValueString adds the mappedStringValueString to the a bit of everything service custom2 params
+func (o *ABitOfEverythingServiceCustom2Params) WithMappedStringValueString(mappedStringValueString *string) *ABitOfEverythingServiceCustom2Params {
+	o.SetMappedStringValueString(mappedStringValueString)
 	return o
 }
 
-// SetMappedNestedValue adds the mappedNestedValue to the a bit of everything service custom2 params
-func (o *ABitOfEverythingServiceCustom2Params) SetMappedNestedValue(mappedNestedValue *string) {
-	o.MappedNestedValue = mappedNestedValue
-}
-
-// WithMappedStringValue adds the mappedStringValue to the a bit of everything service custom2 params
-func (o *ABitOfEverythingServiceCustom2Params) WithMappedStringValue(mappedStringValue *string) *ABitOfEverythingServiceCustom2Params {
-	o.SetMappedStringValue(mappedStringValue)
-	return o
-}
-
-// SetMappedStringValue adds the mappedStringValue to the a bit of everything service custom2 params
-func (o *ABitOfEverythingServiceCustom2Params) SetMappedStringValue(mappedStringValue *string) {
-	o.MappedStringValue = mappedStringValue
+// SetMappedStringValueString adds the mappedStringValueString to the a bit of everything service custom2 params
+func (o *ABitOfEverythingServiceCustom2Params) SetMappedStringValueString(mappedStringValueString *string) {
+	o.MappedStringValueString = mappedStringValueString
 }
 
 // WithNestedAnnotationAmount adds the nestedAnnotationAmount to the a bit of everything service custom2 params
@@ -1190,52 +1176,35 @@ func (o *ABitOfEverythingServiceCustom2Params) WriteToRequest(r runtime.ClientRe
 		}
 	}
 
-	if o.MapValue != nil {
+	if o.MapValueString != nil {
 
-		// query param mapValue
-		var qrMapValue string
+		// query param mapValue[string]
+		var qrMapValueString string
 
-		if o.MapValue != nil {
-			qrMapValue = *o.MapValue
+		if o.MapValueString != nil {
+			qrMapValueString = *o.MapValueString
 		}
-		qMapValue := qrMapValue
-		if qMapValue != "" {
+		qMapValueString := qrMapValueString
+		if qMapValueString != "" {
 
-			if err := r.SetQueryParam("mapValue", qMapValue); err != nil {
+			if err := r.SetQueryParam("mapValue[string]", qMapValueString); err != nil {
 				return err
 			}
 		}
 	}
 
-	if o.MappedNestedValue != nil {
+	if o.MappedStringValueString != nil {
 
-		// query param mappedNestedValue
-		var qrMappedNestedValue string
+		// query param mappedStringValue[string]
+		var qrMappedStringValueString string
 
-		if o.MappedNestedValue != nil {
-			qrMappedNestedValue = *o.MappedNestedValue
+		if o.MappedStringValueString != nil {
+			qrMappedStringValueString = *o.MappedStringValueString
 		}
-		qMappedNestedValue := qrMappedNestedValue
-		if qMappedNestedValue != "" {
+		qMappedStringValueString := qrMappedStringValueString
+		if qMappedStringValueString != "" {
 
-			if err := r.SetQueryParam("mappedNestedValue", qMappedNestedValue); err != nil {
-				return err
-			}
-		}
-	}
-
-	if o.MappedStringValue != nil {
-
-		// query param mappedStringValue
-		var qrMappedStringValue string
-
-		if o.MappedStringValue != nil {
-			qrMappedStringValue = *o.MappedStringValue
-		}
-		qMappedStringValue := qrMappedStringValue
-		if qMappedStringValue != "" {
-
-			if err := r.SetQueryParam("mappedStringValue", qMappedStringValue); err != nil {
+			if err := r.SetQueryParam("mappedStringValue[string]", qMappedStringValueString); err != nil {
 				return err
 			}
 		}

--- a/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_custom_options_request_parameters.go
+++ b/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_custom_options_request_parameters.go
@@ -128,22 +128,19 @@ type ABitOfEverythingServiceCustomOptionsRequestParams struct {
 	// Format: int64
 	Int64Value string
 
-	/* MapValue.
+	/* MapValueString.
 
 	   map of numeric enum
 	*/
-	MapValue *string
+	MapValueString *string
 
-	// MappedNestedValue.
-	MappedNestedValue *string
-
-	/* MappedStringValue.
+	/* MappedStringValueString.
 
 	     Map of string title
 
 	Map of string description.
 	*/
-	MappedStringValue *string
+	MappedStringValueString *string
 
 	// NestedAnnotationAmount.
 	//
@@ -565,37 +562,26 @@ func (o *ABitOfEverythingServiceCustomOptionsRequestParams) SetInt64Value(int64V
 	o.Int64Value = int64Value
 }
 
-// WithMapValue adds the mapValue to the a bit of everything service custom options request params
-func (o *ABitOfEverythingServiceCustomOptionsRequestParams) WithMapValue(mapValue *string) *ABitOfEverythingServiceCustomOptionsRequestParams {
-	o.SetMapValue(mapValue)
+// WithMapValueString adds the mapValueString to the a bit of everything service custom options request params
+func (o *ABitOfEverythingServiceCustomOptionsRequestParams) WithMapValueString(mapValueString *string) *ABitOfEverythingServiceCustomOptionsRequestParams {
+	o.SetMapValueString(mapValueString)
 	return o
 }
 
-// SetMapValue adds the mapValue to the a bit of everything service custom options request params
-func (o *ABitOfEverythingServiceCustomOptionsRequestParams) SetMapValue(mapValue *string) {
-	o.MapValue = mapValue
+// SetMapValueString adds the mapValueString to the a bit of everything service custom options request params
+func (o *ABitOfEverythingServiceCustomOptionsRequestParams) SetMapValueString(mapValueString *string) {
+	o.MapValueString = mapValueString
 }
 
-// WithMappedNestedValue adds the mappedNestedValue to the a bit of everything service custom options request params
-func (o *ABitOfEverythingServiceCustomOptionsRequestParams) WithMappedNestedValue(mappedNestedValue *string) *ABitOfEverythingServiceCustomOptionsRequestParams {
-	o.SetMappedNestedValue(mappedNestedValue)
+// WithMappedStringValueString adds the mappedStringValueString to the a bit of everything service custom options request params
+func (o *ABitOfEverythingServiceCustomOptionsRequestParams) WithMappedStringValueString(mappedStringValueString *string) *ABitOfEverythingServiceCustomOptionsRequestParams {
+	o.SetMappedStringValueString(mappedStringValueString)
 	return o
 }
 
-// SetMappedNestedValue adds the mappedNestedValue to the a bit of everything service custom options request params
-func (o *ABitOfEverythingServiceCustomOptionsRequestParams) SetMappedNestedValue(mappedNestedValue *string) {
-	o.MappedNestedValue = mappedNestedValue
-}
-
-// WithMappedStringValue adds the mappedStringValue to the a bit of everything service custom options request params
-func (o *ABitOfEverythingServiceCustomOptionsRequestParams) WithMappedStringValue(mappedStringValue *string) *ABitOfEverythingServiceCustomOptionsRequestParams {
-	o.SetMappedStringValue(mappedStringValue)
-	return o
-}
-
-// SetMappedStringValue adds the mappedStringValue to the a bit of everything service custom options request params
-func (o *ABitOfEverythingServiceCustomOptionsRequestParams) SetMappedStringValue(mappedStringValue *string) {
-	o.MappedStringValue = mappedStringValue
+// SetMappedStringValueString adds the mappedStringValueString to the a bit of everything service custom options request params
+func (o *ABitOfEverythingServiceCustomOptionsRequestParams) SetMappedStringValueString(mappedStringValueString *string) {
+	o.MappedStringValueString = mappedStringValueString
 }
 
 // WithNestedAnnotationAmount adds the nestedAnnotationAmount to the a bit of everything service custom options request params
@@ -1190,52 +1176,35 @@ func (o *ABitOfEverythingServiceCustomOptionsRequestParams) WriteToRequest(r run
 		}
 	}
 
-	if o.MapValue != nil {
+	if o.MapValueString != nil {
 
-		// query param mapValue
-		var qrMapValue string
+		// query param mapValue[string]
+		var qrMapValueString string
 
-		if o.MapValue != nil {
-			qrMapValue = *o.MapValue
+		if o.MapValueString != nil {
+			qrMapValueString = *o.MapValueString
 		}
-		qMapValue := qrMapValue
-		if qMapValue != "" {
+		qMapValueString := qrMapValueString
+		if qMapValueString != "" {
 
-			if err := r.SetQueryParam("mapValue", qMapValue); err != nil {
+			if err := r.SetQueryParam("mapValue[string]", qMapValueString); err != nil {
 				return err
 			}
 		}
 	}
 
-	if o.MappedNestedValue != nil {
+	if o.MappedStringValueString != nil {
 
-		// query param mappedNestedValue
-		var qrMappedNestedValue string
+		// query param mappedStringValue[string]
+		var qrMappedStringValueString string
 
-		if o.MappedNestedValue != nil {
-			qrMappedNestedValue = *o.MappedNestedValue
+		if o.MappedStringValueString != nil {
+			qrMappedStringValueString = *o.MappedStringValueString
 		}
-		qMappedNestedValue := qrMappedNestedValue
-		if qMappedNestedValue != "" {
+		qMappedStringValueString := qrMappedStringValueString
+		if qMappedStringValueString != "" {
 
-			if err := r.SetQueryParam("mappedNestedValue", qMappedNestedValue); err != nil {
-				return err
-			}
-		}
-	}
-
-	if o.MappedStringValue != nil {
-
-		// query param mappedStringValue
-		var qrMappedStringValue string
-
-		if o.MappedStringValue != nil {
-			qrMappedStringValue = *o.MappedStringValue
-		}
-		qMappedStringValue := qrMappedStringValue
-		if qMappedStringValue != "" {
-
-			if err := r.SetQueryParam("mappedStringValue", qMappedStringValue); err != nil {
+			if err := r.SetQueryParam("mappedStringValue[string]", qMappedStringValueString); err != nil {
 				return err
 			}
 		}

--- a/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_custom_parameters.go
+++ b/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_custom_parameters.go
@@ -128,22 +128,19 @@ type ABitOfEverythingServiceCustomParams struct {
 	// Format: int64
 	Int64Value string
 
-	/* MapValue.
+	/* MapValueString.
 
 	   map of numeric enum
 	*/
-	MapValue *string
+	MapValueString *string
 
-	// MappedNestedValue.
-	MappedNestedValue *string
-
-	/* MappedStringValue.
+	/* MappedStringValueString.
 
 	     Map of string title
 
 	Map of string description.
 	*/
-	MappedStringValue *string
+	MappedStringValueString *string
 
 	// NestedAnnotationAmount.
 	//
@@ -565,37 +562,26 @@ func (o *ABitOfEverythingServiceCustomParams) SetInt64Value(int64Value string) {
 	o.Int64Value = int64Value
 }
 
-// WithMapValue adds the mapValue to the a bit of everything service custom params
-func (o *ABitOfEverythingServiceCustomParams) WithMapValue(mapValue *string) *ABitOfEverythingServiceCustomParams {
-	o.SetMapValue(mapValue)
+// WithMapValueString adds the mapValueString to the a bit of everything service custom params
+func (o *ABitOfEverythingServiceCustomParams) WithMapValueString(mapValueString *string) *ABitOfEverythingServiceCustomParams {
+	o.SetMapValueString(mapValueString)
 	return o
 }
 
-// SetMapValue adds the mapValue to the a bit of everything service custom params
-func (o *ABitOfEverythingServiceCustomParams) SetMapValue(mapValue *string) {
-	o.MapValue = mapValue
+// SetMapValueString adds the mapValueString to the a bit of everything service custom params
+func (o *ABitOfEverythingServiceCustomParams) SetMapValueString(mapValueString *string) {
+	o.MapValueString = mapValueString
 }
 
-// WithMappedNestedValue adds the mappedNestedValue to the a bit of everything service custom params
-func (o *ABitOfEverythingServiceCustomParams) WithMappedNestedValue(mappedNestedValue *string) *ABitOfEverythingServiceCustomParams {
-	o.SetMappedNestedValue(mappedNestedValue)
+// WithMappedStringValueString adds the mappedStringValueString to the a bit of everything service custom params
+func (o *ABitOfEverythingServiceCustomParams) WithMappedStringValueString(mappedStringValueString *string) *ABitOfEverythingServiceCustomParams {
+	o.SetMappedStringValueString(mappedStringValueString)
 	return o
 }
 
-// SetMappedNestedValue adds the mappedNestedValue to the a bit of everything service custom params
-func (o *ABitOfEverythingServiceCustomParams) SetMappedNestedValue(mappedNestedValue *string) {
-	o.MappedNestedValue = mappedNestedValue
-}
-
-// WithMappedStringValue adds the mappedStringValue to the a bit of everything service custom params
-func (o *ABitOfEverythingServiceCustomParams) WithMappedStringValue(mappedStringValue *string) *ABitOfEverythingServiceCustomParams {
-	o.SetMappedStringValue(mappedStringValue)
-	return o
-}
-
-// SetMappedStringValue adds the mappedStringValue to the a bit of everything service custom params
-func (o *ABitOfEverythingServiceCustomParams) SetMappedStringValue(mappedStringValue *string) {
-	o.MappedStringValue = mappedStringValue
+// SetMappedStringValueString adds the mappedStringValueString to the a bit of everything service custom params
+func (o *ABitOfEverythingServiceCustomParams) SetMappedStringValueString(mappedStringValueString *string) {
+	o.MappedStringValueString = mappedStringValueString
 }
 
 // WithNestedAnnotationAmount adds the nestedAnnotationAmount to the a bit of everything service custom params
@@ -1190,52 +1176,35 @@ func (o *ABitOfEverythingServiceCustomParams) WriteToRequest(r runtime.ClientReq
 		}
 	}
 
-	if o.MapValue != nil {
+	if o.MapValueString != nil {
 
-		// query param mapValue
-		var qrMapValue string
+		// query param mapValue[string]
+		var qrMapValueString string
 
-		if o.MapValue != nil {
-			qrMapValue = *o.MapValue
+		if o.MapValueString != nil {
+			qrMapValueString = *o.MapValueString
 		}
-		qMapValue := qrMapValue
-		if qMapValue != "" {
+		qMapValueString := qrMapValueString
+		if qMapValueString != "" {
 
-			if err := r.SetQueryParam("mapValue", qMapValue); err != nil {
+			if err := r.SetQueryParam("mapValue[string]", qMapValueString); err != nil {
 				return err
 			}
 		}
 	}
 
-	if o.MappedNestedValue != nil {
+	if o.MappedStringValueString != nil {
 
-		// query param mappedNestedValue
-		var qrMappedNestedValue string
+		// query param mappedStringValue[string]
+		var qrMappedStringValueString string
 
-		if o.MappedNestedValue != nil {
-			qrMappedNestedValue = *o.MappedNestedValue
+		if o.MappedStringValueString != nil {
+			qrMappedStringValueString = *o.MappedStringValueString
 		}
-		qMappedNestedValue := qrMappedNestedValue
-		if qMappedNestedValue != "" {
+		qMappedStringValueString := qrMappedStringValueString
+		if qMappedStringValueString != "" {
 
-			if err := r.SetQueryParam("mappedNestedValue", qMappedNestedValue); err != nil {
-				return err
-			}
-		}
-	}
-
-	if o.MappedStringValue != nil {
-
-		// query param mappedStringValue
-		var qrMappedStringValue string
-
-		if o.MappedStringValue != nil {
-			qrMappedStringValue = *o.MappedStringValue
-		}
-		qMappedStringValue := qrMappedStringValue
-		if qMappedStringValue != "" {
-
-			if err := r.SetQueryParam("mappedStringValue", qMappedStringValue); err != nil {
+			if err := r.SetQueryParam("mappedStringValue[string]", qMappedStringValueString); err != nil {
 				return err
 			}
 		}

--- a/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_double_colon_parameters.go
+++ b/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_double_colon_parameters.go
@@ -128,22 +128,19 @@ type ABitOfEverythingServiceDoubleColonParams struct {
 	// Format: int64
 	Int64Value string
 
-	/* MapValue.
+	/* MapValueString.
 
 	   map of numeric enum
 	*/
-	MapValue *string
+	MapValueString *string
 
-	// MappedNestedValue.
-	MappedNestedValue *string
-
-	/* MappedStringValue.
+	/* MappedStringValueString.
 
 	     Map of string title
 
 	Map of string description.
 	*/
-	MappedStringValue *string
+	MappedStringValueString *string
 
 	// NestedAnnotationAmount.
 	//
@@ -565,37 +562,26 @@ func (o *ABitOfEverythingServiceDoubleColonParams) SetInt64Value(int64Value stri
 	o.Int64Value = int64Value
 }
 
-// WithMapValue adds the mapValue to the a bit of everything service double colon params
-func (o *ABitOfEverythingServiceDoubleColonParams) WithMapValue(mapValue *string) *ABitOfEverythingServiceDoubleColonParams {
-	o.SetMapValue(mapValue)
+// WithMapValueString adds the mapValueString to the a bit of everything service double colon params
+func (o *ABitOfEverythingServiceDoubleColonParams) WithMapValueString(mapValueString *string) *ABitOfEverythingServiceDoubleColonParams {
+	o.SetMapValueString(mapValueString)
 	return o
 }
 
-// SetMapValue adds the mapValue to the a bit of everything service double colon params
-func (o *ABitOfEverythingServiceDoubleColonParams) SetMapValue(mapValue *string) {
-	o.MapValue = mapValue
+// SetMapValueString adds the mapValueString to the a bit of everything service double colon params
+func (o *ABitOfEverythingServiceDoubleColonParams) SetMapValueString(mapValueString *string) {
+	o.MapValueString = mapValueString
 }
 
-// WithMappedNestedValue adds the mappedNestedValue to the a bit of everything service double colon params
-func (o *ABitOfEverythingServiceDoubleColonParams) WithMappedNestedValue(mappedNestedValue *string) *ABitOfEverythingServiceDoubleColonParams {
-	o.SetMappedNestedValue(mappedNestedValue)
+// WithMappedStringValueString adds the mappedStringValueString to the a bit of everything service double colon params
+func (o *ABitOfEverythingServiceDoubleColonParams) WithMappedStringValueString(mappedStringValueString *string) *ABitOfEverythingServiceDoubleColonParams {
+	o.SetMappedStringValueString(mappedStringValueString)
 	return o
 }
 
-// SetMappedNestedValue adds the mappedNestedValue to the a bit of everything service double colon params
-func (o *ABitOfEverythingServiceDoubleColonParams) SetMappedNestedValue(mappedNestedValue *string) {
-	o.MappedNestedValue = mappedNestedValue
-}
-
-// WithMappedStringValue adds the mappedStringValue to the a bit of everything service double colon params
-func (o *ABitOfEverythingServiceDoubleColonParams) WithMappedStringValue(mappedStringValue *string) *ABitOfEverythingServiceDoubleColonParams {
-	o.SetMappedStringValue(mappedStringValue)
-	return o
-}
-
-// SetMappedStringValue adds the mappedStringValue to the a bit of everything service double colon params
-func (o *ABitOfEverythingServiceDoubleColonParams) SetMappedStringValue(mappedStringValue *string) {
-	o.MappedStringValue = mappedStringValue
+// SetMappedStringValueString adds the mappedStringValueString to the a bit of everything service double colon params
+func (o *ABitOfEverythingServiceDoubleColonParams) SetMappedStringValueString(mappedStringValueString *string) {
+	o.MappedStringValueString = mappedStringValueString
 }
 
 // WithNestedAnnotationAmount adds the nestedAnnotationAmount to the a bit of everything service double colon params
@@ -1190,52 +1176,35 @@ func (o *ABitOfEverythingServiceDoubleColonParams) WriteToRequest(r runtime.Clie
 		}
 	}
 
-	if o.MapValue != nil {
+	if o.MapValueString != nil {
 
-		// query param mapValue
-		var qrMapValue string
+		// query param mapValue[string]
+		var qrMapValueString string
 
-		if o.MapValue != nil {
-			qrMapValue = *o.MapValue
+		if o.MapValueString != nil {
+			qrMapValueString = *o.MapValueString
 		}
-		qMapValue := qrMapValue
-		if qMapValue != "" {
+		qMapValueString := qrMapValueString
+		if qMapValueString != "" {
 
-			if err := r.SetQueryParam("mapValue", qMapValue); err != nil {
+			if err := r.SetQueryParam("mapValue[string]", qMapValueString); err != nil {
 				return err
 			}
 		}
 	}
 
-	if o.MappedNestedValue != nil {
+	if o.MappedStringValueString != nil {
 
-		// query param mappedNestedValue
-		var qrMappedNestedValue string
+		// query param mappedStringValue[string]
+		var qrMappedStringValueString string
 
-		if o.MappedNestedValue != nil {
-			qrMappedNestedValue = *o.MappedNestedValue
+		if o.MappedStringValueString != nil {
+			qrMappedStringValueString = *o.MappedStringValueString
 		}
-		qMappedNestedValue := qrMappedNestedValue
-		if qMappedNestedValue != "" {
+		qMappedStringValueString := qrMappedStringValueString
+		if qMappedStringValueString != "" {
 
-			if err := r.SetQueryParam("mappedNestedValue", qMappedNestedValue); err != nil {
-				return err
-			}
-		}
-	}
-
-	if o.MappedStringValue != nil {
-
-		// query param mappedStringValue
-		var qrMappedStringValue string
-
-		if o.MappedStringValue != nil {
-			qrMappedStringValue = *o.MappedStringValue
-		}
-		qMappedStringValue := qrMappedStringValue
-		if qMappedStringValue != "" {
-
-			if err := r.SetQueryParam("mappedStringValue", qMappedStringValue); err != nil {
+			if err := r.SetQueryParam("mappedStringValue[string]", qMappedStringValueString); err != nil {
 				return err
 			}
 		}

--- a/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_exists_parameters.go
+++ b/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_exists_parameters.go
@@ -128,22 +128,19 @@ type ABitOfEverythingServiceExistsParams struct {
 	// Format: int64
 	Int64Value string
 
-	/* MapValue.
+	/* MapValueString.
 
 	   map of numeric enum
 	*/
-	MapValue *string
+	MapValueString *string
 
-	// MappedNestedValue.
-	MappedNestedValue *string
-
-	/* MappedStringValue.
+	/* MappedStringValueString.
 
 	     Map of string title
 
 	Map of string description.
 	*/
-	MappedStringValue *string
+	MappedStringValueString *string
 
 	// NestedAnnotationAmount.
 	//
@@ -565,37 +562,26 @@ func (o *ABitOfEverythingServiceExistsParams) SetInt64Value(int64Value string) {
 	o.Int64Value = int64Value
 }
 
-// WithMapValue adds the mapValue to the a bit of everything service exists params
-func (o *ABitOfEverythingServiceExistsParams) WithMapValue(mapValue *string) *ABitOfEverythingServiceExistsParams {
-	o.SetMapValue(mapValue)
+// WithMapValueString adds the mapValueString to the a bit of everything service exists params
+func (o *ABitOfEverythingServiceExistsParams) WithMapValueString(mapValueString *string) *ABitOfEverythingServiceExistsParams {
+	o.SetMapValueString(mapValueString)
 	return o
 }
 
-// SetMapValue adds the mapValue to the a bit of everything service exists params
-func (o *ABitOfEverythingServiceExistsParams) SetMapValue(mapValue *string) {
-	o.MapValue = mapValue
+// SetMapValueString adds the mapValueString to the a bit of everything service exists params
+func (o *ABitOfEverythingServiceExistsParams) SetMapValueString(mapValueString *string) {
+	o.MapValueString = mapValueString
 }
 
-// WithMappedNestedValue adds the mappedNestedValue to the a bit of everything service exists params
-func (o *ABitOfEverythingServiceExistsParams) WithMappedNestedValue(mappedNestedValue *string) *ABitOfEverythingServiceExistsParams {
-	o.SetMappedNestedValue(mappedNestedValue)
+// WithMappedStringValueString adds the mappedStringValueString to the a bit of everything service exists params
+func (o *ABitOfEverythingServiceExistsParams) WithMappedStringValueString(mappedStringValueString *string) *ABitOfEverythingServiceExistsParams {
+	o.SetMappedStringValueString(mappedStringValueString)
 	return o
 }
 
-// SetMappedNestedValue adds the mappedNestedValue to the a bit of everything service exists params
-func (o *ABitOfEverythingServiceExistsParams) SetMappedNestedValue(mappedNestedValue *string) {
-	o.MappedNestedValue = mappedNestedValue
-}
-
-// WithMappedStringValue adds the mappedStringValue to the a bit of everything service exists params
-func (o *ABitOfEverythingServiceExistsParams) WithMappedStringValue(mappedStringValue *string) *ABitOfEverythingServiceExistsParams {
-	o.SetMappedStringValue(mappedStringValue)
-	return o
-}
-
-// SetMappedStringValue adds the mappedStringValue to the a bit of everything service exists params
-func (o *ABitOfEverythingServiceExistsParams) SetMappedStringValue(mappedStringValue *string) {
-	o.MappedStringValue = mappedStringValue
+// SetMappedStringValueString adds the mappedStringValueString to the a bit of everything service exists params
+func (o *ABitOfEverythingServiceExistsParams) SetMappedStringValueString(mappedStringValueString *string) {
+	o.MappedStringValueString = mappedStringValueString
 }
 
 // WithNestedAnnotationAmount adds the nestedAnnotationAmount to the a bit of everything service exists params
@@ -1190,52 +1176,35 @@ func (o *ABitOfEverythingServiceExistsParams) WriteToRequest(r runtime.ClientReq
 		}
 	}
 
-	if o.MapValue != nil {
+	if o.MapValueString != nil {
 
-		// query param mapValue
-		var qrMapValue string
+		// query param mapValue[string]
+		var qrMapValueString string
 
-		if o.MapValue != nil {
-			qrMapValue = *o.MapValue
+		if o.MapValueString != nil {
+			qrMapValueString = *o.MapValueString
 		}
-		qMapValue := qrMapValue
-		if qMapValue != "" {
+		qMapValueString := qrMapValueString
+		if qMapValueString != "" {
 
-			if err := r.SetQueryParam("mapValue", qMapValue); err != nil {
+			if err := r.SetQueryParam("mapValue[string]", qMapValueString); err != nil {
 				return err
 			}
 		}
 	}
 
-	if o.MappedNestedValue != nil {
+	if o.MappedStringValueString != nil {
 
-		// query param mappedNestedValue
-		var qrMappedNestedValue string
+		// query param mappedStringValue[string]
+		var qrMappedStringValueString string
 
-		if o.MappedNestedValue != nil {
-			qrMappedNestedValue = *o.MappedNestedValue
+		if o.MappedStringValueString != nil {
+			qrMappedStringValueString = *o.MappedStringValueString
 		}
-		qMappedNestedValue := qrMappedNestedValue
-		if qMappedNestedValue != "" {
+		qMappedStringValueString := qrMappedStringValueString
+		if qMappedStringValueString != "" {
 
-			if err := r.SetQueryParam("mappedNestedValue", qMappedNestedValue); err != nil {
-				return err
-			}
-		}
-	}
-
-	if o.MappedStringValue != nil {
-
-		// query param mappedStringValue
-		var qrMappedStringValue string
-
-		if o.MappedStringValue != nil {
-			qrMappedStringValue = *o.MappedStringValue
-		}
-		qMappedStringValue := qrMappedStringValue
-		if qMappedStringValue != "" {
-
-			if err := r.SetQueryParam("mappedStringValue", qMappedStringValue); err != nil {
+			if err := r.SetQueryParam("mappedStringValue[string]", qMappedStringValueString); err != nil {
 				return err
 			}
 		}

--- a/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_get_query_parameters.go
+++ b/examples/internal/clients/abe/client/a_bit_of_everything/a_bit_of_everything_service_get_query_parameters.go
@@ -128,22 +128,19 @@ type ABitOfEverythingServiceGetQueryParams struct {
 	// Format: int64
 	Int64Value string
 
-	/* MapValue.
+	/* MapValueString.
 
 	   map of numeric enum
 	*/
-	MapValue *string
+	MapValueString *string
 
-	// MappedNestedValue.
-	MappedNestedValue *string
-
-	/* MappedStringValue.
+	/* MappedStringValueString.
 
 	     Map of string title
 
 	Map of string description.
 	*/
-	MappedStringValue *string
+	MappedStringValueString *string
 
 	// NestedAnnotationAmount.
 	//
@@ -565,37 +562,26 @@ func (o *ABitOfEverythingServiceGetQueryParams) SetInt64Value(int64Value string)
 	o.Int64Value = int64Value
 }
 
-// WithMapValue adds the mapValue to the a bit of everything service get query params
-func (o *ABitOfEverythingServiceGetQueryParams) WithMapValue(mapValue *string) *ABitOfEverythingServiceGetQueryParams {
-	o.SetMapValue(mapValue)
+// WithMapValueString adds the mapValueString to the a bit of everything service get query params
+func (o *ABitOfEverythingServiceGetQueryParams) WithMapValueString(mapValueString *string) *ABitOfEverythingServiceGetQueryParams {
+	o.SetMapValueString(mapValueString)
 	return o
 }
 
-// SetMapValue adds the mapValue to the a bit of everything service get query params
-func (o *ABitOfEverythingServiceGetQueryParams) SetMapValue(mapValue *string) {
-	o.MapValue = mapValue
+// SetMapValueString adds the mapValueString to the a bit of everything service get query params
+func (o *ABitOfEverythingServiceGetQueryParams) SetMapValueString(mapValueString *string) {
+	o.MapValueString = mapValueString
 }
 
-// WithMappedNestedValue adds the mappedNestedValue to the a bit of everything service get query params
-func (o *ABitOfEverythingServiceGetQueryParams) WithMappedNestedValue(mappedNestedValue *string) *ABitOfEverythingServiceGetQueryParams {
-	o.SetMappedNestedValue(mappedNestedValue)
+// WithMappedStringValueString adds the mappedStringValueString to the a bit of everything service get query params
+func (o *ABitOfEverythingServiceGetQueryParams) WithMappedStringValueString(mappedStringValueString *string) *ABitOfEverythingServiceGetQueryParams {
+	o.SetMappedStringValueString(mappedStringValueString)
 	return o
 }
 
-// SetMappedNestedValue adds the mappedNestedValue to the a bit of everything service get query params
-func (o *ABitOfEverythingServiceGetQueryParams) SetMappedNestedValue(mappedNestedValue *string) {
-	o.MappedNestedValue = mappedNestedValue
-}
-
-// WithMappedStringValue adds the mappedStringValue to the a bit of everything service get query params
-func (o *ABitOfEverythingServiceGetQueryParams) WithMappedStringValue(mappedStringValue *string) *ABitOfEverythingServiceGetQueryParams {
-	o.SetMappedStringValue(mappedStringValue)
-	return o
-}
-
-// SetMappedStringValue adds the mappedStringValue to the a bit of everything service get query params
-func (o *ABitOfEverythingServiceGetQueryParams) SetMappedStringValue(mappedStringValue *string) {
-	o.MappedStringValue = mappedStringValue
+// SetMappedStringValueString adds the mappedStringValueString to the a bit of everything service get query params
+func (o *ABitOfEverythingServiceGetQueryParams) SetMappedStringValueString(mappedStringValueString *string) {
+	o.MappedStringValueString = mappedStringValueString
 }
 
 // WithNestedAnnotationAmount adds the nestedAnnotationAmount to the a bit of everything service get query params
@@ -1190,52 +1176,35 @@ func (o *ABitOfEverythingServiceGetQueryParams) WriteToRequest(r runtime.ClientR
 		}
 	}
 
-	if o.MapValue != nil {
+	if o.MapValueString != nil {
 
-		// query param mapValue
-		var qrMapValue string
+		// query param mapValue[string]
+		var qrMapValueString string
 
-		if o.MapValue != nil {
-			qrMapValue = *o.MapValue
+		if o.MapValueString != nil {
+			qrMapValueString = *o.MapValueString
 		}
-		qMapValue := qrMapValue
-		if qMapValue != "" {
+		qMapValueString := qrMapValueString
+		if qMapValueString != "" {
 
-			if err := r.SetQueryParam("mapValue", qMapValue); err != nil {
+			if err := r.SetQueryParam("mapValue[string]", qMapValueString); err != nil {
 				return err
 			}
 		}
 	}
 
-	if o.MappedNestedValue != nil {
+	if o.MappedStringValueString != nil {
 
-		// query param mappedNestedValue
-		var qrMappedNestedValue string
+		// query param mappedStringValue[string]
+		var qrMappedStringValueString string
 
-		if o.MappedNestedValue != nil {
-			qrMappedNestedValue = *o.MappedNestedValue
+		if o.MappedStringValueString != nil {
+			qrMappedStringValueString = *o.MappedStringValueString
 		}
-		qMappedNestedValue := qrMappedNestedValue
-		if qMappedNestedValue != "" {
+		qMappedStringValueString := qrMappedStringValueString
+		if qMappedStringValueString != "" {
 
-			if err := r.SetQueryParam("mappedNestedValue", qMappedNestedValue); err != nil {
-				return err
-			}
-		}
-	}
-
-	if o.MappedStringValue != nil {
-
-		// query param mappedStringValue
-		var qrMappedStringValue string
-
-		if o.MappedStringValue != nil {
-			qrMappedStringValue = *o.MappedStringValue
-		}
-		qMappedStringValue := qrMappedStringValue
-		if qMappedStringValue != "" {
-
-			if err := r.SetQueryParam("mappedStringValue", qMappedStringValue); err != nil {
+			if err := r.SetQueryParam("mappedStringValue[string]", qMappedStringValueString); err != nil {
 				return err
 			}
 		}

--- a/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
+++ b/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
@@ -353,22 +353,18 @@
             "type": "string"
           },
           {
-            "name": "mapValue",
+            "name": "mapValue[string]",
             "description": "map of numeric enum",
-            "in": "query",
-            "required": false
-          },
-          {
-            "name": "mappedStringValue",
-            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "mappedNestedValue",
+            "name": "mappedStringValue[string]",
+            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
-            "required": false
+            "required": false,
+            "type": "string"
           },
           {
             "name": "nonConventionalNameValue",
@@ -999,22 +995,18 @@
             "type": "string"
           },
           {
-            "name": "mapValue",
+            "name": "mapValue[string]",
             "description": "map of numeric enum",
-            "in": "query",
-            "required": false
-          },
-          {
-            "name": "mappedStringValue",
-            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "mappedNestedValue",
+            "name": "mappedStringValue[string]",
+            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
-            "required": false
+            "required": false,
+            "type": "string"
           },
           {
             "name": "nonConventionalNameValue",
@@ -1453,22 +1445,18 @@
             "type": "string"
           },
           {
-            "name": "mapValue",
+            "name": "mapValue[string]",
             "description": "map of numeric enum",
-            "in": "query",
-            "required": false
-          },
-          {
-            "name": "mappedStringValue",
-            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "mappedNestedValue",
+            "name": "mappedStringValue[string]",
+            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
-            "required": false
+            "required": false,
+            "type": "string"
           },
           {
             "name": "nonConventionalNameValue",
@@ -1894,22 +1882,18 @@
             "type": "string"
           },
           {
-            "name": "mapValue",
+            "name": "mapValue[string]",
             "description": "map of numeric enum",
-            "in": "query",
-            "required": false
-          },
-          {
-            "name": "mappedStringValue",
-            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "mappedNestedValue",
+            "name": "mappedStringValue[string]",
+            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
-            "required": false
+            "required": false,
+            "type": "string"
           },
           {
             "name": "nonConventionalNameValue",
@@ -2361,22 +2345,18 @@
             "type": "string"
           },
           {
-            "name": "mapValue",
+            "name": "mapValue[string]",
             "description": "map of numeric enum",
-            "in": "query",
-            "required": false
-          },
-          {
-            "name": "mappedStringValue",
-            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "mappedNestedValue",
+            "name": "mappedStringValue[string]",
+            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
-            "required": false
+            "required": false,
+            "type": "string"
           },
           {
             "name": "nonConventionalNameValue",
@@ -2849,22 +2829,18 @@
             "type": "string"
           },
           {
-            "name": "mapValue",
+            "name": "mapValue[string]",
             "description": "map of numeric enum",
-            "in": "query",
-            "required": false
-          },
-          {
-            "name": "mappedStringValue",
-            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "mappedNestedValue",
+            "name": "mappedStringValue[string]",
+            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
-            "required": false
+            "required": false,
+            "type": "string"
           },
           {
             "name": "timestampValue",
@@ -3338,22 +3314,18 @@
             "type": "string"
           },
           {
-            "name": "mapValue",
+            "name": "mapValue[string]",
             "description": "map of numeric enum",
-            "in": "query",
-            "required": false
-          },
-          {
-            "name": "mappedStringValue",
-            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "mappedNestedValue",
+            "name": "mappedStringValue[string]",
+            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
-            "required": false
+            "required": false,
+            "type": "string"
           },
           {
             "name": "nonConventionalNameValue",
@@ -3780,22 +3752,18 @@
             "type": "string"
           },
           {
-            "name": "mapValue",
+            "name": "mapValue[string]",
             "description": "map of numeric enum",
-            "in": "query",
-            "required": false
-          },
-          {
-            "name": "mappedStringValue",
-            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "mappedNestedValue",
+            "name": "mappedStringValue[string]",
+            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
-            "required": false
+            "required": false,
+            "type": "string"
           },
           {
             "name": "nonConventionalNameValue",
@@ -4246,22 +4214,18 @@
             "type": "string"
           },
           {
-            "name": "mapValue",
+            "name": "mapValue[string]",
             "description": "map of numeric enum",
-            "in": "query",
-            "required": false
-          },
-          {
-            "name": "mappedStringValue",
-            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "mappedNestedValue",
+            "name": "mappedStringValue[string]",
+            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
-            "required": false
+            "required": false,
+            "type": "string"
           },
           {
             "name": "nonConventionalNameValue",
@@ -4712,22 +4676,18 @@
             "type": "string"
           },
           {
-            "name": "mapValue",
+            "name": "mapValue[string]",
             "description": "map of numeric enum",
-            "in": "query",
-            "required": false
-          },
-          {
-            "name": "mappedStringValue",
-            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "mappedNestedValue",
+            "name": "mappedStringValue[string]",
+            "description": "Map of string title\n\nMap of string description.",
             "in": "query",
-            "required": false
+            "required": false,
+            "type": "string"
           },
           {
             "name": "nonConventionalNameValue",

--- a/examples/internal/proto/examplepb/opaque.swagger.json
+++ b/examples/internal/proto/examplepb/opaque.swagger.json
@@ -361,7 +361,7 @@
             "type": "boolean"
           },
           {
-            "name": "order.shippingAddress.metadata",
+            "name": "order.shippingAddress.metadata[string]",
             "in": "query",
             "required": false,
             "type": "string"
@@ -409,7 +409,7 @@
             "type": "boolean"
           },
           {
-            "name": "order.billingAddress.metadata",
+            "name": "order.billingAddress.metadata[string]",
             "in": "query",
             "required": false,
             "type": "string"
@@ -483,7 +483,7 @@
             "collectionFormat": "multi"
           },
           {
-            "name": "order.metadata",
+            "name": "order.metadata[string]",
             "in": "query",
             "required": false,
             "type": "string"
@@ -718,7 +718,7 @@
             "type": "string"
           },
           {
-            "name": "filters",
+            "name": "filters[string]",
             "in": "query",
             "required": false,
             "type": "string"

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -339,6 +339,12 @@ func nestedQueryParams(message *descriptor.Message, field *descriptor.Field, pre
 
 	isEnum := field.GetType() == descriptorpb.FieldDescriptorProto_TYPE_ENUM
 	items := schema.Items
+	// mapKeySuffix spells out the key of a map field in the parameter name, as in
+	// "filters[string]". It is appended to the parameter name rather than to the
+	// field name so that it is emitted whichever naming the parameter uses, and so
+	// that the field descriptor, which is shared with the rest of the generated
+	// document, is left alone.
+	var mapKeySuffix string
 	if schema.Type != "" || isEnum {
 		if schema.Type == "object" {
 			location := ""
@@ -352,10 +358,23 @@ func nestedQueryParams(message *descriptor.Message, field *descriptor.Field, pre
 					if err != nil {
 						return nil, err
 					}
+					v := m.GetField()[1]
+					switch {
+					case v.GetType() == descriptorpb.FieldDescriptorProto_TYPE_ENUM:
+						schema.Type = "string"
+						if reg.GetEnumsAsInts() {
+							schema.Type = "integer"
+						}
+					case schema.AdditionalProperties != nil:
+						schema.Type = schema.AdditionalProperties.schemaCore.Type
+					}
+					if schema.Type == "" || schema.Type == "object" {
+						// The map value has no primitive representation, so there is no
+						// way to spell it in a query parameter.
+						return nil, nil
+					}
 					// This will generate a query in the format map_name[key_type]
-					fName := fmt.Sprintf("%s[%s]", *field.Name, kType)
-					field.Name = proto.String(fName)
-					schema.Type = schema.AdditionalProperties.schemaCore.Type
+					mapKeySuffix = "[" + kType + "]"
 				}
 			}
 		}
@@ -407,7 +426,7 @@ func nestedQueryParams(message *descriptor.Message, field *descriptor.Field, pre
 			param.CollectionFormat = "multi"
 		}
 
-		param.Name = prefix + reg.FieldName(field)
+		param.Name = prefix + reg.FieldName(field) + mapKeySuffix
 
 		if isEnum {
 			enum, err := reg.LookupEnum("", fieldType)

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -1938,6 +1938,191 @@ func TestMessageToQueryParametersWithDeprecatedField(t *testing.T) {
 	}
 }
 
+func TestMessageToQueryParametersWithMapField(t *testing.T) {
+	mapEntry := func(name string, keyType, valueType descriptorpb.FieldDescriptorProto_Type, valueTypeName string) *descriptorpb.DescriptorProto {
+		value := &descriptorpb.FieldDescriptorProto{
+			Name:   proto.String("value"),
+			Number: proto.Int32(2),
+			Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+			Type:   valueType.Enum(),
+		}
+		if valueTypeName != "" {
+			value.TypeName = proto.String(valueTypeName)
+		}
+		return &descriptorpb.DescriptorProto{
+			Name:    proto.String(name),
+			Options: &descriptorpb.MessageOptions{MapEntry: proto.Bool(true)},
+			Field: []*descriptorpb.FieldDescriptorProto{
+				{
+					Name:   proto.String("key"),
+					Number: proto.Int32(1),
+					Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+					Type:   keyType.Enum(),
+				},
+				value,
+			},
+		}
+	}
+	mapField := func(name, jsonName, entry string, number int32) *descriptorpb.FieldDescriptorProto {
+		return &descriptorpb.FieldDescriptorProto{
+			Name:     proto.String(name),
+			JsonName: proto.String(jsonName),
+			Number:   proto.Int32(number),
+			Label:    descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
+			Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+			TypeName: proto.String(".example.ExampleMessage." + entry),
+		}
+	}
+
+	nestedDesc := &descriptorpb.DescriptorProto{
+		Name: proto.String("Nested"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:     proto.String("a"),
+				JsonName: proto.String("a"),
+				Number:   proto.Int32(1),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+			},
+		},
+	}
+	msgDesc := &descriptorpb.DescriptorProto{
+		Name: proto.String("ExampleMessage"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			mapField("string_map", "stringMap", "StringMapEntry", 1),
+			mapField("int_key_map", "intKeyMap", "IntKeyMapEntry", 2),
+			mapField("enum_map", "enumMap", "EnumMapEntry", 3),
+			mapField("message_map", "messageMap", "MessageMapEntry", 4),
+		},
+		NestedType: []*descriptorpb.DescriptorProto{
+			mapEntry("StringMapEntry", descriptorpb.FieldDescriptorProto_TYPE_STRING, descriptorpb.FieldDescriptorProto_TYPE_STRING, ""),
+			mapEntry("IntKeyMapEntry", descriptorpb.FieldDescriptorProto_TYPE_INT32, descriptorpb.FieldDescriptorProto_TYPE_STRING, ""),
+			mapEntry("EnumMapEntry", descriptorpb.FieldDescriptorProto_TYPE_STRING, descriptorpb.FieldDescriptorProto_TYPE_ENUM, ".example.ExampleMessage.Kind"),
+			mapEntry("MessageMapEntry", descriptorpb.FieldDescriptorProto_TYPE_STRING, descriptorpb.FieldDescriptorProto_TYPE_MESSAGE, ".example.Nested"),
+		},
+		EnumType: []*descriptorpb.EnumDescriptorProto{
+			{
+				Name: proto.String("Kind"),
+				Value: []*descriptorpb.EnumValueDescriptorProto{
+					{Name: proto.String("KIND_A"), Number: proto.Int32(0)},
+					{Name: proto.String("KIND_B"), Number: proto.Int32(1)},
+				},
+			},
+		},
+	}
+
+	// The parameter name carries the key type of the map, whichever naming the
+	// document uses for fields. Maps of messages are left out entirely: they have
+	// no primitive representation to put in a query string.
+	tests := []struct {
+		name                  string
+		useJSONNamesForFields bool
+		enumsAsInts           bool
+		params                []openapiParameterObject
+	}{
+		{
+			name:                  "proto field names",
+			useJSONNamesForFields: false,
+			params: []openapiParameterObject{
+				{Name: "string_map[string]", In: "query", Type: "string"},
+				{Name: "int_key_map[integer]", In: "query", Type: "string"},
+				{Name: "enum_map[string]", In: "query", Type: "string"},
+			},
+		},
+		{
+			name:                  "JSON field names",
+			useJSONNamesForFields: true,
+			params: []openapiParameterObject{
+				{Name: "stringMap[string]", In: "query", Type: "string"},
+				{Name: "intKeyMap[integer]", In: "query", Type: "string"},
+				{Name: "enumMap[string]", In: "query", Type: "string"},
+			},
+		},
+		{
+			name:                  "enums as ints",
+			useJSONNamesForFields: true,
+			enumsAsInts:           true,
+			params: []openapiParameterObject{
+				{Name: "stringMap[string]", In: "query", Type: "string"},
+				{Name: "intKeyMap[integer]", In: "query", Type: "string"},
+				{Name: "enumMap[string]", In: "query", Type: "integer"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := descriptor.NewRegistry()
+			reg.SetUseJSONNamesForFields(tt.useJSONNamesForFields)
+			reg.SetEnumsAsInts(tt.enumsAsInts)
+			msgs := []*descriptor.Message{
+				{DescriptorProto: msgDesc},
+				{DescriptorProto: nestedDesc},
+			}
+			file := descriptor.File{
+				FileDescriptorProto: &descriptorpb.FileDescriptorProto{
+					SourceCodeInfo: &descriptorpb.SourceCodeInfo{},
+					Name:           proto.String("example.proto"),
+					Package:        proto.String("example"),
+					Dependency:     []string{},
+					MessageType:    []*descriptorpb.DescriptorProto{msgDesc, nestedDesc},
+					Service:        []*descriptorpb.ServiceDescriptorProto{},
+					Options: &descriptorpb.FileOptions{
+						GoPackage: proto.String("github.com/grpc-ecosystem/grpc-gateway/runtime/internal/examplepb;example"),
+					},
+				},
+				GoPkg: descriptor.GoPackage{
+					Path: "example.com/path/to/example/example.pb",
+					Name: "example_pb",
+				},
+				Messages: msgs,
+			}
+			if err := reg.Load(&pluginpb.CodeGeneratorRequest{
+				ProtoFile: []*descriptorpb.FileDescriptorProto{file.FileDescriptorProto},
+			}); err != nil {
+				t.Fatalf("failed to load code generator request: %v", err)
+			}
+
+			message, err := reg.LookupMsg("", ".example.ExampleMessage")
+			if err != nil {
+				t.Fatalf("failed to lookup message: %s", err)
+			}
+			params, err := messageToQueryParameters(message, reg, []descriptor.Parameter{}, nil, "")
+			if err != nil {
+				t.Fatalf("failed to convert message to query parameters: %s", err)
+			}
+			if !reflect.DeepEqual(params, tt.params) {
+				t.Errorf("expected %v, got %v", tt.params, params)
+			}
+
+			// Rendering the query parameters must not rename the fields of the
+			// message: the same descriptor is used for the rest of the document.
+			want := []string{"string_map", "int_key_map", "enum_map", "message_map"}
+			var got []string
+			for _, f := range message.Fields {
+				got = append(got, f.GetName())
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("field names after messageToQueryParameters: got %v, want %v", got, want)
+			}
+			schema, err := renderMessageAsDefinition(message, reg, map[string]struct{}{}, nil)
+			if err != nil {
+				t.Fatalf("failed to render message as definition: %s", err)
+			}
+			var properties []string
+			for _, kv := range *schema.Properties {
+				properties = append(properties, kv.Key)
+			}
+			wantProperties := want
+			if tt.useJSONNamesForFields {
+				wantProperties = []string{"stringMap", "intKeyMap", "enumMap", "messageMap"}
+			}
+			if !reflect.DeepEqual(properties, wantProperties) {
+				t.Errorf("definition properties: got %v, want %v", properties, wantProperties)
+			}
+		})
+	}
+}
+
 func TestMessageToQueryParametersWithEnumFieldOption(t *testing.T) {
 	type test struct {
 		MsgDescs []*descriptorpb.DescriptorProto
@@ -6135,14 +6320,14 @@ func TestRenderMessagesAsDefinition(t *testing.T) {
 	boolTrue := true
 
 	tests := []struct {
-		descr                 string
-		msgDescs              []*descriptorpb.DescriptorProto
-		schema                map[string]*openapi_options.Schema // per-message schema to add
-		defs                  openapiDefinitionsObject
-		openAPIOptions        *openapiconfig.OpenAPIOptions
-		pathParams            []descriptor.Parameter
-		UseJSONNamesForFields bool
-		UseAllOfForRefs       bool
+		descr                  string
+		msgDescs               []*descriptorpb.DescriptorProto
+		schema                 map[string]*openapi_options.Schema // per-message schema to add
+		defs                   openapiDefinitionsObject
+		openAPIOptions         *openapiconfig.OpenAPIOptions
+		pathParams             []descriptor.Parameter
+		UseJSONNamesForFields  bool
+		UseAllOfForRefs        bool
 		Proto3OptionalNullable bool
 	}{
 		{


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #984

This overlaps with the draft #6245, which adds the missing `type` to `map<K, enum>` query
parameters. That fix is included here, so #6245 can be closed if this lands.

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

Map fields in query parameters are meant to be documented as `name[key_type]`, e.g.
`filters[string]`, which is the form the runtime's query parser accepts.

```json
// before
{ "name": "filters",         "in": "query", "required": false, "type": "string" }
// after
{ "name": "filters[string]", "in": "query", "required": false, "type": "string" }
```

Regenerated: `a_bit_of_everything.swagger.json`, `opaque.swagger.json`, and the go-swagger
ABE client.

#### Other comments
