### PR TITLE
fix(openapiv2): emit a primitive type for well-known object query parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,24 +17,17 @@ GENERATE_UNBOUND_METHODS_EXAMPLE_SPEC=examples/internal/proto/examplepb/generate
 # Targets are PHONY because the file set isn't fully predictable from the
 # spec without parsing it.
 #
-# The jq pass coerces non-body parameters with no `type`/`schema` (map<K,V>
-# request fields) and non-body parameters typed as `object` (oneof-of-empty
-# fields) to `string`. They can't round-trip through a query string in a
-# meaningful way, but go-swagger needs *some* primitive to chew on. The
-# accompanying default-value rewrite turns string defaults on numeric/integer
-# parameters into the corresponding number — protoc-gen-openapiv2 emits e.g.
-# `"default": "0"` on integer params, which go-swagger refuses.
+# The jq pass turns string defaults on numeric/integer parameters into the
+# corresponding number — protoc-gen-openapiv2 emits e.g. `"default": "0"` on
+# integer params, which go-swagger refuses.
 define swagger_client
 	rm -rf $(1)/client $(1)/models
 	mkdir -p $(1)
 	jq 'walk( \
-		if type == "object" and has("in") and (.in != "body") then \
-			(if (has("type") | not) and (has("schema") | not) then . + {type: "string"} \
-			 elif .type == "object" then . + {type: "string"} \
-			 else . end) \
-			| (if (.type == "number" or .type == "integer") and (.default | type) == "string" \
-			   then .default |= tonumber else . end) \
-		else . end \
+		if type == "object" and has("in") and (.in != "body") \
+		   and (.type == "number" or .type == "integer") \
+		   and (.default | type) == "string" \
+		then .default |= tonumber else . end \
 	)' $(2) > $(1)/.spec.json
 	swagger generate client -q -f $(1)/.spec.json -t $(1) \
 		--client-package=client --model-package=models --skip-validation

--- a/examples/internal/integration/integration_test.go
+++ b/examples/internal/integration/integration_test.go
@@ -2159,6 +2159,20 @@ func testRequestQueryParams(t *testing.T, port int) {
 			},
 		},
 		{
+			name:        "get oneof of empty url query value",
+			httpMethod:  "GET",
+			contentType: "application/json",
+			apiURL:      fmt.Sprintf("http://localhost:%d/v1/example/a_bit_of_everything/params/get/foo?oneof_empty=", port),
+			wantContent: &examplepb.ABitOfEverything{
+				SingleNested: &examplepb.ABitOfEverything_Nested{
+					Name: "foo",
+				},
+				OneofValue: &examplepb.ABitOfEverything_OneofEmpty{
+					OneofEmpty: &emptypb.Empty{},
+				},
+			},
+		},
+		{
 			name:        "post url query values",
 			httpMethod:  "POST",
 			contentType: "application/json",

--- a/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
+++ b/examples/internal/proto/examplepb/a_bit_of_everything.swagger.json
@@ -344,7 +344,7 @@
             "name": "oneofEmpty",
             "in": "query",
             "required": false,
-            "type": "object"
+            "type": "string"
           },
           {
             "name": "oneofString",
@@ -986,7 +986,7 @@
             "name": "oneofEmpty",
             "in": "query",
             "required": false,
-            "type": "object"
+            "type": "string"
           },
           {
             "name": "oneofString",
@@ -1436,7 +1436,7 @@
             "name": "oneofEmpty",
             "in": "query",
             "required": false,
-            "type": "object"
+            "type": "string"
           },
           {
             "name": "oneofString",
@@ -1873,7 +1873,7 @@
             "name": "oneofEmpty",
             "in": "query",
             "required": false,
-            "type": "object"
+            "type": "string"
           },
           {
             "name": "oneofString",
@@ -2336,7 +2336,7 @@
             "name": "oneofEmpty",
             "in": "query",
             "required": false,
-            "type": "object"
+            "type": "string"
           },
           {
             "name": "oneofString",
@@ -2820,7 +2820,7 @@
             "name": "oneofEmpty",
             "in": "query",
             "required": false,
-            "type": "object"
+            "type": "string"
           },
           {
             "name": "oneofString",
@@ -3305,7 +3305,7 @@
             "name": "oneofEmpty",
             "in": "query",
             "required": false,
-            "type": "object"
+            "type": "string"
           },
           {
             "name": "oneofString",
@@ -3743,7 +3743,7 @@
             "name": "oneofEmpty",
             "in": "query",
             "required": false,
-            "type": "object"
+            "type": "string"
           },
           {
             "name": "oneofString",
@@ -4205,7 +4205,7 @@
             "name": "oneofEmpty",
             "in": "query",
             "required": false,
-            "type": "object"
+            "type": "string"
           },
           {
             "name": "oneofString",
@@ -4667,7 +4667,7 @@
             "name": "oneofEmpty",
             "in": "query",
             "required": false,
-            "type": "object"
+            "type": "string"
           },
           {
             "name": "oneofString",

--- a/protoc-gen-openapiv2/internal/genopenapi/template.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template.go
@@ -377,6 +377,13 @@ func nestedQueryParams(message *descriptor.Message, field *descriptor.Field, pre
 					mapKeySuffix = "[" + kType + "]"
 				}
 			}
+			if _, ok := wktSchemas[fieldType]; ok && schema.Type == "object" {
+				// Empty and Struct are rendered as "object", which is not a valid type
+				// for a parameter that is not in the body. Both are read from the query
+				// string as text: Struct as its JSON encoding, Empty as an empty value
+				// or as "{}".
+				schema.Type = "string"
+			}
 		}
 		if items != nil && (items.Type == "" || items.Type == "object") && !isEnum {
 			return nil, nil // TODO: currently, mapping object in query parameter is not supported

--- a/protoc-gen-openapiv2/internal/genopenapi/template_test.go
+++ b/protoc-gen-openapiv2/internal/genopenapi/template_test.go
@@ -1592,6 +1592,53 @@ func TestMessageToQueryParametersWellKnownTypes(t *testing.T) {
 				},
 			},
 		},
+		{
+			MsgDescs: []*descriptorpb.DescriptorProto{
+				{
+					Name: proto.String("ExampleMessage"),
+					Field: []*descriptorpb.FieldDescriptorProto{
+						{
+							Name:     proto.String("an_empty"),
+							Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+							TypeName: proto.String(".google.protobuf.Empty"),
+							Number:   proto.Int32(1),
+						},
+						{
+							Name:     proto.String("a_struct"),
+							Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+							TypeName: proto.String(".google.protobuf.Struct"),
+							Number:   proto.Int32(2),
+						},
+					},
+				},
+			},
+			WellKnownMsgDescs: []*descriptorpb.DescriptorProto{
+				{
+					Name: proto.String("Empty"),
+				},
+				{
+					Name: proto.String("Struct"),
+				},
+			},
+			Message: "ExampleMessage",
+			// Empty and Struct are objects as schemas, but a parameter that is not in
+			// the body has to have a primitive type. Both are read from the query
+			// string as text.
+			Params: []openapiParameterObject{
+				{
+					Name:     "an_empty",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+				},
+				{
+					Name:     "a_struct",
+					In:       "query",
+					Required: false,
+					Type:     "string",
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/runtime/BUILD.bazel
+++ b/runtime/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "@org_golang_google_protobuf//reflect/protoreflect",
         "@org_golang_google_protobuf//reflect/protoregistry",
         "@org_golang_google_protobuf//types/known/durationpb",
+        "@org_golang_google_protobuf//types/known/emptypb",
         "@org_golang_google_protobuf//types/known/fieldmaskpb",
         "@org_golang_google_protobuf//types/known/structpb",
         "@org_golang_google_protobuf//types/known/timestamppb",

--- a/runtime/query.go
+++ b/runtime/query.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/emptypb"
 	field_mask "google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -370,6 +371,14 @@ func parseMessage(msgDescriptor protoreflect.MessageDescriptor, value string) (p
 			return protoreflect.Value{}, err
 		}
 		msg = &v
+	case "google.protobuf.Empty":
+		// An Empty carries nothing, so the only thing the value can say is that the
+		// field is present. Accept the two spellings of "no content" and reject
+		// anything else, rather than silently ignoring it.
+		if value != "" && value != "{}" {
+			return protoreflect.Value{}, fmt.Errorf("expected an empty value or %q, got %q", "{}", value)
+		}
+		msg = &emptypb.Empty{}
 	default:
 		return protoreflect.Value{}, fmt.Errorf("unsupported message type: %q", string(msgDescriptor.FullName()))
 	}

--- a/runtime/query_test.go
+++ b/runtime/query_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/emptypb"
 	field_mask "google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -543,6 +544,62 @@ func TestPopulateParameters(t *testing.T) {
 			}
 			if diff := cmp.Diff(spec.want, msg, protocmp.Transform()); diff != "" {
 				t.Errorf("runtime.PopulateQueryParameters(msg, %v, %v): %s", spec.values, spec.filter, diff)
+			}
+		})
+	}
+}
+
+func TestPopulateParametersEmptyMessage(t *testing.T) {
+	for _, spec := range []struct {
+		name    string
+		values  url.Values
+		want    proto.Message
+		wanterr error
+	}{
+		{
+			name:   "empty value",
+			values: url.Values{"oneof_empty": {""}},
+			want: &examplepb.ABitOfEverything{
+				OneofValue: &examplepb.ABitOfEverything_OneofEmpty{OneofEmpty: &emptypb.Empty{}},
+			},
+		},
+		{
+			name:   "empty JSON object",
+			values: url.Values{"oneof_empty": {"{}"}},
+			want: &examplepb.ABitOfEverything{
+				OneofValue: &examplepb.ABitOfEverything_OneofEmpty{OneofEmpty: &emptypb.Empty{}},
+			},
+		},
+		{
+			name:   "JSON name",
+			values: url.Values{"oneofEmpty": {""}},
+			want: &examplepb.ABitOfEverything{
+				OneofValue: &examplepb.ABitOfEverything_OneofEmpty{OneofEmpty: &emptypb.Empty{}},
+			},
+		},
+		{
+			name:    "value with content",
+			values:  url.Values{"oneof_empty": {"true"}},
+			want:    &examplepb.ABitOfEverything{},
+			wanterr: errors.New(`parsing field "oneof_empty": expected an empty value or "{}", got "true"`),
+		},
+	} {
+		t.Run(spec.name, func(t *testing.T) {
+			msg := spec.want.ProtoReflect().New().Interface()
+			err := runtime.PopulateQueryParameters(msg, spec.values, utilities.NewDoubleArray(nil))
+			if spec.wanterr != nil {
+				if err == nil || err.Error() != spec.wanterr.Error() {
+					t.Errorf("runtime.PopulateQueryParameters(msg, %v, _) failed with %q; want error %q", spec.values, err, spec.wanterr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("runtime.PopulateQueryParameters(msg, %v, _) failed with %v; want success", spec.values, err)
+				return
+			}
+			if diff := cmp.Diff(spec.want, msg, protocmp.Transform()); diff != "" {
+				t.Errorf("runtime.PopulateQueryParameters(msg, %v, _): %s", spec.values, diff)
 			}
 		})
 	}


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #4758

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes.

#### Brief description of what is fixed or changed

Option A from the discussion in #4758.

`google.protobuf.Empty` and `google.protobuf.Struct` render as `type: object`, which is not
valid for a parameter outside the body, and Empty could not be parsed from a query string at
all (`unsupported message type: "google.protobuf.Empty"`), so the parameter we document in
10 ABE operations could not be sent by anyone.

- Generator: non-body parameters whose well-known type renders as an object are
  `type: string` — Empty, Struct, and the `structValue` member of `google.protobuf.Value`.
  The runtime already read Struct and Value as JSON text, so this just describe
- Runtime: `parseMessage` gains a `google.protobuf.Empty` case, accepting an empty value or
  `{}` and rejecting anything else.

```
?oneof_empty=      -> 200, oneofValue set to oneofEmpty {}
?oneof_empty={}    -> 200, same (?oneofEmpty= works too)
?oneof_empty=true  -> parsing field "oneof_empty": expected an empty value or "{}", got "true"
```

Nothing breaks — the old behaviour was a hard INVALID_ARGUMENT.

#### Other comments

- go-swagger validation of the ABE spec drops from 84 errors to 24; all 60 remo
  those 10 parameters, no new errors. The rest are the pre-existing `floatValue.default` ones.
- No spec in the repo now has a non-body parameter with a missing or `object` t
  Makefile `jq` pass no longer needs its coercion branches. Removed them; all five clients
  regenerate byte-identically. Happy to drop that commit if you'd rather keep t
- Tests at three levels, each failing without the fix: parameter type, query parsing, and a
  round trip through a real gateway (400 before, 200 after).
