### PR TITLE
Add edition 2026 support

### DIFF
--- a/internal/codegenerator/supported_features.go
+++ b/internal/codegenerator/supported_features.go
@@ -12,8 +12,8 @@ func supportedCodeGeneratorFeatures() uint64 {
 }
 
 func supportedEditions() (descriptorpb.Edition, descriptorpb.Edition) {
-	// Declare support up to edition 2024
-	return descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2024
+	// Declare support up to edition 2026
+	return descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2026
 }
 
 // SetSupportedFeaturesOnPluginGen sets supported proto3 features


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

Yes

#### Brief description of what is fixed or changed

Added support for Edition 2026. I tested it locally and it looks like no other code changes are needed beyond declaring compatibility.

#### Other comments

The same as edition 2024 support.